### PR TITLE
Metric position control

### DIFF
--- a/app/robots/iCubDarmstadt01/hardware/motorControl/left_lower_arm-ems2-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/left_lower_arm-ems2-mc.xml
@@ -16,7 +16,9 @@
         <param name="Currents">   500           800           800           485           485           485           485           485           485           485           485           485   	</param>
     </group>
 
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">          -200          1000          -1000         -200    -500          -8000         -8000         -8000         8000          -8000         -8000         1200         </param>       
         <param name="kd">          -1000         10000         -10000        -200    -32000        -32000        -32000        -32000        32000         -32000        -32000        12500        </param>       
         <param name="ki">          -1            1             -1            -1      -1            -5            -5            -5            5             -5            -5            1            </param>       
@@ -31,7 +33,7 @@
     </group>
    
     <group name="TORQUE_CONTROL">
-	    <param name="controlLaw">    joint_pid </param> 
+	    <param name="controlLaw">    joint_pid_v1 </param> 
         <param name="controlUnits">  machine_units               </param> 
         <param name="kp">            -80      0      0      0      0      0      0      0      0      0      0      0    </param>       
         <param name="kd">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       

--- a/app/robots/iCubDarmstadt01/hardware/motorControl/left_lower_leg-ems7-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/left_lower_leg-ems7-mc.xml
@@ -16,7 +16,9 @@
         <param name="Currents">   5000          5000		</param>
     </group>
 
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">           -1000        -1000         </param>       
         <param name="kd">               0            0         </param>       
         <param name="ki">          -10000       -10000         </param>       

--- a/app/robots/iCubDarmstadt01/hardware/motorControl/left_upper_arm-ems1-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/left_upper_arm-ems1-mc.xml
@@ -20,7 +20,9 @@
       <param name="damping">	0.05   0.05  0.05   0.05    </param>
     </group>
 
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">            -1000      -1500      -1000      -1500 </param>       
         <param name="kd">                0          0          0          0 </param>       
         <param name="ki">           -10000     -15000     -10000     -15000 </param>       

--- a/app/robots/iCubDarmstadt01/hardware/motorControl/left_upper_leg-ems6-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/left_upper_leg-ems6-mc.xml
@@ -15,7 +15,9 @@
         <param name="Currents">                 5000          5000          5000          5000  </param>
     </group>
 
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">               1500       -1500       1000       1280 </param>       
         <param name="kd">                  0           0          0          0 </param>       
         <param name="ki">              15000      -20000      10000      15000 </param>       

--- a/app/robots/iCubDarmstadt01/hardware/motorControl/right_lower_arm-ems4-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/right_lower_arm-ems4-mc.xml
@@ -17,7 +17,9 @@
     </group>
 
     
-	<group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">           -200          1000          -1000         200   -500          -8000         8000          -8000         -8000         -8000         8000          -1200    </param>       
         <param name="kd">           -1000         10000         -10000        200   -32000        -32000        32000         -32000        -32000        -32000        32000         -12500   </param>       
         <param name="ki">           -1            1             -1            1     -1            -5            5             -5            -5            -5            5             -1       </param>       
@@ -32,7 +34,7 @@
     </group>
 	
 	<group name="TORQUE_CONTROL">
-	    <param name="controlLaw">    joint_pid </param> 
+	    <param name="controlLaw">    joint_pid_v1 </param> 
         <param name="controlUnits">  machine_units               </param> 
         <param name="kp">             80      0      0      0      0      0      0      0      0      0      0      0    </param>       
         <param name="kd">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       

--- a/app/robots/iCubDarmstadt01/hardware/motorControl/right_lower_leg-ems9-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/right_lower_leg-ems9-mc.xml
@@ -15,7 +15,9 @@
         <param name="Currents">                 5000          5000      </param>
     </group>
 	
-	<group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">            1000         1000         </param>       
         <param name="kd">               0            0         </param>       
         <param name="ki">           10000        10000         </param>       

--- a/app/robots/iCubDarmstadt01/hardware/motorControl/right_upper_arm-ems3-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/right_upper_arm-ems3-mc.xml
@@ -19,7 +19,9 @@
       <param name="damping">	0.00  0.00  0.00 0.00   </param>
     </group>
 
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">             1000       1500       1000       1500 </param>       
         <param name="kd">                0          0          0          0 </param>       
         <param name="ki">            10000      15000      10000      15000 </param>       

