### PR TITLE
[emotionInterface] Fix infinite respond() loop on unknown rpc command 

### DIFF
--- a/src/core/emotionInterface/emotionInterfaceModule.cpp
+++ b/src/core/emotionInterface/emotionInterfaceModule.cpp
@@ -264,7 +264,7 @@ bool EmotionInterfaceModule::respond(const Bottle &command,Bottle &reply){
     _semaphore.post();
 
     if (!rec)
-        ok = respond(command,reply);
+        ok = false;
     
     if (!ok) {
         reply.clear();


### PR DESCRIPTION
This infinite loop caused emotionInterface crash on unknown rpc command. 
