### PR TITLE
robotMotorGui default configuration file

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -46,4 +46,5 @@ add_subdirectory(iCubStartup)
 add_subdirectory(dataSetPlayer)
 add_subdirectory(simFaceExpressions)
 add_subdirectory(fingersTuner)
+add_subdirectory(robotMotorGui)
 

--- a/app/robotMotorGui/CMakeLists.txt
+++ b/app/robotMotorGui/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright: (C) 2014 iCubFacility - Istituto Italiano di Tecnologia
+# Authors: Elena Ceseracciu
+# CopyPolicy: Released under the terms of the GNU GPL v2.0.
+
+yarp_install(FILES robotMotorGui.ini DESTINATION ${ICUB_CONTEXTS_INSTALL_DIR}/robotMotorGui)
+

--- a/app/robotMotorGui/robotMotorGui.ini
+++ b/app/robotMotorGui/robotMotorGui.ini
@@ -1,5 +1,5 @@
 //name of the robot
-name icub
+name icubSim
 //parts to be opened by the GUI
 parts (head torso left_arm right_arm left_leg right_leg)
 //parts (head)
@@ -7,12 +7,12 @@ parts (head torso left_arm right_arm left_leg right_leg)
 [head_zero]
 //                  0          1        2         3          4          5
 PositionZero      0.0        0.0      0.0       0.0        0.0        0.0
-VelocityZero     10.0       10.0     10.0      10.0       10.0       10.0 
+VelocityZero     10.0       10.0     10.0      10.0       10.0       10.0
 
 [torso_zero]
-//                  0          1        2 
-PositionZero      0.0        0.0      0.0 
-VelocityZero     10.0       10.0     10.0 
+//                  0          1        2
+PositionZero      0.0        0.0      0.0
+VelocityZero     10.0       10.0     10.0
 
 [left_arm_zero]
 //Joint              0	       1       2       3        4      5      6       7      8	   9    10    11    12    13     14      15

--- a/src/tools/robotMotorGui/src/main.cpp
+++ b/src/tools/robotMotorGui/src/main.cpp
@@ -85,9 +85,9 @@
  * \code
  * [head_calib]
  * CalibrationType     0          0        0         0          0          0
- * Calibration1    500.0      1000.0    900.0     300.0     1333.0     1333.0
- * Calibration2     20.0        20.0     20.0     -20.0        5.0        5.0
- * Calibration3      0.0         0.0      0.0       0.0        0.0        0.0
+ * Calibration1    500.0	  1000.0    900.0     300.0     1333.0     1333.0
+ * Calibration2     20.0	    20.0     20.0     -20.0        5.0        5.0
+ * Calibration3      0.0	     0.0      0.0       0.0        0.0        0.0
  * \endcode
  *
  * A set of parameters can be optionally specified in order to
@@ -189,7 +189,7 @@ bool enable_calib_all =false;
 ResourceFinder *finder;
 ////////////////////////
 