--- a/app/robots/iCubDarmstadt01/hardware/motorControl/right_upper_leg-ems8-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/right_upper_leg-ems8-mc.xml
@@ -16,7 +16,9 @@
         <param name="Currents">         5000          5000          5000        5000    </param>
     </group>
 
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">              -1500        1500      -1000      -1280 </param>       
         <param name="kd">                  0           0          0          0 </param>       
         <param name="ki">             -15000       20000     -10000     -15000 </param>       

--- a/app/robots/iCubDarmstadt01/hardware/motorControl/torso-ems5-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/torso-ems5-mc.xml
@@ -15,7 +15,9 @@
         <param name="Currents">         5000          5000          5000        </param>
     </group>
 
-	<group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">              1000    1500    1500 </param>       
         <param name="kd">                 0       0       0 </param>       
         <param name="ki">             10000   15000   20000 </param>       

--- a/app/robots/iCubGenova02/hardware/motorControl/left_lower_arm-ems2-mc.xml
+++ b/app/robots/iCubGenova02/hardware/motorControl/left_lower_arm-ems2-mc.xml
@@ -16,7 +16,9 @@
         <param name="Currents">   500           800           800           485           485           485           485           485           485           485           485           485   	</param>
     </group>
 
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">          -200          1000          -1000         -200    -500          -8000         -8000         -8000         8000          -8000         -8000         1200         </param>       
         <param name="kd">          -1000         10000         -10000        -200    -32000        -32000        -32000        -32000        32000         -32000        -32000        12500        </param>       
         <param name="ki">          -1            1             -1            -1      -1            -5            -5            -5            5             -5            -5            1            </param>       
@@ -31,7 +33,7 @@
     </group>
    
     <group name="TORQUE_CONTROL">
-	    <param name="controlLaw">    joint_pid </param> 
+	    <param name="controlLaw">    joint_pid_v1 </param> 
         <param name="controlUnits">  machine_units               </param> 
         <param name="kp">            -80      0      0      0      0      0      0      0      0      0      0      0    </param>       
         <param name="kd">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       

--- a/app/robots/iCubGenova02/hardware/motorControl/left_upper_arm-ems1-mc.xml
+++ b/app/robots/iCubGenova02/hardware/motorControl/left_upper_arm-ems1-mc.xml
@@ -20,7 +20,9 @@
         <param name="damping">         0         0         0         0         </param>    
     </group>
     
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">             1000       1500       1000       1500 </param>       
         <param name="kd">                0          0          0          0 </param>       
         <param name="ki">            10000      15000      10000      15000 </param>       

--- a/app/robots/iCubGenova02/hardware/motorControl/right_lower_arm-ems4-mc.xml
+++ b/app/robots/iCubGenova02/hardware/motorControl/right_lower_arm-ems4-mc.xml
@@ -20,7 +20,9 @@
         <param name="damping">         0      0      0      0      0      0      0      0      0      0      0      0    </param>    
     </group>
     
-	<group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">           -200          1000          -1000         200   -500          -8000         8000          -8000         -8000         -8000         8000          -1200    </param>       
         <param name="kd">           -1000         10000         -10000        200   -32000        -32000        32000         -32000        -32000        -32000        32000         -12500   </param>       
         <param name="ki">           -1            1             -1            1     -1            -5            5             -5            -5            -5            5             -1       </param>       
@@ -35,7 +37,7 @@
     </group>
 
     <group name="TORQUE_CONTROL">
-        <param name="controlLaw">    joint_pid </param> 
+        <param name="controlLaw">    joint_pid_v1 </param> 
         <param name="controlUnits">  machine_units               </param> 
         <param name="kp">             80      0      0      0      0      0      0      0      0      0      0      0    </param>       
         <param name="kd">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       

--- a/app/robots/iCubGenova02/hardware/motorControl/right_upper_arm-ems3-mc.xml
+++ b/app/robots/iCubGenova02/hardware/motorControl/right_upper_arm-ems3-mc.xml
@@ -20,7 +20,9 @@
         <param name="damping">         0      0      0      0       </param>    
     </group>
     
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">           -1000       -1500       -1000     -1500 </param>       
         <param name="kd">                0          0          0          0 </param>       
         <param name="ki">           -10000     -15000     -10000     -15000 </param>       

