### PR TITLE
added (asymmetric) circles in  stereoCalib

### DIFF
--- a/src/tools/stereoCalib/include/stereoCalibThread.h
+++ b/src/tools/stereoCalib/include/stereoCalibThread.h
@@ -85,6 +85,7 @@ private:
     int boardWidth;
     int boardHeight;
     float squareSize;
+    string boardType;
     char pathL[256];
     char pathR[256];
     void printMatrix(Mat &matrix);


### PR DESCRIPTION
- added cofiguration flag to specify pattern used (boardType) - default to CHESSBOARD
- allowed cv::findCirclesGridDefault to run when boardType is CIRCLES_GRID or ASYMMETRIC_CIRCLES_GRID
- added new calculation for calcChessboardCorners for ASYMMETRIC_CIRCLES_GRID
- added calls to cout flush due to text not always being printed
- added an early exit of threadInit when only doing MonoCalibration to remove dependence on robot joint positions when they are not used. This allows MonoCalibration to work when not running on a robot
- bug fix: changed flag options when calling cv::findChessboardCorners to use | instead of & when multiple flags are specified