### PR TITLE
updated ETH robot configuration files to use metric units in position control

### DIFF
--- a/app/robots/iCubDarmstadt01/hardware/motorControl/left_lower_leg-ems7-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/left_lower_leg-ems7-mc.xml
@@ -18,14 +18,14 @@
 
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">           -1000        -1000         </param>       
-        <param name="kd">               0            0         </param>       
-        <param name="ki">          -10000       -10000         </param>       
+        <param name="controlUnits">  metric_units              </param> 
+        <param name="kp">         -711.11      -711.11         </param>       
+        <param name="kd">            0.00         0.00         </param>       
+        <param name="ki">        -7111.09     -7111.09         </param>       
         <param name="limPwm">        2500         2500         </param>       
         <param name="maxPwm">        8000         8000         </param>       
         <param name="maxInt">         750          750         </param>       
-        <param name="shift">            8            8         </param>       
+        <param name="shift">            0            0         </param>       
         <param name="ko">               0            0         </param>       
         <param name="stictionUp">       0            0         </param>       
         <param name="stictionDwn">      0            0         </param>      

--- a/app/robots/iCubDarmstadt01/hardware/motorControl/left_upper_arm-ems1-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/left_upper_arm-ems1-mc.xml
@@ -22,14 +22,14 @@
 
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">            -1000      -1500      -1000      -1500 </param>       
-        <param name="kd">                0          0          0          0 </param>       
-        <param name="ki">           -10000     -15000     -10000     -15000 </param>       
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">          -711.11   -1066.66    -711.11   -1066.66 </param>       
+        <param name="kd">             0.00       0.00       0.00       0.00 </param>       
+        <param name="ki">         -7111.09  -10666.64   -7111.09  -10666.64 </param>       
         <param name="limPwm">         3000       3000       3000       3000 </param>       
         <param name="maxPwm">         8000       8000       8000       8000 </param>    
         <param name="maxInt">          200        200        200       1000 </param>       
-        <param name="shift">             8          8          8          8 </param>       
+        <param name="shift">             0          0          0          0 </param>       
         <param name="ko">                0          0          0          0 </param>       
         <param name="stictionUp">        0          0          0          0 </param>       
         <param name="stictionDwn">       0          0          0          0 </param>       

--- a/app/robots/iCubDarmstadt01/hardware/motorControl/left_upper_leg-ems6-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/left_upper_leg-ems6-mc.xml
@@ -17,14 +17,14 @@
 
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">               1500       -1500       1000       1280 </param>       
-        <param name="kd">                  0           0          0          0 </param>       
-        <param name="ki">              15000      -20000      10000      15000 </param>       
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">            1066.66    -1066.66     711.11    1066.66 </param>       
+        <param name="kd">               0.00        0.00       0.00       0.00 </param>       
+        <param name="ki">           10666.64   -14222.18    7111.09   10666.64 </param>       
         <param name="limPwm">           2500        2500       2500       2500 </param>       
         <param name="maxPwm">           8000        8000       8000       8000 </param>       
         <param name="maxInt">           1500        1500        750       1000 </param>       
-        <param name="shift">               8           8          8          8 </param>       
+        <param name="shift">               0           0          0          0 </param>       
         <param name="ko">                  0           0          0          0 </param>       
         <param name="stictionUp">          0           0          0          0 </param>       
         <param name="stictionDwn">         0           0          0          0 </param>       

--- a/app/robots/iCubDarmstadt01/hardware/motorControl/right_lower_leg-ems9-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/right_lower_leg-ems9-mc.xml
@@ -17,14 +17,14 @@
 	
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">            1000         1000         </param>       
-        <param name="kd">               0            0         </param>       
-        <param name="ki">           10000        10000         </param>       
+        <param name="controlUnits">  metric_units              </param> 
+        <param name="kp">          711.11       711.11         </param>       
+        <param name="kd">            0.00         0.00         </param>       
+        <param name="ki">         7111.09      7111.09         </param>       
         <param name="limPwm">        2500         2500         </param>       
         <param name="maxPwm">        8000         8000         </param>      
         <param name="maxInt">         750          750         </param>       
