### PR TITLE
[ctrlLib/adaptWinPolyEstimator] rearrange initialization list of AWPolyElement 

### DIFF
--- a/src/libraries/ctrlLib/include/iCub/ctrl/adaptWinPolyEstimator.h
+++ b/src/libraries/ctrlLib/include/iCub/ctrl/adaptWinPolyEstimator.h
@@ -66,7 +66,7 @@ public:
     * @param d is the element data vector.
     * @param t is time instant of sampled data.
     */ 
-    AWPolyElement(const yarp::sig::Vector &d, const double t): data(d), time(t) {}
+    AWPolyElement(const yarp::sig::Vector &d, const double t): time(t), data(d) {}
 };
 
 


### PR DESCRIPTION
To avoid "will be initialized after" warning when including the header. 