--- a/app/robots/iCubGenova04/hardware/motorControl/left_lower_arm-ems2-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/left_lower_arm-ems2-mc.xml
@@ -16,7 +16,9 @@
     </group>
 
    	
-	<group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">          200           100           100          -200     8000          -8000         8000         -8000         8000          -8000         -8000         -120         </param>       
         <param name="kd">          1000          100           100          -200     32000        -32000         32000        -32000        32000         -32000        -32000        -1250        </param>       
         <param name="ki">          1             2             2            -1       5            -5             5            -5            5             -5            -5             0            </param>       
@@ -31,7 +33,7 @@
     </group>
    
     <group name="TORQUE_CONTROL">
-	    <param name="controlLaw">    joint_pid </param> 
+	    <param name="controlLaw">    joint_pid_v1 </param> 
         <param name="controlUnits">  machine_units               </param> 
         <param name="kp">            -50      0      0      0      0      0      0      0      0      0      0      0    </param>       
         <param name="kd">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       

--- a/app/robots/iCubGenova04/hardware/motorControl/left_lower_leg-ems7-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/left_lower_leg-ems7-mc.xml
@@ -15,7 +15,9 @@
         <param name="Currents">   5000          5000		</param>
     </group>
 	
-	<group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">           -1280        -1280         </param>       
         <param name="kd">               0            0         </param>       
         <param name="ki">           -6250        -6250         </param>       

--- a/app/robots/iCubGenova04/hardware/motorControl/left_upper_arm-ems1-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/left_upper_arm-ems1-mc.xml
@@ -15,7 +15,9 @@
     </group>
 
    
-	 <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">            -1280        -1280  		  -1280		  -1280  </param>       
         <param name="kd">                0            0  		      0		      0  </param>       
         <param name="ki">            -1250        -1250  		  -1250		  -1250  </param>       

--- a/app/robots/iCubGenova04/hardware/motorControl/left_upper_leg-ems6-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/left_upper_leg-ems6-mc.xml
@@ -15,7 +15,9 @@
         <param name="Currents">                 5000          5000          5000          5000  </param>
     </group>
       
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">               1280      -1280  1280  -1280  </param>       
         <param name="kd">                  0         0     0     0  </param>       
         <param name="ki">               6250      -6250  6250  -6250  </param>       

--- a/app/robots/iCubGenova04/hardware/motorControl/right_lower_arm-ems4-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/right_lower_arm-ems4-mc.xml
@@ -15,7 +15,9 @@
         <param name="Currents">   500           800           800           485           485           485           485           485           485           485           485           485   	</param>
     </group>
 	
-	<group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">          200           100           100           200     8000          -8000         8000         -8000         -8000          -8000         8000         -120         </param>       
         <param name="kd">          1000          100           100           200     32000        -32000         32000        -32000        -32000         -32000        32000        -1250        </param>       
         <param name="ki">          1             2             2             1       5            -5             5            -5            -5             -5            5             0            </param>       
@@ -30,7 +32,7 @@
     </group>
    
     <group name="TORQUE_CONTROL">
-	    <param name="controlLaw">    joint_pid </param> 
+	    <param name="controlLaw">    joint_pid_v1 </param> 
         <param name="controlUnits">  machine_units               </param> 
         <param name="kp">             50      0      0      0      0      0      0      0      0      0      0      0    </param>       
         <param name="kd">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       

--- a/app/robots/iCubGenova04/hardware/motorControl/right_lower_leg-ems9-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/right_lower_leg-ems9-mc.xml
@@ -15,7 +15,9 @@
         <param name="Currents">                 5000          5000      </param>
     </group>
 
-	<group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">            1280          1280        </param>       
         <param name="kd">               0            0         </param>       
         <param name="ki">            6250          6250         </param>       

--- a/app/robots/iCubGenova04/hardware/motorControl/right_upper_arm-ems3-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/right_upper_arm-ems3-mc.xml
@@ -13,7 +13,9 @@
         <param name="Currents">   5000          5000          5000          5000        </param>
     </group>
 