-        <param name="shift">            8            8         </param>       
+        <param name="shift">            0            0          </param>       
         <param name="ko">               0            0         </param>       
         <param name="stictionUp">       0            0         </param>       
         <param name="stictionDwn">      0            0         </param>       

--- a/app/robots/iCubDarmstadt01/hardware/motorControl/right_upper_arm-ems3-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/right_upper_arm-ems3-mc.xml
@@ -21,14 +21,14 @@
 
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">             1000       1500       1000       1500 </param>       
-        <param name="kd">                0          0          0          0 </param>       
-        <param name="ki">            10000      15000      10000      15000 </param>       
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">           711.10    1066.66     711.10    1066.66 </param>       
+        <param name="kd">             0.00       0.00       0.00       0.00 </param>       
+        <param name="ki">          7111.09   10666.64    7111.09   10666.64 </param>       
         <param name="limPwm">         3000       3000       3000       3000 </param>      
         <param name="maxPwm">         8000       8000       8000       8000 </param>              
         <param name="maxInt">          200        200        200       1000 </param>       
-        <param name="shift">             8          8          8          8 </param>       
+        <param name="shift">             0          0          0          0 </param>       
         <param name="ko">                0          0          0          0 </param>       
         <param name="stictionUp">        0          0          0          0 </param>       
         <param name="stictionDwn">       0          0          0          0 </param>       

--- a/app/robots/iCubDarmstadt01/hardware/motorControl/right_upper_leg-ems8-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/right_upper_leg-ems8-mc.xml
@@ -18,14 +18,14 @@
 
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">              -1500        1500      -1000      -1280 </param>       
-        <param name="kd">                  0           0          0          0 </param>       
-        <param name="ki">             -15000       20000     -10000     -15000 </param>       
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">           -1066.66     1066.66    -711.11   -1066.66 </param>       
+        <param name="kd">               0.00        0.00       0.00       0.00 </param>       
+        <param name="ki">          -10666.64    14222.18   -7111.0   -10666.64 </param>       
         <param name="limPwm">           2500        2500       2500       2500 </param>      
         <param name="maxPwm">           8000        8000       8000       8000 </param>          
         <param name="maxInt">           1500        1500        750       1000 </param>       
-        <param name="shift">               8           8          8          8 </param>       
+        <param name="shift">               0           0          0          0 </param>       
         <param name="ko">                  0           0          0          0 </param>       
         <param name="stictionUp">          0           0          0          0 </param>       
         <param name="stictionDwn">         0           0          0          0 </param>     

--- a/app/robots/iCubDarmstadt01/hardware/motorControl/torso-ems5-mc.xml
+++ b/app/robots/iCubDarmstadt01/hardware/motorControl/torso-ems5-mc.xml
@@ -17,18 +17,18 @@
 
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">              1000    1500    1500 </param>       
-        <param name="kd">                 0       0       0 </param>       
-        <param name="ki">             10000   15000   20000 </param>       
-        <param name="limPwm">          4000    4000    8000 </param>       
-        <param name="maxPwm">          4000    4000    8000 </param>  
-        <param name="maxInt">           750    1000    2000 </param>       
-        <param name="shift">              8       8       8 </param>       
-        <param name="ko">                 0       0       0 </param>       
-        <param name="stictionUp">         0       0       0 </param>       
-        <param name="stictionDwn">        0       0       0 </param>       
-        <param name="kff">                0       0       0 </param>     
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">            711.11   1066.66   1066.66 </param>       
+        <param name="kd">              0.00      0.00      0.00 </param>       
+        <param name="ki">           7111.09  10666.64  14222.18 </param>       
+        <param name="limPwm">          4000      4000      8000 </param>       
+        <param name="maxPwm">          4000      4000      8000 </param>  
+        <param name="maxInt">           750      1000      2000 </param>       
+        <param name="shift">              0         0         0 </param>       
+        <param name="ko">                 0         0         0 </param>       
+        <param name="stictionUp">         0         0         0 </param>       
+        <param name="stictionDwn">        0         0         0 </param>       
+        <param name="kff">                0         0         0 </param>     
     </group>
 	
 	<group name="TORQUE_CONTROL">