-static void destroy_main (GtkWindow *window,    gpointer   user_data)
+static void destroy_main (GtkWindow *window,	gpointer   user_data)
 {
     gtk_widget_destroy (GTK_WIDGET(window));
     gtk_main_quit ();
@@ -214,7 +214,7 @@ GtkWidget *buttonCrtSeqAllStop;
 
 //*********************************************************************************
 // This callback switches among tabs
-void notebook_change (GtkNotebook *nb, GtkNotebookPage *nbp,    gint current_enabled, partMover** currentPartMover)
+void notebook_change (GtkNotebook *nb, GtkNotebookPage *nbp,	gint current_enabled, partMover** currentPartMover)
 {
     gint i;
 
@@ -238,7 +238,7 @@ void notebook_change (GtkNotebook *nb, GtkNotebookPage *nbp,    gint current_ena
 void add_enabled_joints(cartesianMover* cm, GtkWidget *vbox)
 {
     GtkWidget *check= gtk_check_button_new_with_mnemonic ("test");
-    gtk_fixed_put   (GTK_FIXED(vbox), check, 10, 0);
+    gtk_fixed_put	(GTK_FIXED(vbox), check, 10, 0);
     gtk_widget_set_size_request     (check, 80, 50);
     gtk_toggle_button_set_active((GtkToggleButton*) check, true);
     //g_signal_connect (check, "clicked", G_CALLBACK (check_pressed),ENA[n]);
@@ -247,17 +247,17 @@ void add_enabled_joints(cartesianMover* cm, GtkWidget *vbox)
 //*********************************************************************************
 // This function is main window after selection of the part to be controlled
 
-static void myMain2(GtkButton *button,  int *position)
+static void myMain2(GtkButton *button,	int *position)
 {
     std::string robotName;
     std::string portLocalName;
-    std::string portLocalName2;
+	std::string portLocalName2;
 
-    GtkWidget *main_vbox1        = NULL;
-    GtkWidget *main_vbox2        = NULL;
-    GtkWidget *main_vbox3        = NULL;
-    GtkWidget *main_vbox4        = NULL;
-    GtkWidget *main_vbox5        = NULL;
+    GtkWidget *main_vbox1		 = NULL;
+    GtkWidget *main_vbox2		 = NULL;
+    GtkWidget *main_vbox3		 = NULL;
+    GtkWidget *main_vbox4		 = NULL;
+    GtkWidget *main_vbox5		 = NULL;
     Property options;
 
     yarp::os::Network::init();
@@ -269,19 +269,19 @@ static void myMain2(GtkButton *button,  int *position)
     gtk_widget_destroy (window);
     window = NULL;
     window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
-    
+	
     //Creation of the notebook
     GtkWidget*  nb1 = gtk_notebook_new();
     gtk_container_add (GTK_CONTAINER (window), nb1);
     g_signal_connect (window, "destroy",G_CALLBACK (destroy_main), &window);
-    gtk_window_set_title (GTK_WINDOW (window), "Robot Motor GUI V1.8");
+	gtk_window_set_title (GTK_WINDOW (window), "Robot Motor GUI V1.8");
 
     char legsLabel[]= "Legs";
     GtkWidget *label;
     int n;
 
     PolyDriver *partsdd[MAX_NUMBER_ACTIVATED];
-    PolyDriver *debugdd[MAX_NUMBER_ACTIVATED];
+	PolyDriver *debugdd[MAX_NUMBER_ACTIVATED];
     PolyDriver *cartesiandd[MAX_NUMBER_ACTIVATED];
     partMover *partMoverList[MAX_NUMBER_ACTIVATED];
     cartesianMover *cartesianMoverList[MAX_NUMBER_ACTIVATED];
@@ -301,7 +301,7 @@ static void myMain2(GtkButton *button,  int *position)
                     robotPartPort += "/";
                     robotPartPort += partsName[n];
 
-                    std::string robotPartDebugPort= "/";
+					std::string robotPartDebugPort= "/";
                     robotPartDebugPort += robotName.c_str();
                     robotPartDebugPort += "/debug/";
                     robotPartDebugPort += partsName[n];
@@ -348,33 +348,33 @@ static void myMain2(GtkButton *button,  int *position)
                             adr=Network::queryName(nameToCheck.c_str());
                         }
 
-                    options.put("local", portLocalName.c_str());    
+                    options.put("local", portLocalName.c_str());	
                     options.put("device", "remote_controlboard");
                     options.put("remote", robotPartPort.c_str());
                     options.put("carrier", "udp");
                     partsdd[n] = new PolyDriver(options);
 
-                    if (debug_param_enabled)
-                    {
-                        Property debugOptions;
-                        portLocalName2=portLocalName;
-                        // the following complex line of code performs a substring substitution (see example below)
-                        // "/icub/robotMotorGui2/right_arm" -> "/icub/robotMotorGui2/debug/right_arm"
-                        portLocalName2.replace(portLocalName2.find(partsName[n]),strlen(partsName[n]),std::string("debug/")+std::string(partsName[n]));
-                        debugOptions.put("local", portLocalName2.c_str());  
-                        debugOptions.put("device", "debugInterfaceClient");
-                        debugOptions.put("remote", robotPartPort.c_str());
-                        debugOptions.put("carrier", "udp");
-                        debugdd[n] = new PolyDriver(debugOptions);
-                        if(debugdd[n]->isValid() == false)
-                          {
-                              fprintf(stderr, "Problems opening the debug client \n");
-                          } 
-                    }
-                    else
-                    {
-                        debugdd[n]=0;
-                    }
+					if (debug_param_enabled)
+					{
+						Property debugOptions;
+						portLocalName2=portLocalName;
+						// the following complex line of code performs a substring substitution (see example below)
+						// "/icub/robotMotorGui2/right_arm" -> "/icub/robotMotorGui2/debug/right_arm"
+						portLocalName2.replace(portLocalName2.find(partsName[n]),strlen(partsName[n]),std::string("debug/")+std::string(partsName[n]));
+						debugOptions.put("local", portLocalName2.c_str());	
+						debugOptions.put("device", "debugInterfaceClient");
+						debugOptions.put("remote", robotPartPort.c_str());
+						debugOptions.put("carrier", "udp");
+						debugdd[n] = new PolyDriver(debugOptions);
+						if(debugdd[n]->isValid() == false)
+						  {
+							  fprintf(stderr, "Problems opening the debug client \n");
+						  }	
+					}
+					else
+					{
+						debugdd[n]=0;
+					}
 
                     currentPartMover = new partMover(main_vbox4, partsdd[n], debugdd[n], partsName[n], finder,speedview_param_enabled, enable_calib_all);
                     if(!(currentPartMover->interfaceError)) 
@@ -434,7 +434,7 @@ static void myMain2(GtkButton *button,  int *position)
                                                     //adr=nic.queryName(nameToCheck.c_str());
                                                 }
 
-                                            options.put("local", portLocalName.c_str());    //local port names
+                                            options.put("local", portLocalName.c_str());	//local port names
                                             options.put("device", "cartesiancontrollerclient");
                                             options.put("remote", robotPartPort.c_str());
                                             
@@ -477,72 +477,72 @@ static void myMain2(GtkButton *button,  int *position)
                     //Frame
                     fprintf(stderr, "Appending all frame \n");
                     GtkWidget *frame1 = gtk_frame_new ("Global joint commands");
-                    gtk_widget_set_size_request     (frame1, 250, 550);
+                    gtk_widget_set_size_request 	(frame1, 250, 550);
                     gtk_fixed_put (GTK_FIXED (main_vbox5), frame1, 10, 10);
 
                     //Button 1 in the panel
                     buttonGoAll = gtk_button_new_with_mnemonic ("Go ALL!");
-                    gtk_fixed_put   (GTK_FIXED(main_vbox5), buttonGoAll, 30, 50);
+                    gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonGoAll, 30, 50);
                     g_signal_connect (buttonGoAll, "clicked", G_CALLBACK (go_all_click), partMoverList);
                     gtk_widget_set_size_request(buttonGoAll, 190, 30);
-    
+	
                     //Button 2 in the panel
                     buttonSeqAll = gtk_button_new_with_mnemonic ("Run ALL Sequence");
-                    gtk_fixed_put   (GTK_FIXED(main_vbox5), buttonSeqAll, 30, 100);
+                    gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonSeqAll, 30, 100);
                     g_signal_connect (buttonSeqAll, "clicked",G_CALLBACK(sequence_all_click), partMoverList);
                     gtk_widget_set_size_request     (buttonSeqAll, 190, 30);
 
                     //Button 2time in the panel
                     buttonSeqAllTime = gtk_button_new_with_mnemonic ("Run ALL Sequence (time)");
-                    gtk_fixed_put   (GTK_FIXED(main_vbox5), buttonSeqAllTime, 30, 150);
+                    gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonSeqAllTime, 30, 150);
                     g_signal_connect (buttonSeqAllTime, "clicked",G_CALLBACK(sequence_all_click_time), partMoverList);
