### PR TITLE
[ICUBMOD] [CANBUSKIN] Minor fixes to the canBusSkin device

### DIFF
--- a/src/libraries/icubmod/canBusSkin/CanBusSkin.cpp
+++ b/src/libraries/icubmod/canBusSkin/CanBusSkin.cpp
@@ -192,10 +192,11 @@ int CanBusSkin::calibrateChannel(int ch)
 
 
 bool CanBusSkin::threadInit() {
-    sendCANMessage4C();
-    sendCANMessage4E();
-
-    return true;
+    if(sendCANMessage4C()) {
+        return sendCANMessage4E();
+    } else {
+        return false;
+    }
 }
 
 void CanBusSkin::run() {    
@@ -276,7 +277,7 @@ void CanBusSkin::checkParameterListLength(const string &i_paramName, Bottle &i_p
 
 /* *********************************************************************************************************************** */
 /* ******* Sends CAN setup message type 4C.                                 ********************************************** */
-void CanBusSkin::sendCANMessage4C(void) {
+bool CanBusSkin::sendCANMessage4C(void) {
     for (size_t i = 0; i < cardId.size(); ++i) {
 #if SKIN_DEBUG
         printf("CanBusSkin: Thread initialising board ID: %d. \n",cardId[i]);
@@ -311,16 +312,20 @@ void CanBusSkin::sendCANMessage4C(void) {
             << ". \n";
 #endif
 
-        canMessages=0;
-        pCanBus->canWrite(outBuffer, 1, &canMessages);
+        if (!pCanBus->canWrite(outBuffer, 1, &canMessages)) {
+            cerr << "ERROR: CanBusSkin: Could not write to the CAN interface. \n";
+            return false;
+        }
     }
+
+    return true;
 }
 /* *********************************************************************************************************************** */
 
 
 /* *********************************************************************************************************************** */
 /* ******* Sends CAN setup message type 4E.                                 ********************************************** */
-void CanBusSkin::sendCANMessage4E(void) {
+bool CanBusSkin::sendCANMessage4E(void) {
     // Send 0x4E message to modify offset
     for (size_t i = 0; i < cardId.size(); ++i) {
         // FG: Sending 4E message to all MTBs
@@ -357,10 +362,12 @@ void CanBusSkin::sendCANMessage4E(void) {
             << ". \n";
 #endif
 
-        canMessages = 0;
-        pCanBus->canWrite(outBuffer, 1, &canMessages);
-
-        break;
+        if (!pCanBus->canWrite(outBuffer, 1, &canMessages)) {
+            cerr << "ERROR: CanBusSkin: Could not write to the CAN interface. \n";
+            return false;
+        }
     }
+
+    return true;
 }
 /* *********************************************************************************************************************** */

--- a/src/libraries/icubmod/canBusSkin/CanBusSkin.h
+++ b/src/libraries/icubmod/canBusSkin/CanBusSkin.h
@@ -90,11 +90,12 @@ private:
     /**
      * Sends the CMD_TACT_SETUP 0x4C CAN message to the MTB boards.
      */
-    void sendCANMessage4C(void);
+    bool sendCANMessage4C(void);
+    
     /**
      * Sends the CMD_TACT_SETUP2 0x4E CAN message to the MTB boards.
      */
-    void sendCANMessage4E(void);
+    bool sendCANMessage4E(void);
 };
 
 #endif


### PR DESCRIPTION
We are now sending the 4E message to all skin MTBs and not only hand ones. Parameters for the message are in the respective xml file. If not then current default values are used.

threadInit() now returns false if canBusSkin cannot write to the CAN interface.