--- a/app/robots/iCubGenova02/hardware/motorControl/left_upper_arm-ems1-mc.xml
+++ b/app/robots/iCubGenova02/hardware/motorControl/left_upper_arm-ems1-mc.xml
@@ -22,14 +22,14 @@
     
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">             1000       1500       1000       1500 </param>       
-        <param name="kd">                0          0          0          0 </param>       
-        <param name="ki">            10000      15000      10000      15000 </param>       
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">           711.11    1066.66     711.11    1066.66 </param>       
+        <param name="kd">             0.00       0.00       0.00       0.00 </param>       
+        <param name="ki">          7111.09   10666.64    7111.09   10666.64 </param>       
         <param name="limPwm">         3000       3000       3000       3000 </param>       
         <param name="maxPwm">         8000       8000       8000       8000 </param>    
         <param name="maxInt">          200        200        200       1000 </param>       
-        <param name="shift">             8          8          8          8 </param>       
+        <param name="shift">             0          0          0          0 </param>       
         <param name="ko">                0          0          0          0 </param>       
         <param name="stictionUp">        0          0          0          0 </param>       
         <param name="stictionDwn">       0          0          0          0 </param>       

--- a/app/robots/iCubGenova02/hardware/motorControl/right_upper_arm-ems3-mc.xml
+++ b/app/robots/iCubGenova02/hardware/motorControl/right_upper_arm-ems3-mc.xml
@@ -22,14 +22,14 @@
     
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">           -1000       -1500       -1000     -1500 </param>       
-        <param name="kd">                0          0          0          0 </param>       
-        <param name="ki">           -10000     -15000     -10000     -15000 </param>       
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">          -711.11   -1066.66    -711.11   -1066.66 </param>       
+        <param name="kd">             0.00       0.00       0.00       0.00 </param>       
+        <param name="ki">         -7111.09  -10666.64   -7111.09  -10666.64 </param>       
         <param name="limPwm">         3000       3000       3000       3000 </param>      
         <param name="maxPwm">         8000       8000       8000       8000 </param>              
         <param name="maxInt">          200        200        200       1000 </param>       
-        <param name="shift">             8          8          8          8 </param>       
+        <param name="shift">             0          0          0          0 </param>       
         <param name="ko">                0          0          0          0 </param>       
         <param name="stictionUp">        0          0          0          0 </param>       
         <param name="stictionDwn">       0          0          0          0 </param>       

--- a/app/robots/iCubGenova04/hardware/motorControl/left_lower_leg-ems7-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/left_lower_leg-ems7-mc.xml
@@ -17,14 +17,14 @@
 	
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">           -1280        -1280         </param>       
-        <param name="kd">               0            0         </param>       
-        <param name="ki">           -6250        -6250         </param>       
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">         -910.22      -910.22         </param>       
+        <param name="kd">            0.00         0.00         </param>       
+        <param name="ki">        -4444.43     -4444.43         </param>       
         <param name="limPwm">        5000         5000         </param>       
         <param name="maxPwm">        5000         8000         </param>       
         <param name="maxInt">         750          750         </param>       
-        <param name="shift">            8            8         </param>       
+        <param name="shift">            0            0         </param>       
         <param name="ko">               0            0         </param>       
         <param name="stictionUp">       0            0         </param>       
         <param name="stictionDwn">      0            0         </param>      