-                    gtk_widget_set_size_request     (buttonSeqAllTime, 190, 30);    
-    
+                    gtk_widget_set_size_request     (buttonSeqAllTime, 190, 30);	
+	
                     //Button 3 in the panel
                     buttonSeqAllSave = gtk_button_new_with_mnemonic ("Save ALL Sequence");
-                    gtk_fixed_put   (GTK_FIXED(main_vbox5), buttonSeqAllSave, 30, 200);
+                    gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonSeqAllSave, 30, 200);
                     g_signal_connect (buttonSeqAllSave, "clicked", G_CALLBACK(sequence_all_save), partMoverList);
-                    gtk_widget_set_size_request     (buttonSeqAllSave, 190, 30);    
-    
+                    gtk_widget_set_size_request     (buttonSeqAllSave, 190, 30);	
+	
                     //Button 4 in the panel
                     buttonSeqAllLoad = gtk_button_new_with_mnemonic ("Load ALL Sequence");
-                    gtk_fixed_put   (GTK_FIXED(main_vbox5), buttonSeqAllLoad, 30, 250);
+                    gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonSeqAllLoad, 30, 250);
                     g_signal_connect (buttonSeqAllLoad, "clicked", G_CALLBACK (sequence_all_load), partMoverList);
                     gtk_widget_set_size_request     (buttonSeqAllLoad, 190, 30);
