### PR TITLE
Mark installation of .pdb files as optional

### DIFF
--- a/conf/iCubHelpers.cmake
+++ b/conf/iCubHelpers.cmake
@@ -74,10 +74,11 @@ MACRO(icub_export_library target)
   # Install/export rules
   install(TARGETS ${target} EXPORT icub-targets LIBRARY DESTINATION lib ARCHIVE DESTINATION lib COMPONENT Development)
   if (MSVC) 
-	install (	FILES ${CMAKE_BINARY_DIR}/lib/Debug/${target}d.pdb 
-				DESTINATION lib 
-				CONFIGURATIONS Debug 
-				COMPONENT Development )
+    install ( FILES ${CMAKE_BINARY_DIR}/lib/Debug/${target}d.pdb
+              DESTINATION lib
+              CONFIGURATIONS Debug
+              COMPONENT Development
+              OPTIONAL)
   endif()
   export(TARGETS ${target} APPEND FILE ${CMAKE_BINARY_DIR}/${ICUB_EXPORTBUILD_FILE})
     #important wrap ${dependencies} with "" to allows storing a list of dependencies


### PR DESCRIPTION
As per this CMake issue http://public.kitware.com/Bug/view.php?id=14600 and related issues/commits, .pdb file generation by VisualStudio projects seems to have changed since CMake 2.8.12. In particular, <LibraryName>.pdb files have disappeared for static libraries, which causes installation to fail because we used to install those files. As a quick fix, I suggest to mark installation of such files as OPTIONAL; anyway, new CMake (and VS) policies for PDB files should be studied in greater detail to find appropriate solution (hoping they are "final" by now ^^).