-	<group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">             1280          1280  		   1280		   1280  </param>       
         <param name="kd">                0             0  		      0		      0  </param>       
         <param name="ki">             1250          1250  		   1250		   1250  </param>       

--- a/app/robots/iCubGenova04/hardware/motorControl/right_upper_leg-ems8-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/right_upper_leg-ems8-mc.xml
@@ -15,7 +15,9 @@
         <param name="Currents">         5000          5000          5000        5000    </param>
     </group>
 
-	<group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">               -1280      1280  -1280  1280  </param>       
         <param name="kd">                  0         0     0     0  </param>       
         <param name="ki">               -6250      6250  -6250  6250  </param>       

--- a/app/robots/iCubGenova04/hardware/motorControl/torso-ems5-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/torso-ems5-mc.xml
@@ -13,7 +13,9 @@
         <param name="Currents">         5000          5000          5000        </param>
     </group>
 	
-	<group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1         </param> 
+        <param name="controlUnits">  machine_units        </param> 
         <param name="kp">              1792   2560  2560  </param>       
         <param name="kd">                 0      0     0  </param>       
         <param name="ki">              6250   6250  6250  </param>       

--- a/app/robots/iCubHeidelberg01/hardware/motorControl/left_lower_leg-ems7-mc.xml
+++ b/app/robots/iCubHeidelberg01/hardware/motorControl/left_lower_leg-ems7-mc.xml
@@ -13,7 +13,9 @@
         <param name="Currents">   5000          5000		</param>
     </group>
 
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">            1000         1000         </param>       
         <param name="kd">               0            0         </param>       
         <param name="ki">           10000        10000         </param>       

--- a/app/robots/iCubHeidelberg01/hardware/motorControl/left_upper_leg-ems6-mc.xml
+++ b/app/robots/iCubHeidelberg01/hardware/motorControl/left_upper_leg-ems6-mc.xml
@@ -18,7 +18,9 @@
         <param name="damping">           0.0	     0.0	   0.0         0.0 </param>
     </group>
     
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">              -1500        1500      -1000       1280 </param>       
         <param name="kd">                  0           0          0          0 </param>       
         <param name="ki">             -15000       20000     -10000      15000 </param>       

--- a/app/robots/iCubHeidelberg01/hardware/motorControl/right_lower_leg-ems9-mc.xml
+++ b/app/robots/iCubHeidelberg01/hardware/motorControl/right_lower_leg-ems9-mc.xml
@@ -13,7 +13,9 @@
         <param name="Currents">                 5000          5000      </param>
     </group>
 	
-	<group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">           -1000        -1000         </param>       
         <param name="kd">               0            0         </param>       
         <param name="ki">          -10000       -10000         </param>       

--- a/app/robots/iCubHeidelberg01/hardware/motorControl/right_upper_leg-ems8-mc.xml
+++ b/app/robots/iCubHeidelberg01/hardware/motorControl/right_upper_leg-ems8-mc.xml
@@ -18,7 +18,9 @@
         <param name="damping">           0.0	     0.0	   0.0         0.0 </param>
     </group>
     
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">               1500       -1500       1000      -1280 </param>       
         <param name="kd">                  0           0          0          0 </param>       
         <param name="ki">              15000      -20000      10000     -15000 </param>       

--- a/app/robots/iCubHeidelberg01/hardware/motorControl/torso-ems5-mc.xml
+++ b/app/robots/iCubHeidelberg01/hardware/motorControl/torso-ems5-mc.xml
@@ -18,7 +18,9 @@
         <param name="damping">           0.0	     0.0	   0.0       </param>
     </group>
     
-	<group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">              1000   -1500   -1500 </param>       
         <param name="kd">                 0       0       0 </param>       
         <param name="ki">             10000  -15000  -20000 </param>       

--- a/app/robots/iCubSheffield01/hardware/motorControl/left_lower_arm-ems2-mc.xml
+++ b/app/robots/iCubSheffield01/hardware/motorControl/left_lower_arm-ems2-mc.xml
@@ -16,7 +16,9 @@
         <param name="Currents">   500           800           800           485           485           485           485           485           485           485           485           485   	</param>
     </group>
 
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">          -200          1000          -1000         -200    -500          -8000         -8000         -8000         8000          -8000         -8000         1200         </param>       
         <param name="kd">          -1000         10000         -10000        -200    -32000        -32000        -32000        -32000        32000         -32000        -32000        12500        </param>       
         <param name="ki">          -1            1             -1            -1      -1            -5            -5            -5            5             -5            -5            1            </param>       