-    
+	
                     //Button 5 in the panel
                     buttonSeqAllCycle = gtk_button_new_with_mnemonic ("Cycle ALL Sequence");
-                    gtk_fixed_put   (GTK_FIXED(main_vbox5), buttonSeqAllCycle, 30, 300);
+                    gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonSeqAllCycle, 30, 300);
                     g_signal_connect (buttonSeqAllCycle, "clicked", G_CALLBACK (sequence_all_cycle), partMoverList);
                     gtk_widget_set_size_request     (buttonSeqAllCycle, 190, 30);
 
                     //Button 5time in the panel
                     buttonSeqAllCycleTime = gtk_button_new_with_mnemonic ("Cycle ALL Sequence (time)");
-                    gtk_fixed_put   (GTK_FIXED(main_vbox5), buttonSeqAllCycleTime, 30, 350);
+                    gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonSeqAllCycleTime, 30, 350);
                     g_signal_connect (buttonSeqAllCycleTime, "clicked", G_CALLBACK (sequence_all_cycle_time), partMoverList);
                     gtk_widget_set_size_request     (buttonSeqAllCycleTime, 190, 30);
 
                     //Button 6 in the panel
                     buttonSeqAllStop = gtk_button_new_with_mnemonic ("Stop ALL Sequence");
-                    gtk_fixed_put   (GTK_FIXED(main_vbox5), buttonSeqAllStop, 30, 400);
+                    gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonSeqAllStop, 30, 400);
                     g_signal_connect (buttonSeqAllStop, "clicked", G_CALLBACK (sequence_all_stop),  partMoverList);
                     gtk_widget_set_size_request     (buttonSeqAllStop, 190, 30);
-    
+	
                     //Button 6time in the panel
                     //buttonSeqAllStopTime = gtk_button_new_with_mnemonic ("Stop ALL Sequence (time)");
-                    //gtk_fixed_put (GTK_FIXED(main_vbox5), buttonSeqAllStopTime, 120, 450);
+                    //gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonSeqAllStopTime, 120, 450);
                     //g_signal_connect (buttonSeqAllStopTime, "clicked", G_CALLBACK (sequence_all_stop_time),  partMoverList);
                     //gtk_widget_set_size_request     (buttonSeqAllStopTime, 190, 30);
 
                     //Button 6time in the panel
                     buttonRunAllParts = gtk_button_new_with_mnemonic ("Run ALL Parts");
-                    gtk_fixed_put   (GTK_FIXED(main_vbox5), buttonRunAllParts, 30, 450);
+                    gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonRunAllParts, 30, 450);
                     g_signal_connect (buttonRunAllParts, "clicked", G_CALLBACK (run_all_parts),  partMoverList);
                     gtk_widget_set_size_request     (buttonRunAllParts, 190, 30);
 
                     //Button 7 in the panel
                     buttonHomeAllParts = gtk_button_new_with_mnemonic ("Home ALL Parts");
-                    gtk_fixed_put   (GTK_FIXED(main_vbox5), buttonHomeAllParts, 30, 500);
+                    gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonHomeAllParts, 30, 500);
                     g_signal_connect (buttonHomeAllParts, "clicked", G_CALLBACK (home_all_parts),  partMoverList);
                     gtk_widget_set_size_request     (buttonHomeAllParts, 190, 30);
 
@@ -552,7 +552,7 @@ static void myMain2(GtkButton *button,  int *position)
                             //Frame
                             fprintf(stderr, "Appending all cartesian frame \n");
                             GtkWidget *frame2 = gtk_frame_new ("Global cartesian commands");