--- a/app/robots/iCubGenova04/hardware/motorControl/left_upper_arm-ems1-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/left_upper_arm-ems1-mc.xml
@@ -17,18 +17,18 @@
    
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">            -1280        -1280  		  -1280		  -1280  </param>       
-        <param name="kd">                0            0  		      0		      0  </param>       
-        <param name="ki">            -1250        -1250  		  -1250		  -1250  </param>       
-        <param name="limPwm">         8000         8000  		   8000		   8000  </param>       
-        <param name="maxPwm">         8000         8000  		   8000		   8000  </param>    
-        <param name="maxInt">          750          750  		    750		    750  </param>       
-        <param name="shift">             8            8  		      8		      8  </param>       
-        <param name="ko">                0            0  		      0		      0  </param>       
-        <param name="stictionUp">        0            0  		      0		      0  </param>       
-        <param name="stictionDwn">       0            0  		      0		      0  </param>       
-        <param name="kff">               0            0  		      0		      0  </param>       
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">          -910.22      -910.22  -910.22  -910.22  </param>       
+        <param name="kd">             0.00         0.00     0.00     0.00  </param>       
+        <param name="ki">          -888.88      -888.88  -888.88  -888.88  </param>       
+        <param name="limPwm">         8000         8000     8000     8000  </param>       
+        <param name="maxPwm">         8000         8000     8000     8000  </param>    
+        <param name="maxInt">          750          750      750      750  </param>       
+        <param name="shift">             0            0        0        0  </param>       
+        <param name="ko">                0            0        0        0  </param>       
+        <param name="stictionUp">        0            0        0        0  </param>       
+        <param name="stictionDwn">       0            0        0        0  </param>       
+        <param name="kff">               0            0        0        0  </param>       
     </group>
 
     <group name="TORQUE_CONTROL">

--- a/app/robots/iCubGenova04/hardware/motorControl/left_upper_leg-ems6-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/left_upper_leg-ems6-mc.xml
@@ -17,18 +17,18 @@
       
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">               1280      -1280  1280  -1280  </param>       
-        <param name="kd">                  0         0     0     0  </param>       
-        <param name="ki">               6250      -6250  6250  -6250  </param>       
-        <param name="limPwm">           2500      2500  2500  2500  </param>       
-        <param name="maxPwm">           8000      8000  8000  8000  </param>       
-        <param name="maxInt">            750       750   750   750  </param>       
-        <param name="shift">               8         8     8     8  </param>       
-        <param name="ko">                  0         0     0     0  </param>       
-        <param name="stictionUp">          0         0     0     0  </param>       
-        <param name="stictionDwn">         0         0     0     0  </param>       
-        <param name="kff">                 0         0     0     0  </param>  
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">             910.22   -910.22  910.22  -910.22  </param>       
+        <param name="kd">               0.00      0.00    0.00     0.00  </param>       
+        <param name="ki">            4444.43  -4444.43 4444.43 -4444.43  </param>       
+        <param name="limPwm">           2500      2500    2500     2500  </param>       
+        <param name="maxPwm">           8000      8000    8000     8000  </param>       
+        <param name="maxInt">            750       750     750      750  </param>       
+        <param name="shift">               0         0       0        0  </param>       
+        <param name="ko">                  0         0       0        0  </param>       
+        <param name="stictionUp">          0         0       0        0  </param>       
+        <param name="stictionDwn">         0         0       0        0  </param>       
+        <param name="kff">                 0         0       0        0  </param>  
     </group>
     
      <group name="IMPEDANCE">

--- a/app/robots/iCubGenova04/hardware/motorControl/right_lower_leg-ems9-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/right_lower_leg-ems9-mc.xml
@@ -17,14 +17,14 @@
 
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">            1280          1280        </param>       
-        <param name="kd">               0            0         </param>       
-        <param name="ki">            6250          6250         </param>       
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">          910.22       910.22         </param>       
+        <param name="kd">            0.00         0.00         </param>       
+        <param name="ki">         4444.43      4444.43         </param>       
         <param name="limPwm">        5000         5000         </param>       
         <param name="maxPwm">        5000         8000         </param>       
         <param name="maxInt">         750          750         </param>       
-        <param name="shift">            8            8         </param>       
+        <param name="shift">            0            0         </param>       
         <param name="ko">               0            0         </param>       
         <param name="stictionUp">       0            0         </param>       
         <param name="stictionDwn">      0            0         </param>      