@@ -31,7 +33,7 @@
     </group>
    
     <group name="TORQUE_CONTROL">
-	    <param name="controlLaw">    joint_pid </param> 
+	    <param name="controlLaw">    joint_pid_v1 </param> 
         <param name="controlUnits">  machine_units               </param> 
         <param name="kp">            -80      0      0      0      0      0      0      0      0      0      0      0    </param>       
         <param name="kd">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       

--- a/app/robots/iCubSheffield01/hardware/motorControl/left_upper_arm-ems1-mc.xml
+++ b/app/robots/iCubSheffield01/hardware/motorControl/left_upper_arm-ems1-mc.xml
@@ -20,7 +20,9 @@
       <param name="damping">	0.05   0.05  0.05   0.05    </param>
     </group>
 
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">             1000       1500       1000       1500 </param>       
         <param name="kd">                0          0          0          0 </param>       
         <param name="ki">            10000      15000      10000      15000 </param>       

--- a/app/robots/iCubSheffield01/hardware/motorControl/right_lower_arm-ems4-mc.xml
+++ b/app/robots/iCubSheffield01/hardware/motorControl/right_lower_arm-ems4-mc.xml
@@ -20,7 +20,9 @@
         <param name="damping">         0      0      0      0      0      0      0      0      0      0      0      0    </param>    
     </group>
     
-	<group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">           -200          1000          -1000         200   -500          -8000         8000          -8000         -8000         -8000         8000          -1200    </param>       
         <param name="kd">           -1000         10000         -10000        200   -32000        -32000        32000         -32000        -32000        -32000        32000         -12500   </param>       
         <param name="ki">           -1            1             -1            1     -1            -5            5             -5            -5            -5            5             -1       </param>       
@@ -35,7 +37,7 @@
     </group>
 	
 	<group name="TORQUE_CONTROL">
-	    <param name="controlLaw">    joint_pid </param> 
+	    <param name="controlLaw">    joint_pid_v1 </param> 
         <param name="controlUnits">  machine_units               </param> 
         <param name="kp">             80      0      0      0      0      0      0      0      0      0      0      0    </param>       
         <param name="kd">              0      0      0      0      0      0      0      0      0      0      0      0    </param>       

--- a/app/robots/iCubSheffield01/hardware/motorControl/right_upper_arm-ems3-mc.xml
+++ b/app/robots/iCubSheffield01/hardware/motorControl/right_upper_arm-ems3-mc.xml
@@ -20,7 +20,9 @@
         <param name="damping">	   0.05    0.05    0.05   0.05   </param>
     </group>
 
-    <group name="POS_PIDS">
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1 </param> 
+        <param name="controlUnits">  machine_units               </param> 
         <param name="kp">           -1000       -1500       -1000     -1500 </param>       
         <param name="kd">                0          0          0          0 </param>       
         <param name="ki">           -10000     -15000     -10000     -15000 </param>       

--- a/app/robots/iCubSheffield01/hardware/motorControl/torso-ems5-mc.xml
+++ b/app/robots/iCubSheffield01/hardware/motorControl/torso-ems5-mc.xml
@@ -15,9 +15,11 @@
         <param name="Currents">         5000          5000          5000        </param>
     </group>
 