-                            gtk_widget_set_size_request     (frame2, 250, 550);
+                            gtk_widget_set_size_request 	(frame2, 250, 550);
                             gtk_fixed_put (GTK_FIXED (main_vbox5), frame2, 300, 10);
 
                             //for(int i = 0; i < NUMBER_OF_ACTIVATED_CARTESIAN; i++)
@@ -560,37 +560,37 @@ static void myMain2(GtkButton *button,  int *position)
 
                             //Button 3 in the panel
                             buttonCrtSeqAllSave = gtk_button_new_with_mnemonic ("Save ALL Cartesian Seq");
-                            gtk_fixed_put   (GTK_FIXED(main_vbox5), buttonCrtSeqAllSave, 320, 200);
+                            gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonCrtSeqAllSave, 320, 200);
                             g_signal_connect (buttonCrtSeqAllSave, "clicked", G_CALLBACK(sequence_crt_all_save), cartesianMoverList);
-                            gtk_widget_set_size_request     (buttonCrtSeqAllSave, 190, 30); 
-    
+                            gtk_widget_set_size_request     (buttonCrtSeqAllSave, 190, 30);	
+	
                             //Button 4 in the panel
                             buttonCrtSeqAllLoad = gtk_button_new_with_mnemonic ("Load ALL Cartesian Seq");
-                            gtk_fixed_put   (GTK_FIXED(main_vbox5), buttonCrtSeqAllLoad, 320, 250);
+                            gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonCrtSeqAllLoad, 320, 250);
                             g_signal_connect (buttonCrtSeqAllLoad, "clicked", G_CALLBACK (sequence_crt_all_load), cartesianMoverList);
                             gtk_widget_set_size_request     (buttonCrtSeqAllLoad, 190, 30);
-    
+	
                             //Button 5time in the panel
                             buttonCrtSeqAllCycleTime = gtk_button_new_with_mnemonic ("Cycle ALL Cartesian Seq");
-                            gtk_fixed_put   (GTK_FIXED(main_vbox5), buttonCrtSeqAllCycleTime, 320, 350);
+                            gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonCrtSeqAllCycleTime, 320, 350);
                             g_signal_connect (buttonCrtSeqAllCycleTime, "clicked", G_CALLBACK (sequence_crt_all_cycle_time), cartesianMoverList);
                             gtk_widget_set_size_request     (buttonCrtSeqAllCycleTime, 190, 30);
 
                             //Button 6 in the panel
                             buttonCrtSeqAllStop = gtk_button_new_with_mnemonic ("Stop ALL Cartsian Seq");
-                            gtk_fixed_put   (GTK_FIXED(main_vbox5), buttonCrtSeqAllStop, 320, 400);
+                            gtk_fixed_put	(GTK_FIXED(main_vbox5), buttonCrtSeqAllStop, 320, 400);
                             g_signal_connect (buttonCrtSeqAllStop, "clicked", G_CALLBACK (sequence_crt_all_stop),  cartesianMoverList);
                             gtk_widget_set_size_request     (buttonCrtSeqAllStop, 190, 30);
 
                         }
                     // finish & show
-                    //  connected_status();
+                    //	connected_status();
                     fprintf(stderr, "Resizing window \n");
                     gtk_window_set_default_size (GTK_WINDOW (window), 480, 250);
                     gtk_window_set_resizable (GTK_WINDOW (window), true);
                 }
         }
-        
+		
     fprintf(stderr, "Making the window visible \n");
     if (!GTK_WIDGET_VISIBLE (window))
         gtk_widget_show_all (window);
@@ -600,7 +600,7 @@ static void myMain2(GtkButton *button,  int *position)
             window = NULL;
         }
 
-    gtk_main ();        
+    gtk_main ();		
     fprintf(stderr, "Closing the partMovers. Number of activated parts was %d. \n", NUMBER_OF_ACTIVATED_PARTS);
     for (int i = 0; i < NUMBER_OF_ACTIVATED_PARTS; i++)
         {
@@ -623,7 +623,7 @@ static void myMain2(GtkButton *button,  int *position)
     fprintf(stderr, "Closing the main GUI \n");
     Network::fini();
     return;
-    
+	
 }
 
 