--- a/app/robots/iCubGenova04/hardware/motorControl/right_upper_arm-ems3-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/right_upper_arm-ems3-mc.xml
@@ -15,18 +15,18 @@
 
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">             1280          1280  		   1280		   1280  </param>       
-        <param name="kd">                0             0  		      0		      0  </param>       
-        <param name="ki">             1250          1250  		   1250		   1250  </param>       
-        <param name="limPwm">         8000         8000  		   8000		   8000  </param>       
-        <param name="maxPwm">         8000         8000  		   8000		   8000  </param>    
-        <param name="maxInt">          750          750  		    750		    750  </param>       
-        <param name="shift">             8            8  		      8		      8  </param>       
-        <param name="ko">                0            0  		      0		      0  </param>       
-        <param name="stictionUp">        0            0  		      0		      0  </param>       
-        <param name="stictionDwn">       0            0  		      0		      0  </param>       
-        <param name="kff">               0            0  		      0		      0  </param>       
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">           910.22       910.22     910.22   910.22  </param>       
+        <param name="kd">             0.00         0.00       0.00     0.00  </param>       
+        <param name="ki">           888.88       888.88     888.88   888.88  </param>       
+        <param name="limPwm">         8000         8000       8000     8000  </param>       
+        <param name="maxPwm">         8000         8000       8000     8000  </param>    
+        <param name="maxInt">          750          750        750      750  </param>       
+        <param name="shift">             0            0          0        0  </param>       
+        <param name="ko">                0            0          0        0  </param>       
+        <param name="stictionUp">        0            0          0        0  </param>       
+        <param name="stictionDwn">       0            0          0        0  </param>       
+        <param name="kff">               0            0          0        0  </param>       
     </group>
 
     <group name="IMPEDANCE">

--- a/app/robots/iCubGenova04/hardware/motorControl/right_upper_leg-ems8-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/right_upper_leg-ems8-mc.xml
@@ -17,18 +17,18 @@
 
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">               -1280      1280  -1280  1280  </param>       
-        <param name="kd">                  0         0     0     0  </param>       
-        <param name="ki">               -6250      6250  -6250  6250  </param>       
-        <param name="limPwm">           2500      2500  2500  2500  </param>       
-        <param name="maxPwm">           8000      8000  8000  8000  </param>       
-        <param name="maxInt">            750       750   750   750  </param>       
-        <param name="shift">               8         8     8     8  </param>       
-        <param name="ko">                  0         0     0     0  </param>       
-        <param name="stictionUp">          0         0     0     0  </param>       
-        <param name="stictionDwn">         0         0     0     0  </param>       
-        <param name="kff">                 0         0     0     0  </param>  
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">            -910.22    910.22   -910.22   910.22  </param>       
+        <param name="kd">               0.00      0.00      0.00     0.00  </param>       
+        <param name="ki">           -4444.43   4444.43  -4444.43  4444.43  </param>       
+        <param name="limPwm">           2500      2500      2500     2500  </param>       
+        <param name="maxPwm">           8000      8000      8000     8000  </param>       
+        <param name="maxInt">            750       750       750      750  </param>       
+        <param name="shift">               0         0         0        0  </param>       
+        <param name="ko">                  0         0         0        0  </param>       
+        <param name="stictionUp">          0         0         0        0  </param>       
+        <param name="stictionDwn">         0         0         0        0  </param>       
+        <param name="kff">                 0         0         0        0  </param>  
     </group>
     
      <group name="IMPEDANCE">