-	<group name="POS_PIDS">
-        <param name="kp">              2000   -1500    -1500 </param>       
-        <param name="kd">                 0       0       0 </param>       
+	<group name="POSITION_CONTROL">
+	    <param name="controlLaw">    joint_pid_v1             </param> 
+        <param name="controlUnits">  machine_units            </param> 
+        <param name="kp">              2000   -1500    -1500  </param>       
+        <param name="kd">                 0       0       0   </param>       
         <param name="ki">             10000   -15000   -20000 </param>       
         <param name="limPwm">          4000    4000    4000 </param>       
         <param name="maxPwm">          8000    8000    8000 </param>  

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -1116,8 +1116,8 @@ bool embObjMotionControl::fromConfig(yarp::os::Searchable &config)
            Value &controlUnits=posPidsGroup.find("controlUnits");
            if  (controlUnits.isNull() == false && controlUnits.isString() == true)
            {
-                if      (controlUnits.toString()==string("metric_units"))  {_positionControlUnits=P_METRIC_UNITS;}
-                else if (controlUnits.toString()==string("machine_units")) {_positionControlUnits=P_MACHINE_UNITS;}
+                if      (controlUnits.toString()==string("metric_units"))  {yDebug("POSITION_CONTROL: using metric_units");  _positionControlUnits=P_METRIC_UNITS;}
+                else if (controlUnits.toString()==string("machine_units")) {yDebug("POSITION_CONTROL: using machine_units"); _positionControlUnits=P_MACHINE_UNITS;}
                 else    {yError() << "embObjMotionControl::fromConfig(): POSITION_CONTROL section: invalid controlUnits value";
                          return false;}
            }
@@ -1140,10 +1140,7 @@ bool embObjMotionControl::fromConfig(yarp::os::Searchable &config)
                    }
                    else
                    {
-                       if(verbosewhenok)
-                       {
-                            yDebug() << "embObjMotionControl::fromConfig(): POSITION_CONTROL new format successfully loaded";
-                       }
+                        yDebug("POSITION_CONTROL: using control law joint_pid_v1");
                    }
                }
                else if (s_controlaw==string("not_implemented"))
@@ -1180,8 +1177,8 @@ bool embObjMotionControl::fromConfig(yarp::os::Searchable &config)
            Value &controlUnits=trqPidsGroup.find("controlUnits");
            if  (controlUnits.isNull() == false && controlUnits.isString() == true)
            {
-                if      (controlUnits.toString()==string("metric_units"))  {_torqueControlUnits=T_METRIC_UNITS;}
-                else if (controlUnits.toString()==string("machine_units")) {_torqueControlUnits=T_MACHINE_UNITS;}
+                if      (controlUnits.toString()==string("metric_units"))  {yDebug("TORQUE_CONTROL: using metric_units"); _torqueControlUnits=T_METRIC_UNITS;}
+                else if (controlUnits.toString()==string("machine_units")) {yDebug("TORQUE_CONTROL: using metric_units"); _torqueControlUnits=T_MACHINE_UNITS;}
                 else    {yError() << "embObjMotionControl::fromConfig(): TORQUE_CONTROL section: invalid controlUnits value";
                          return false;}
            }
@@ -1207,10 +1204,7 @@ bool embObjMotionControl::fromConfig(yarp::os::Searchable &config)
                    else
                    {
                        _torqueControlEnabled = true;
-                       if(verbosewhenok)
-                       {
-                            yDebug() << "embObjMotionControl::fromConfig(): TORQUE_CONTROL new format successfully loaded";
-                       }
+                        yDebug("TORQUE_CONTROL: using control law motor_pid_with_friction_v1");
                    }
                }
                else if (s_controlaw==string("joint_pid_v1"))