@@ -633,10 +633,10 @@ static GtkTreeModel * create_net_model (void)
     gint i = 0;
     GtkListStore *store;
     GtkTreeIter iter;
-    
+	
     // create list store
     store = gtk_list_store_new (1, G_TYPE_STRING);
-    
+	
     // add data to the list store
     gtk_list_store_append (store, &iter);
     gtk_list_store_set (store, &iter, 0, "Right Arm",-1);
@@ -646,17 +646,17 @@ static GtkTreeModel * create_net_model (void)
     gtk_list_store_set (store, &iter, 0, "Head Waist",-1);  
     gtk_list_store_append (store, &iter);
     gtk_list_store_set (store, &iter, 0, "Legs",-1);  
-    
+	
     return GTK_TREE_MODEL (store);
 }
 
 //*********************************************************************************
-static void combo_net_changed (GtkComboBox *box,    gpointer   user_data)
+static void combo_net_changed (GtkComboBox *box,	gpointer   user_data)
 {
     PART = gtk_combo_box_get_active (box);
 }
 
-static void check_pressed(GtkWidget *box,   gpointer   user_data)
+static void check_pressed(GtkWidget *box,	gpointer   user_data)
 {
     int *pENA = (int *) user_data;
     if (*pENA == 0)
@@ -685,21 +685,21 @@ int myMain( int   argc, char *argv[] )
     //the application when the main window is closed
     //////////////////////////////////////////////////////////////////////
     window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
-    
+	
     gtk_window_set_title (GTK_WINDOW (window), "Robot Motor GUI V1.8");
     g_signal_connect (window, "destroy",G_CALLBACK (destroy_main), &window);
-    
+	
     gtk_container_set_border_width (GTK_CONTAINER (window), 8);
-    
+	
     //Creation of main_vbox the container for every other widget
     main_vbox = gtk_vbox_new (FALSE, 0);
     gtk_container_add (GTK_CONTAINER (window), main_vbox);
-    
+	
     //creation of the top_hbox
     top_hbox = gtk_hbox_new (FALSE, 0);
     gtk_container_set_border_width (GTK_CONTAINER (top_hbox), 10);
     gtk_container_add (GTK_CONTAINER (main_vbox), top_hbox);
-    
+	
     inv1 = gtk_fixed_new ();
     gtk_container_add (GTK_CONTAINER (top_hbox), inv1);
   
@@ -720,28 +720,24 @@ int myMain( int   argc, char *argv[] )
         enable_calib_all = true;
         debug_param_enabled = true;
     }
-    if (finder->check("debug"))
-    {
-        printf("Debug interface requested.\n");
-        debug_param_enabled = true;
-    }
-    if (finder->check("speed"))
-    {
-        printf("Speed view requested.\n");
-        speedview_param_enabled = true;
-    }
+	if (finder->check("debug"))
+	{
+		printf("Debug interface requested.\n");
+		debug_param_enabled = true;
+	}
+	if (finder->check("speed"))
+	{
+		printf("Speed view requested.\n");
+		speedview_param_enabled = true;
+	}
 
-    bool deleteParts=false;
     std::string robotName=finder->find("name").asString().c_str();
     Bottle *pParts=finder->find("parts").asList();
-    if (pParts==NULL)
-    {
-        printf("Setting default parts.\n");
-        pParts=new Bottle("head torso left_arm right_arm left_leg right_leg");
-        deleteParts=true;
-    }
+    if (pParts!=0)
+        NUMBER_OF_AVAILABLE_PARTS=pParts->size();
+    else
+        NUMBER_OF_AVAILABLE_PARTS=0;
 