--- a/app/robots/iCubGenova04/hardware/motorControl/torso-ems5-mc.xml
+++ b/app/robots/iCubGenova04/hardware/motorControl/torso-ems5-mc.xml
@@ -15,18 +15,18 @@
 	
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1         </param> 
-        <param name="controlUnits">  machine_units        </param> 
-        <param name="kp">              1792   2560  2560  </param>       
-        <param name="kd">                 0      0     0  </param>       
-        <param name="ki">              6250   6250  6250  </param>       
-        <param name="limPwm">          4000   4000  8000  </param>       
-        <param name="maxPwm">          8000   8000 16000  </param>  
-        <param name="maxInt">           750    750  1500  </param>       
-        <param name="shift">              8      8     8  </param>       
-        <param name="ko">                 0      0     0  </param>       
-        <param name="stictionUp">         0      0     0  </param>       
-        <param name="stictionDwn">        0      0     0  </param>       
-        <param name="kff">                0      0     0  </param>     
+        <param name="controlUnits">  metric_units        </param> 
+        <param name="kp">           1274.30  1820.44  1820.44  </param>       
+        <param name="kd">              0.00     0.00     0.00  </param>       
+        <param name="ki">           4444.43  4444.43  4444.43  </param>       
+        <param name="limPwm">          4000     4000     8000  </param>       
+        <param name="maxPwm">          8000     8000    16000  </param>  
+        <param name="maxInt">           750      750     1500  </param>       
+        <param name="shift">              0        0        0  </param>       
+        <param name="ko">                 0        0        0  </param>       
+        <param name="stictionUp">         0        0        0  </param>       
+        <param name="stictionDwn">        0        0        0  </param>       
+        <param name="kff">                0        0        0  </param>     
     </group>
 	
 	<group name="TORQUE_CONTROL">

--- a/app/robots/iCubHeidelberg01/hardware/motorControl/left_lower_leg-ems7-mc.xml
+++ b/app/robots/iCubHeidelberg01/hardware/motorControl/left_lower_leg-ems7-mc.xml
@@ -15,14 +15,14 @@
 
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">            1000         1000         </param>       
-        <param name="kd">               0            0         </param>       
-        <param name="ki">           10000        10000         </param>       
+        <param name="controlUnits">  metric_units              </param> 
+        <param name="kp">          711.11       711.11         </param>       
+        <param name="kd">            0.00         0.00         </param>       
+        <param name="ki">         7111.09      7111.09         </param>       
         <param name="limPwm">        2500         2500         </param>       
         <param name="maxPwm">        8000         8000         </param>       
         <param name="maxInt">         750          750         </param>       
-        <param name="shift">            8            8         </param>       
+        <param name="shift">            0            0         </param>       
         <param name="ko">               0            0         </param>       
         <param name="stictionUp">       0            0         </param>       
         <param name="stictionDwn">      0            0         </param>   

--- a/app/robots/iCubHeidelberg01/hardware/motorControl/left_upper_leg-ems6-mc.xml
+++ b/app/robots/iCubHeidelberg01/hardware/motorControl/left_upper_leg-ems6-mc.xml
@@ -20,14 +20,14 @@
     
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">              -1500        1500      -1000       1280 </param>       
-        <param name="kd">                  0           0          0          0 </param>       
-        <param name="ki">             -15000       20000     -10000      15000 </param>       
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">           -1066.66     1066.66    -711.11    1066.66 </param>       
+        <param name="kd">               0.00        0.00       0.00       0.00 </param>       
+        <param name="ki">          -10666.64    14222.18   -7111.09   10666.64 </param>       
         <param name="limPwm">           2500        2500       2500       2500 </param>       
         <param name="maxPwm">           8000        8000       8000       8000 </param>       
         <param name="maxInt">           1500        1500        750       1000 </param>       
-        <param name="shift">               8           8          8          8 </param>       
+        <param name="shift">               0           0          0          0 </param>       
         <param name="ko">                  0           0          0          0 </param>       
         <param name="stictionUp">          0           0          0          0 </param>       
         <param name="stictionDwn">         0           0          0          0 </param>     

--- a/app/robots/iCubHeidelberg01/hardware/motorControl/right_lower_leg-ems9-mc.xml
+++ b/app/robots/iCubHeidelberg01/hardware/motorControl/right_lower_leg-ems9-mc.xml
@@ -15,14 +15,14 @@
 	
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">           -1000        -1000         </param>       
-        <param name="kd">               0            0         </param>       
-        <param name="ki">          -10000       -10000         </param>       
+        <param name="controlUnits">  metric_units              </param> 
+        <param name="kp">         -711.11      -711.11         </param>       
+        <param name="kd">            0.00         0.00         </param>       
+        <param name="ki">        -7111.09     -7111.09         </param>       
         <param name="limPwm">        2500         2500         </param>       
         <param name="maxPwm">        8000         8000         </param>      
         <param name="maxInt">         750          750         </param>       