@@ -1225,10 +1219,7 @@ bool embObjMotionControl::fromConfig(yarp::os::Searchable &config)
                     else
                     {
                        _torqueControlEnabled = true;
-                       if(verbosewhenok)
-                       {
-                            yDebug() << "embObjMotionControl::fromConfig(): TORQUE_CONTROL new format successfully loaded";
-                       }
+                        yDebug("TORQUE_CONTROL: using control law joint_pid_v1");
                     }
                }
                else if (s_controlaw==string("not_implemented"))

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -1194,7 +1194,7 @@ bool embObjMotionControl::fromConfig(yarp::os::Searchable &config)
                string s_controlaw = controlLaw.toString();
                if (s_controlaw==string("motor_pid_with_friction_v1"))
                {
-                   yDebug() << "control law" << s_controlaw << " will be use for torque control";
+                   yDebug("TORQUE_CONTROL: using control law motor_pid_with_friction_v1");
                    if (!parseTorquePidsGroup (trqPidsGroup, _tpids, _kbemf, _ktau, _filterType))
                    {
                        yError() << "embObjMotionControl::fromConfig(): TORQUE_CONTROL section: error detected in parameters syntax";
@@ -1204,12 +1204,11 @@ bool embObjMotionControl::fromConfig(yarp::os::Searchable &config)
                    else
                    {
                        _torqueControlEnabled = true;
-                        yDebug("TORQUE_CONTROL: using control law motor_pid_with_friction_v1");
                    }
                }
                else if (s_controlaw==string("joint_pid_v1"))
                {
-                    yDebug() << "control law" << s_controlaw << " will be use for torque control";
+                    yDebug("TORQUE_CONTROL: using control law joint_pid_v1");
                     if (!parseTorquePidsGroup (trqPidsGroup, _tpids, _kbemf, _ktau, _filterType))
                     {
                        yError() << "embObjMotionControl::fromConfig(): TORQUE_CONTROL section: error detected in parameters syntax";
@@ -1219,7 +1218,6 @@ bool embObjMotionControl::fromConfig(yarp::os::Searchable &config)
                     else
                     {
                        _torqueControlEnabled = true;
-                        yDebug("TORQUE_CONTROL: using control law joint_pid_v1");
                     }
                }
                else if (s_controlaw==string("not_implemented"))
@@ -1909,9 +1907,9 @@ bool embObjMotionControl::setPidRaw(int j, const Pid &pid)
     
     if (_positionControlUnits==P_METRIC_UNITS)
     {
-        hwPid.kp = hwPid.kp * _angleToEncoder[j];  //[PWM/deg]
-        hwPid.ki = hwPid.ki * _angleToEncoder[j];  //[PWM/deg]
-        hwPid.kd = hwPid.kd * _angleToEncoder[j];  //[PWM/deg]
+        hwPid.kp = hwPid.kp / _angleToEncoder[j];  //[PWM/deg]
+        hwPid.ki = hwPid.ki / _angleToEncoder[j];  //[PWM/deg]
+        hwPid.kd = hwPid.kd / _angleToEncoder[j];  //[PWM/deg]
     }
     else if (_positionControlUnits==P_MACHINE_UNITS)
     {
@@ -2064,9 +2062,9 @@ bool embObjMotionControl::getPidRaw(int j, Pid *pid)
 
     if (_positionControlUnits==P_METRIC_UNITS)
     {
-        pid->kp = pid->kp / _angleToEncoder[j];  //[PWM/deg]
-        pid->ki = pid->ki / _angleToEncoder[j];  //[PWM/deg]
-        pid->kd = pid->kd / _angleToEncoder[j];  //[PWM/deg]
+        pid->kp = pid->kp * _angleToEncoder[j];  //[PWM/deg]
+        pid->ki = pid->ki * _angleToEncoder[j];  //[PWM/deg]
+        pid->kd = pid->kd * _angleToEncoder[j];  //[PWM/deg]
     }
     else if (_positionControlUnits==P_MACHINE_UNITS)
     {

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -301,9 +301,12 @@ private:
     bool        _pwmIsLimited;                         /** set to true if pwm is limited */
     bool        _torqueControlEnabled;                 /** set to true if the torque control parameters are successfully loaded. If false, boards cannot switch in torque mode */
     
-    enum       torqueControlUnitsType {MACHINE_UNITS=0, METRIC_UNITS=1};
+    enum       torqueControlUnitsType {T_MACHINE_UNITS=0, T_METRIC_UNITS=1};
     torqueControlUnitsType _torqueControlUnits;
     torqueControlHelper    *_torqueControlHelper;
+
+    enum       positionControlUnitsType {P_MACHINE_UNITS=0, P_METRIC_UNITS=1};
+    positionControlUnitsType _positionControlUnits;
     
 #if !defined(EMBOBJMC_DONT_USE_MAIS)
     int         numberofmaisboards;


### PR DESCRIPTION
This branch implements the following parameters:
`<group name="POSITION_CONTROL">`
`<param name="controlLaw">    joint_pid_v1 </param> `
`<param name="controlUnits">  machine_units  </param>`

if `controlUnits` is set to `machine_units` then the P,I,D gains are expressed as PWM/iCubDegrees
if `controlUnits` is set to `metric_units`  then the P,I,D gains are expressed as PWM/Degrees

Currently, `joint_pid_v1` is the only admissible value for parameter  `controlLaw`.

Configuration files of all ETH robots are updated to use this new format. Default value is still `machine_units` but `metric_units` will become the standard soon for all EMS board. Instead, MC4 and BLL boards will continue to use `machine_units`.