-    NUMBER_OF_AVAILABLE_PARTS=pParts->size();
     if (NUMBER_OF_AVAILABLE_PARTS > MAX_NUMBER_ACTIVATED)
         {
             fprintf(stderr, "The number of parts exceeds the maximum! \n");
@@ -771,7 +767,7 @@ int myMain( int   argc, char *argv[] )
             strcpy(partsName[n], pParts->get(n).asString().c_str());
             //fprintf(stderr, "%s \n", partsName[n]);
             GtkWidget *check= gtk_check_button_new_with_mnemonic (partsName[n]);
-            gtk_fixed_put   (GTK_FIXED(inv1), check, 100*n, 0);
+            gtk_fixed_put	(GTK_FIXED(inv1), check, 100*n, 0);
             gtk_widget_set_size_request     (check, 80, 50);
             gtk_toggle_button_set_active((GtkToggleButton*) check, true);
             g_signal_connect (check, "clicked", G_CALLBACK (check_pressed),ENA[n]);
@@ -782,7 +778,7 @@ int myMain( int   argc, char *argv[] )
     gtk_entry_set_editable(GTK_ENTRY(robotNameBox),true);
     //fprintf(stderr, "%s", (const char*) xtmp);
     gtk_entry_set_text(GTK_ENTRY(robotNameBox), robotName.c_str());
-    gtk_fixed_put   (GTK_FIXED(inv1), robotNameBox, 100*NUMBER_OF_AVAILABLE_PARTS, 10);
+    gtk_fixed_put	(GTK_FIXED(inv1), robotNameBox, 100*NUMBER_OF_AVAILABLE_PARTS, 10);
     //g_signal_connect (renderer, "edited", G_CALLBACK (edited_timing), currentClassData);
     gtk_widget_set_size_request     (robotNameBox, 60, 30);
     //gtk_container_add (GTK_CONTAINER (top_hbox), robotNameBox);
@@ -790,13 +786,13 @@ int myMain( int   argc, char *argv[] )
     //Button 1 in the panel
     button1 = gtk_button_new_with_mnemonic ("Select Parts and Click");
     //gtk_container_add (GTK_CONTAINER (top_hbox ), button1);
-    gtk_fixed_put   (GTK_FIXED(inv1), button1, 100*(NUMBER_OF_AVAILABLE_PARTS +1), 10);
+    gtk_fixed_put	(GTK_FIXED(inv1), button1, 100*(NUMBER_OF_AVAILABLE_PARTS +1), 10);
     g_signal_connect (button1, "clicked", G_CALLBACK (myMain2),NULL);
     gtk_widget_set_size_request     (button1, 180, 30);
 
     gtk_window_set_default_size (GTK_WINDOW (window), 60, 30);
     gtk_window_set_resizable (GTK_WINDOW (window), true);
-    
+	
     if (!GTK_WIDGET_VISIBLE (window))
         gtk_widget_show_all (window);
     else
@@ -804,15 +800,11 @@ int myMain( int   argc, char *argv[] )
             gtk_widget_destroy (window);
             window = NULL;
         }
-    
+	
     gtk_main ();
     fprintf(stderr, "Deleting the finder");
     delete finder;
     fprintf(stderr, "...done!\n");
-
-    if (deleteParts)
-        delete pParts;
-
     return 0;
 }
 

--- a/src/tools/robotMotorGui/src/main.cpp
+++ b/src/tools/robotMotorGui/src/main.cpp
@@ -705,6 +705,7 @@ int myMain( int   argc, char *argv[] )
   
     //retrieve information for the list of parts
     finder->setVerbose();
+    finder->setDefaultContext("robotMotorGui"); //this is just a "backup" in case a robotMotorGui.ini file is not found in the robot-specific directory
     finder->setDefaultConfigFile("robotMotorGui.ini");
     finder->setDefault("name", "icub");
     finder->configure(argc,argv);
@@ -733,7 +734,7 @@ int myMain( int   argc, char *argv[] )
 
     std::string robotName=finder->find("name").asString().c_str();
     Bottle *pParts=finder->find("parts").asList();
-    if (pParts!=0)
+    if (pParts!=NULL)
         NUMBER_OF_AVAILABLE_PARTS=pParts->size();
     else
         NUMBER_OF_AVAILABLE_PARTS=0;


### PR DESCRIPTION
Since the ResourceFinder now searches "robot" directories before "context" ones, it is possible to provide a default configuration file for the robotMotorGui within a context. Current solution, with hard-coded default values, was incomplete, as actually a large number of values are needed for the gui to be fully operational (i.e., for "home" buttons to work), so I reverted related all commits. I changed the default robot name to be icubSim, so that it's easier to understand whether the robot-specific or default file has been loaded (and also because I assume that if a robot is on installed on a machine, the user is working with the simulator; anyway, I think that the simulator at some point should have a set of configuration files that match the real robots ones and that are found in the same way). 