-        <param name="shift">            8            8         </param>       
+        <param name="shift">            0            0         </param>       
         <param name="ko">               0            0         </param>       
         <param name="stictionUp">       0            0         </param>       
         <param name="stictionDwn">      0            0         </param>      

--- a/app/robots/iCubHeidelberg01/hardware/motorControl/right_upper_leg-ems8-mc.xml
+++ b/app/robots/iCubHeidelberg01/hardware/motorControl/right_upper_leg-ems8-mc.xml
@@ -20,14 +20,14 @@
     
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">               1500       -1500       1000      -1280 </param>       
-        <param name="kd">                  0           0          0          0 </param>       
-        <param name="ki">              15000      -20000      10000     -15000 </param>       
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">            1066.66    -1066.66     711.11   -1066.66 </param>       
+        <param name="kd">               0.00        0.00       0.00       0.00 </param>       
+        <param name="ki">           10666.64   -14222.18    7111.09  -10666.64 </param>       
         <param name="limPwm">           2500        2500       2500       2500 </param>      
         <param name="maxPwm">           8000        8000       8000       8000 </param>          
         <param name="maxInt">           1500        1500        750       1000 </param>       
-        <param name="shift">               8           8          8          8 </param>       
+        <param name="shift">               0           0          0          0 </param>       
         <param name="ko">                  0           0          0          0 </param>       
         <param name="stictionUp">          0           0          0          0 </param>       
         <param name="stictionDwn">         0           0          0          0 </param>      

--- a/app/robots/iCubHeidelberg01/hardware/motorControl/torso-ems5-mc.xml
+++ b/app/robots/iCubHeidelberg01/hardware/motorControl/torso-ems5-mc.xml
@@ -20,18 +20,18 @@
     
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">              1000   -1500   -1500 </param>       
-        <param name="kd">                 0       0       0 </param>       
-        <param name="ki">             10000  -15000  -20000 </param>       
-        <param name="limPwm">          4000    4000    8000 </param>       
-        <param name="maxPwm">          8000    8000   16000 </param>  
-        <param name="maxInt">           750    1000    2000 </param>       
-        <param name="shift">              8       8       8 </param>       
-        <param name="ko">                 0       0       0 </param>       
-        <param name="stictionUp">         0       0       0 </param>       
-        <param name="stictionDwn">        0       0       0 </param>       
-        <param name="kff">                0       0       0 </param>       
+        <param name="controlUnits">  metric_units           </param> 
+        <param name="kp">            711.11    -1066.66    -1066.66 </param>       
+        <param name="kd">              0.00        0.00        0.00 </param>       
+        <param name="ki">           7111.09   -10666.64   -14222.18 </param>       
+        <param name="limPwm">          4000        4000        8000 </param>       
+        <param name="maxPwm">          8000        8000       16000 </param>  
+        <param name="maxInt">           750        1000        2000 </param>       
+        <param name="shift">              0           0           0 </param>       
+        <param name="ko">                 0           0           0 </param>       
+        <param name="stictionUp">         0           0           0 </param>       
+        <param name="stictionDwn">        0           0           0 </param>       
+        <param name="kff">                0           0           0 </param>       
     </group>
 	
 	<group name="TORQUE_CONTROL">

--- a/app/robots/iCubSheffield01/hardware/motorControl/left_upper_arm-ems1-mc.xml
+++ b/app/robots/iCubSheffield01/hardware/motorControl/left_upper_arm-ems1-mc.xml
@@ -22,14 +22,14 @@
 
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">             1000       1500       1000       1500 </param>       
-        <param name="kd">                0          0          0          0 </param>       
-        <param name="ki">            10000      15000      10000      15000 </param>       
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">           711.11    1066.66     711.11    1066.66 </param>       
+        <param name="kd">             0.00       0.00       0.00       0.00 </param>       
+        <param name="ki">          7111.09   10666.64    7111.09   10666.64 </param>       
         <param name="limPwm">         3000       3000       3000       3000 </param>       
         <param name="maxPwm">         8000       8000       8000       8000 </param>    
         <param name="maxInt">          200        200        200       1000 </param>       
