### PR TITLE
Do not copy yarprun / yarpserver in /tmp

### DIFF
--- a/app/iCubCluster/scripts/icub-cluster-run.sh
+++ b/app/iCubCluster/scripts/icub-cluster-run.sh
@@ -38,32 +38,30 @@ case "$1" in
 			xhost +
 			echo "Display set to: $DISPLAY"
 		fi
-		
+
         if [ "k$2" == "klog" ];
         then
             echo "enabling logger on $ID"
             log=1
         fi
 
-		if [ "k$4" == "klog" ];
+	if [ "k$4" == "klog" ];
         then
             echo "enabling logger on $ID"
             log=1
         fi
 
-        
-		echo "Starting up yarp run for $ID"
-		cp -f $YARP_DIR/bin/yarprun /tmp/yarprun
+
+	echo "Starting up yarp run for $ID"
         if [ "$log" == 1 ]
-        then        
-            cd /tmp;./yarprun --server $ID --log 2>&1 2>/tmp/yarprunserver.log &
+        then
+                yarprun --server $ID --log 2>&1 2>/tmp/yarprunserver.log &
         else
-		    cd /tmp;./yarprun --server $ID 2>&1 2>/tmp/yarprunserver.log &
+		yarprun --server $ID 2>&1 2>/tmp/yarprunserver.log &
         fi
 		echo \"`date` starting yarprun\" >> /tmp/yarprun.log
 		echo "done!"
 		;;
-	
 	kill)
 		echo "Killing yarprun for $ID"
 		killall -9 yarprun

--- a/app/iCubCluster/scripts/icub-cluster-server.sh
+++ b/app/iCubCluster/scripts/icub-cluster-server.sh
@@ -14,17 +14,15 @@ fi
 
 case "$1" in
 	start)
-		case "$2" in 
-			yarpserver) 
+		case "$2" in
+			yarpserver)
 				echo "Starting up yarp server"
-				cp -f $YARP_DIR/bin/yarpserver /tmp/yarpserver
-				/tmp/yarpserver >/dev/null 2>&1 &
+				yarpserver >/dev/null 2>&1 &
 				echo "done!"
 				;;
 			*) #yarpserver3 is the default
 				echo "Starting up yarp server"
-				cp -f $YARP_DIR/bin/yarpserver3 /tmp/yarpserver3
-				/tmp/yarpserver3 --portdb /tmp/ports.db --subdb /tmp/subs.db >/dev/null 2>&1 &
+				yarpserver3 --portdb /tmp/ports.db --subdb /tmp/subs.db >/dev/null 2>&1 &
 				echo "done!"
 				;;
 		esac


### PR DESCRIPTION
 Fix for https://github.com/robotology/icub-main/issues/154

Works fine on our setup, and has the advantage that `LD_LIBRARY_PATH` does not need to be set, if `INSTALL_WITH_RPATH` is used.

Best, Tobias