### PR TITLE
[icubmod] dynamic_cast -> reinterpret_cast in Cfw2CanMessage::operator=

### DIFF
--- a/src/libraries/icubmod/cfw2Can/Cfw2Can.cpp
+++ b/src/libraries/icubmod/cfw2Can/Cfw2Can.cpp
@@ -171,7 +171,7 @@ bool Cfw2Can::canGetErrors(CanErrors &err)
 
 CanMessage &Cfw2CanMessage::operator=(const CanMessage &l)
 {
-    const Cfw2CanMessage &tmp=static_cast<const Cfw2CanMessage &>(l);
+    const Cfw2CanMessage &tmp=reinterpret_cast<const Cfw2CanMessage &>(l);
     memcpy(msg, tmp.msg, sizeof(CFWCAN_MSG));
     return *this;
 }

--- a/src/libraries/icubmod/cfw2Can/Cfw2Can.cpp
+++ b/src/libraries/icubmod/cfw2Can/Cfw2Can.cpp
@@ -171,6 +171,11 @@ bool Cfw2Can::canGetErrors(CanErrors &err)
 
 CanMessage &Cfw2CanMessage::operator=(const CanMessage &l)
 {
+    // reinterpret_cast is used here for performance reasons, and it works 
+    // with the current version of the iCub software. However it can hide bugs
+    // if this operator is used in a reckless way (i.e. assigning 
+    // a CanMessage of different type to a Cfw2CanMessage).
+    // For more information, check https://github.com/robotology/icub-main/pull/82
     const Cfw2CanMessage &tmp=reinterpret_cast<const Cfw2CanMessage &>(l);
     memcpy(msg, tmp.msg, sizeof(CFWCAN_MSG));
     return *this;

--- a/src/libraries/icubmod/cfw2Can/Cfw2Can.cpp
+++ b/src/libraries/icubmod/cfw2Can/Cfw2Can.cpp
@@ -171,7 +171,7 @@ bool Cfw2Can::canGetErrors(CanErrors &err)
 
 CanMessage &Cfw2CanMessage::operator=(const CanMessage &l)
 {
-    const Cfw2CanMessage &tmp=dynamic_cast<const Cfw2CanMessage &>(l);
+    const Cfw2CanMessage &tmp=static_cast<const Cfw2CanMessage &>(l);
     memcpy(msg, tmp.msg, sizeof(CFWCAN_MSG));
     return *this;
 }

--- a/src/libraries/icubmod/cfw2Can/Cfw2Can.h
+++ b/src/libraries/icubmod/cfw2Can/Cfw2Can.h
@@ -51,7 +51,12 @@ class yarp::dev::Cfw2CanMessage:public yarp::dev::CanMessage
     virtual ~Cfw2CanMessage()
     {
     }
-
+     
+    /**
+      * This operator is defined in a general way, but it will crash if you 
+      * try to assign to a Cfw2CanMessage a CanMessage of a different type. 
+      * For more information, check https://github.com/robotology/icub-main/pull/82
+      */
     virtual CanMessage &operator=(const CanMessage &l);
 
     virtual unsigned int getId() const


### PR DESCRIPTION
Rationale: `dynamic_cast` has a runtime overhead that we pay for each copied Cfw2CanMessage (rough estimate ~1% of CPU in pc104 use of robotInterface). 
Nobody is currently testing the success of this dynamic_cast by checking the `std::bad_cast` exception, so if it will ever fail both the dynamic_cast and the static_cast will cause a crash (however, I don't think this is possible with the current source base). 

I already tested this on the real robot, but given that this is a critical piece of code is better to review this change appropriately. 
cc @lornat75 @randaz81 @francesco-romano 