-        <param name="shift">             8          8          8          8 </param>       
+        <param name="shift">             0          0          0          0 </param>       
         <param name="ko">                0          0          0          0 </param>       
         <param name="stictionUp">        0          0          0          0 </param>       
         <param name="stictionDwn">       0          0          0          0 </param>       

--- a/app/robots/iCubSheffield01/hardware/motorControl/right_upper_arm-ems3-mc.xml
+++ b/app/robots/iCubSheffield01/hardware/motorControl/right_upper_arm-ems3-mc.xml
@@ -22,14 +22,14 @@
 
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1 </param> 
-        <param name="controlUnits">  machine_units               </param> 
-        <param name="kp">           -1000       -1500       -1000     -1500 </param>       
-        <param name="kd">                0          0          0          0 </param>       
-        <param name="ki">           -10000     -15000     -10000     -15000 </param>       
+        <param name="controlUnits">  metric_units               </param> 
+        <param name="kp">          -711.11   -1066.66    -711.11   -1066.66 </param>       
+        <param name="kd">             0.00       0.00       0.00       0.00 </param>       
+        <param name="ki">         -7111.09  -10666.64   -7111.09  -10666.64 </param>       
         <param name="limPwm">         3000       3000       3000       3000 </param>      
         <param name="maxPwm">         8000       8000       8000       8000 </param>              
         <param name="maxInt">          200        200        200       1000 </param>       
-        <param name="shift">             8          8          8          8 </param>       
+        <param name="shift">             0          0          0          0 </param>       
         <param name="ko">                0          0          0          0 </param>       
         <param name="stictionUp">        0          0          0          0 </param>       
         <param name="stictionDwn">       0          0          0          0 </param>       

--- a/app/robots/iCubSheffield01/hardware/motorControl/torso-ems5-mc.xml
+++ b/app/robots/iCubSheffield01/hardware/motorControl/torso-ems5-mc.xml
@@ -17,18 +17,18 @@
 
 	<group name="POSITION_CONTROL">
 	    <param name="controlLaw">    joint_pid_v1             </param> 
-        <param name="controlUnits">  machine_units            </param> 
-        <param name="kp">              2000   -1500    -1500  </param>       
-        <param name="kd">                 0       0       0   </param>       
-        <param name="ki">             10000   -15000   -20000 </param>       
-        <param name="limPwm">          4000    4000    4000 </param>       
-        <param name="maxPwm">          8000    8000    8000 </param>  
-        <param name="maxInt">           200    1000    2000 </param>       
-        <param name="shift">              8       8       8 </param>       
-        <param name="ko">                 0       0       0 </param>       
-        <param name="stictionUp">         0       0       0 </param>       
-        <param name="stictionDwn">        0       0       0 </param>       
-        <param name="kff">                0       0       0 </param>       
+        <param name="controlUnits">  metric_units             </param> 
+        <param name="kp">           1422.21   -1066.66  -1066.66 </param>       
+        <param name="kd">              0.00       0.00      0.00 </param>       
+        <param name="ki">           7111.09  -10666.64 -14222.18 </param>       
+        <param name="limPwm">          4000       4000      4000 </param>       
+        <param name="maxPwm">          8000       8000      8000 </param>  
+        <param name="maxInt">           200       1000      2000 </param>       
+        <param name="shift">              0          0         0 </param>       
+        <param name="ko">                 0          0         0 </param>       
+        <param name="stictionUp">         0          0         0 </param>       
+        <param name="stictionDwn">        0          0         0 </param>       
+        <param name="kff">                0          0         0 </param>       
     </group>
 
     <group name="IMPEDANCE">


### PR DESCRIPTION
affected robots:
iCubGenova02
iCubGenova04
iCubDarmstadt01
iCubSheffield01
iCubHeidelberg01