### PR TITLE
[iCubLisboa01]: fix robotInterface warnings

### DIFF
--- a/app/robots/iCubLisboa01/calibrators/head_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/head_calib.xml
@@ -1,5 +1,6 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
     <device name="head_calibrator" type="parametricCalibrator">        
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/calibrators/head_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/head_calib.xml
@@ -1,7 +1,7 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
 <!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>      
+<devices robot="iCubLisboa01" build="1">      
     <device name="head_calibrator" type="parametricCalibrator">        
 <params file="general.xml" />              
         <group name="GENERAL">             

--- a/app/robots/iCubLisboa01/calibrators/left_arm_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/left_arm_calib.xml
@@ -1,7 +1,7 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
 <!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>      
+<devices robot="iCubLisboa01" build="1">      
     <device name="left_arm_calibrator" type="parametricCalibrator">    
 <params file="general.xml" />              
         <group name="GENERAL">             

--- a/app/robots/iCubLisboa01/calibrators/left_arm_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/left_arm_calib.xml
@@ -1,5 +1,6 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
     <device name="left_arm_calibrator" type="parametricCalibrator">    
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/calibrators/left_hand_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/left_hand_calib.xml
@@ -1,5 +1,6 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
     <device name="left_hand_calibrator" type="parametricCalibrator">   
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/calibrators/left_hand_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/left_hand_calib.xml
@@ -1,7 +1,7 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
 <!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>      
+<devices robot="iCubLisboa01" build="1">      
     <device name="left_hand_calibrator" type="parametricCalibrator">   
 <params file="general.xml" />              
         <group name="GENERAL">             

--- a/app/robots/iCubLisboa01/calibrators/left_leg_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/left_leg_calib.xml
@@ -1,5 +1,6 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
     <device name="left_leg_calibrator" type="parametricCalibrator">    
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/calibrators/left_leg_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/left_leg_calib.xml
@@ -1,7 +1,7 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
 <!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>      
+<devices robot="iCubLisboa01" build="1">      
     <device name="left_leg_calibrator" type="parametricCalibrator">    
 <params file="general.xml" />              
         <group name="GENERAL">             

--- a/app/robots/iCubLisboa01/calibrators/right_arm_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/right_arm_calib.xml
@@ -1,5 +1,6 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
     <device name="right_arm_calibrator" type="parametricCalibrator">   
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/calibrators/right_arm_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/right_arm_calib.xml
@@ -1,7 +1,7 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
 <!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>      
+<devices robot="iCubLisboa01" build="1">      
     <device name="right_arm_calibrator" type="parametricCalibrator">   
 <params file="general.xml" />              
         <group name="GENERAL">             

--- a/app/robots/iCubLisboa01/calibrators/right_hand_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/right_hand_calib.xml
@@ -1,5 +1,6 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
     <device name="right_hand_calibrator" type="parametricCalibrator">  
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/calibrators/right_hand_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/right_hand_calib.xml
@@ -1,7 +1,7 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
 <!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>      
+<devices robot="iCubLisboa01" build="1">      
     <device name="right_hand_calibrator" type="parametricCalibrator">  
 <params file="general.xml" />              
         <group name="GENERAL">             

--- a/app/robots/iCubLisboa01/calibrators/right_leg_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/right_leg_calib.xml
@@ -1,5 +1,6 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
     <device name="right_leg_calibrator" type="parametricCalibrator">   
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/calibrators/right_leg_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/right_leg_calib.xml
@@ -1,7 +1,7 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
 <!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>      
+<devices robot="iCubLisboa01" build="1">      
     <device name="right_leg_calibrator" type="parametricCalibrator">   
 <params file="general.xml" />              
         <group name="GENERAL">             

--- a/app/robots/iCubLisboa01/calibrators/torso_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/torso_calib.xml
@@ -1,7 +1,7 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
 <!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>      
+<devices robot="iCubLisboa01" build="1">      
     <device name="torso_calibrator" type="parametricCalibrator">       
 <params file="general.xml" />              
         <group name="GENERAL">             

--- a/app/robots/iCubLisboa01/calibrators/torso_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/torso_calib.xml
@@ -1,5 +1,6 @@
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
     <device name="torso_calibrator" type="parametricCalibrator">       
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/cartesian/left_arm_cartesian.xml
+++ b/app/robots/iCubLisboa01/cartesian/left_arm_cartesian.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
     <device name="left_arm_cartesian" type="cartesiancontrollerserver">
         <group name="GENERAL">

--- a/app/robots/iCubLisboa01/cartesian/left_arm_cartesian.xml
+++ b/app/robots/iCubLisboa01/cartesian/left_arm_cartesian.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
     <device name="left_arm_cartesian" type="cartesiancontrollerserver">
         <group name="GENERAL">
             <param name="ControllerName">icub/cartesianController/left_arm</param>

--- a/app/robots/iCubLisboa01/cartesian/right_arm_cartesian.xml
+++ b/app/robots/iCubLisboa01/cartesian/right_arm_cartesian.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
     <device name="right_arm_cartesian" type="cartesiancontrollerserver">
         <group name="GENERAL">

--- a/app/robots/iCubLisboa01/cartesian/right_arm_cartesian.xml
+++ b/app/robots/iCubLisboa01/cartesian/right_arm_cartesian.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
     <device name="right_arm_cartesian" type="cartesiancontrollerserver">
         <group name="GENERAL">
             <param name="ControllerName">icub/cartesianController/right_arm</param>

--- a/app/robots/iCubLisboa01/hardware/FT/left_arm_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/FT/left_arm_strain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 <device type="canBusAnalogSensor" name="left_arm_strain">
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/app/robots/iCubLisboa01/hardware/FT/left_arm_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/FT/left_arm_strain.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 <device type="canBusAnalogSensor" name="left_arm_strain">
 	<param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/hardware/FT/left_foot_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/FT/left_foot_strain.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 <device type="canBusAnalogSensor" name="left_foot_strain">
 	<param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/hardware/FT/left_foot_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/FT/left_foot_strain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 <device type="canBusAnalogSensor" name="left_foot_strain">
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/app/robots/iCubLisboa01/hardware/FT/left_leg_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/FT/left_leg_strain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 <device type="canBusAnalogSensor" name="left_leg_strain">
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/app/robots/iCubLisboa01/hardware/FT/left_leg_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/FT/left_leg_strain.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 <device type="canBusAnalogSensor" name="left_leg_strain">
 	<param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/hardware/FT/right_arm_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/FT/right_arm_strain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 <device type="canBusAnalogSensor" name="right_arm_strain">
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/app/robots/iCubLisboa01/hardware/FT/right_arm_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/FT/right_arm_strain.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 <device type="canBusAnalogSensor" name="right_arm_strain">
 	<param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/hardware/FT/right_foot_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/FT/right_foot_strain.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 <device type="canBusAnalogSensor" name="right_foot_strain">
 	<param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/hardware/FT/right_foot_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/FT/right_foot_strain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 <device type="canBusAnalogSensor" name="right_foot_strain">
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/app/robots/iCubLisboa01/hardware/FT/right_leg_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/FT/right_leg_strain.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 <device type="canBusAnalogSensor" name="right_leg_strain">
 	<param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/hardware/FT/right_leg_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/FT/right_leg_strain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 <device type="canBusAnalogSensor" name="right_leg_strain">
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/app/robots/iCubLisboa01/hardware/MAIS/left_hand_mais.xml
+++ b/app/robots/iCubLisboa01/hardware/MAIS/left_hand_mais.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 <device type="canBusAnalogSensor" name="left_hand_mais">
 	<param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/hardware/MAIS/left_hand_mais.xml
+++ b/app/robots/iCubLisboa01/hardware/MAIS/left_hand_mais.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 <device type="canBusAnalogSensor" name="left_hand_mais">
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/app/robots/iCubLisboa01/hardware/MAIS/right_hand_mais.xml
+++ b/app/robots/iCubLisboa01/hardware/MAIS/right_hand_mais.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 <device type="canBusAnalogSensor" name="right_hand_mais">
 	<param name="canbusDevice"> "sharedcan" </param>
 	<param name="physDevice"> "cfw2can" </param>

--- a/app/robots/iCubLisboa01/hardware/MAIS/right_hand_mais.xml
+++ b/app/robots/iCubLisboa01/hardware/MAIS/right_hand_mais.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 <device type="canBusAnalogSensor" name="right_hand_mais">
 	<param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/hardware/VFT/left_arm_virtual_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/VFT/left_arm_virtual_strain.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device type="canBusVirtualAnalogSensor" name="left_arm_virtual_strain">
 		<param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/hardware/VFT/left_leg_virtual_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/VFT/left_leg_virtual_strain.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device type="canBusVirtualAnalogSensor" name="left_leg_virtual_strain">
 		<param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/hardware/VFT/right_arm_virtual_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/VFT/right_arm_virtual_strain.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device type="canBusVirtualAnalogSensor" name="right_arm_virtual_strain">
 		<param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/hardware/VFT/right_leg_virtual_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/VFT/right_leg_virtual_strain.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device type="canBusVirtualAnalogSensor" name="right_leg_virtual_strain">
 		<param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/hardware/VFT/torso_virtual_strain.xml
+++ b/app/robots/iCubLisboa01/hardware/VFT/torso_virtual_strain.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device type="canBusVirtualAnalogSensor" name="torso_virtual_strain">
 		<param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/hardware/inertial.xml
+++ b/app/robots/iCubLisboa01/hardware/inertial.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
   <device name="inertial" type="inertial">
       <param name="name">  /icub/inertial  </param>
       <param name="subdevice">  xsensmtx  </param>

--- a/app/robots/iCubLisboa01/hardware/inertial.xml
+++ b/app/robots/iCubLisboa01/hardware/inertial.xml
@@ -1,3 +1,4 @@
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
   <device name="inertial" type="inertial">
       <param name="name">  /icub/inertial  </param>

--- a/app/robots/iCubLisboa01/hardware/motorControl/icub_head.xml
+++ b/app/robots/iCubLisboa01/hardware/motorControl/icub_head.xml
@@ -1,6 +1,7 @@
  
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
   <device name="head_mc" type="canmotioncontrol">        
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/hardware/motorControl/icub_left_arm.xml
+++ b/app/robots/iCubLisboa01/hardware/motorControl/icub_left_arm.xml
@@ -1,6 +1,7 @@
  
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
   <device name="left_arm_mc" type="canmotioncontrol">    
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/hardware/motorControl/icub_left_hand.xml
+++ b/app/robots/iCubLisboa01/hardware/motorControl/icub_left_hand.xml
@@ -1,6 +1,7 @@
  
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
   <device name="left_hand_mc" type="canmotioncontrol">   
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/hardware/motorControl/icub_left_leg.xml
+++ b/app/robots/iCubLisboa01/hardware/motorControl/icub_left_leg.xml
@@ -1,6 +1,7 @@
  
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
   <device name="left_leg_mc" type="canmotioncontrol">    
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/hardware/motorControl/icub_right_arm.xml
+++ b/app/robots/iCubLisboa01/hardware/motorControl/icub_right_arm.xml
@@ -1,6 +1,7 @@
  
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
   <device name="right_arm_mc" type="canmotioncontrol">   
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/hardware/motorControl/icub_right_hand.xml
+++ b/app/robots/iCubLisboa01/hardware/motorControl/icub_right_hand.xml
@@ -1,6 +1,7 @@
  
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
   <device name="right_hand_mc" type="canmotioncontrol">  
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/hardware/motorControl/icub_right_leg.xml
+++ b/app/robots/iCubLisboa01/hardware/motorControl/icub_right_leg.xml
@@ -1,6 +1,7 @@
  
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
   <device name="right_leg_mc" type="canmotioncontrol">   
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/hardware/motorControl/icub_torso.xml
+++ b/app/robots/iCubLisboa01/hardware/motorControl/icub_torso.xml
@@ -1,6 +1,7 @@
  
  
 <?xml version="1.0" encoding="UTF-8" ?>    
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>      
   <device name="torso_mc" type="canmotioncontrol">       
 <params file="general.xml" />              

--- a/app/robots/iCubLisboa01/hardware/skin/left_hand_inertial_mtb.xml
+++ b/app/robots/iCubLisboa01/hardware/skin/left_hand_inertial_mtb.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 <device type="canBusInertialMTB" name="left_hand_inertial_mtb">
 	<param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/hardware/skin/right_hand_inertial_mtb.xml
+++ b/app/robots/iCubLisboa01/hardware/skin/right_hand_inertial_mtb.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 <device type="canBusInertialMTB" name="right_hand_inertial_mtb">
     <param name="canbusDevice"> "sharedcan" </param>

--- a/app/robots/iCubLisboa01/icub_all.xml
+++ b/app/robots/iCubLisboa01/icub_all.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<robot name="icub">
+<robot name="iCubLisboa01" build="1" portprefix="icub">
 
     <!-- cartesian --> 
     <devices file="cartesian/left_arm_cartesian.xml" />

--- a/app/robots/iCubLisboa01/icub_all.xml
+++ b/app/robots/iCubLisboa01/icub_all.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <robot name="icub">
 
     <!-- cartesian --> 

--- a/app/robots/iCubLisboa01/wrappers/FT/left_arm_FT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/FT/left_arm_FT_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device name="left_arm_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>

--- a/app/robots/iCubLisboa01/wrappers/FT/left_arm_FT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/FT/left_arm_FT_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 	<device name="left_arm_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>
 		<param name="deviceId">     left_arm				</param>

--- a/app/robots/iCubLisboa01/wrappers/FT/left_foot_FT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/FT/left_foot_FT_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 	<device name="left_foot_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>
 		<param name="deviceId">     left_foot			</param>

--- a/app/robots/iCubLisboa01/wrappers/FT/left_foot_FT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/FT/left_foot_FT_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device name="left_foot_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>

--- a/app/robots/iCubLisboa01/wrappers/FT/left_leg_FT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/FT/left_leg_FT_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device name="left_leg_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>

--- a/app/robots/iCubLisboa01/wrappers/FT/left_leg_FT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/FT/left_leg_FT_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 	<device name="left_leg_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>
 		<param name="deviceId">     left_leg				</param>

--- a/app/robots/iCubLisboa01/wrappers/FT/right_arm_FT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/FT/right_arm_FT_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device name="right_arm_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>

--- a/app/robots/iCubLisboa01/wrappers/FT/right_arm_FT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/FT/right_arm_FT_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 	<device name="right_arm_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>
 		<param name="deviceId">     right_arm				</param>

--- a/app/robots/iCubLisboa01/wrappers/FT/right_foot_FT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/FT/right_foot_FT_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 	<device name="right_foot_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>
 		<param name="deviceId">     right_foot				</param>

--- a/app/robots/iCubLisboa01/wrappers/FT/right_foot_FT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/FT/right_foot_FT_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device name="right_foot_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>

--- a/app/robots/iCubLisboa01/wrappers/FT/right_leg_FT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/FT/right_leg_FT_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 	<device name="right_leg_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>
 		<param name="deviceId">     right_leg				</param>

--- a/app/robots/iCubLisboa01/wrappers/FT/right_leg_FT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/FT/right_leg_FT_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device name="right_leg_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>

--- a/app/robots/iCubLisboa01/wrappers/MAIS/left_hand_mais_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/MAIS/left_hand_mais_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device name="left_hand_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>

--- a/app/robots/iCubLisboa01/wrappers/MAIS/left_hand_mais_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/MAIS/left_hand_mais_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 	<device name="left_hand_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>
 		<param name="deviceId">     left_hand				</param>

--- a/app/robots/iCubLisboa01/wrappers/MAIS/right_hand_mais_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/MAIS/right_hand_mais_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
 	<device name="right_hand_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>
 		<param name="deviceId">     right_hand				</param>

--- a/app/robots/iCubLisboa01/wrappers/MAIS/right_hand_mais_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/MAIS/right_hand_mais_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device name="right_hand_as_wrapper" type="analogServer">
 		<param name="period">       10  				</param>

--- a/app/robots/iCubLisboa01/wrappers/VFT/left_arm_VFT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/VFT/left_arm_VFT_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
     <device name="left_arm_VFTserver" type="virtualAnalogServer">
         <param name="period">       10                  </param>

--- a/app/robots/iCubLisboa01/wrappers/VFT/left_arm_VFT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/VFT/left_arm_VFT_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
     <device name="left_arm_VFTserver" type="virtualAnalogServer">
         <param name="period">       10                  </param>
         <param name="deviceId">     left_arm                </param>

--- a/app/robots/iCubLisboa01/wrappers/VFT/left_leg_VFT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/VFT/left_leg_VFT_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
     <device name="left_leg_VFTserver" type="virtualAnalogServer">
         <param name="period">       10                  </param>
         <param name="deviceId">     left_leg                </param>

--- a/app/robots/iCubLisboa01/wrappers/VFT/left_leg_VFT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/VFT/left_leg_VFT_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
     <device name="left_leg_VFTserver" type="virtualAnalogServer">
         <param name="period">       10                  </param>

--- a/app/robots/iCubLisboa01/wrappers/VFT/right_arm_VFT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/VFT/right_arm_VFT_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
     <device name="right_arm_VFTserver" type="virtualAnalogServer">
         <param name="period">       10                  </param>
         <param name="deviceId">     right_arm                </param>

--- a/app/robots/iCubLisboa01/wrappers/VFT/right_arm_VFT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/VFT/right_arm_VFT_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
     <device name="right_arm_VFTserver" type="virtualAnalogServer">
         <param name="period">       10                  </param>

--- a/app/robots/iCubLisboa01/wrappers/VFT/right_leg_VFT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/VFT/right_leg_VFT_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
     <device name="right_leg_VFTserver" type="virtualAnalogServer">
         <param name="period">       10                  </param>

--- a/app/robots/iCubLisboa01/wrappers/VFT/right_leg_VFT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/VFT/right_leg_VFT_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
     <device name="right_leg_VFTserver" type="virtualAnalogServer">
         <param name="period">       10                  </param>
         <param name="deviceId">     right_leg                </param>

--- a/app/robots/iCubLisboa01/wrappers/VFT/torso_VFT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/VFT/torso_VFT_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
     <device name="torso_VFTserver" type="virtualAnalogServer">
         <param name="period">       10                  </param>

--- a/app/robots/iCubLisboa01/wrappers/VFT/torso_VFT_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/VFT/torso_VFT_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
     <device name="torso_VFTserver" type="virtualAnalogServer">
         <param name="period">       10                  </param>
         <param name="deviceId">     torso                </param>

--- a/app/robots/iCubLisboa01/wrappers/motorControl/head_mc_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/motorControl/head_mc_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
   <device name="head_mc_wrapper" type="controlboardwrapper2">
       <paramlist name="networks">
       <elem name="head_joints">  0 5 0 5 </elem>

--- a/app/robots/iCubLisboa01/wrappers/motorControl/head_mc_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/motorControl/head_mc_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
   <device name="head_mc_wrapper" type="controlboardwrapper2">
       <paramlist name="networks">

--- a/app/robots/iCubLisboa01/wrappers/motorControl/left_arm_mc_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/motorControl/left_arm_mc_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
   <device name="left_arm_mc_wrapper" type="controlboardwrapper2">
     <paramlist name="networks">

--- a/app/robots/iCubLisboa01/wrappers/motorControl/left_arm_mc_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/motorControl/left_arm_mc_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
   <device name="left_arm_mc_wrapper" type="controlboardwrapper2">
     <paramlist name="networks">
 	  <elem name="left_arm_joints">  0  7  0  7 </elem>

--- a/app/robots/iCubLisboa01/wrappers/motorControl/left_leg_mc_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/motorControl/left_leg_mc_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
   <device name="left_leg_mc_wrapper" type="controlboardwrapper2">
       <paramlist name="networks">

--- a/app/robots/iCubLisboa01/wrappers/motorControl/left_leg_mc_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/motorControl/left_leg_mc_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
   <device name="left_leg_mc_wrapper" type="controlboardwrapper2">
       <paramlist name="networks">
          <elem name="left_leg_joints">  0  5  0  5 </elem>

--- a/app/robots/iCubLisboa01/wrappers/motorControl/right_arm_mc_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/motorControl/right_arm_mc_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
   <device name="right_arm_mc_wrapper" type="controlboardwrapper2">
       <paramlist name="networks">
 	  <elem name="right_arm_joints">  0  7  0  7 </elem>

--- a/app/robots/iCubLisboa01/wrappers/motorControl/right_arm_mc_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/motorControl/right_arm_mc_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
   <device name="right_arm_mc_wrapper" type="controlboardwrapper2">
       <paramlist name="networks">

--- a/app/robots/iCubLisboa01/wrappers/motorControl/right_leg_mc_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/motorControl/right_leg_mc_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
   <device name="right_leg_mc_wrapper" type="controlboardwrapper2">
       <paramlist name="networks">
          <elem name="right_joints">  0  5  0  5 </elem>

--- a/app/robots/iCubLisboa01/wrappers/motorControl/right_leg_mc_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/motorControl/right_leg_mc_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
   <device name="right_leg_mc_wrapper" type="controlboardwrapper2">
       <paramlist name="networks">

--- a/app/robots/iCubLisboa01/wrappers/motorControl/torso_mc_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/motorControl/torso_mc_wrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
-<devices>
+<devices robot="iCubLisboa01" build="1">
   <device name="torso_mc_wrapper" type="controlboardwrapper2">
       <paramlist name="networks">
       <elem name="torso_joints">  0 2 0 2 </elem>

--- a/app/robots/iCubLisboa01/wrappers/motorControl/torso_mc_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/motorControl/torso_mc_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
   <device name="torso_mc_wrapper" type="controlboardwrapper2">
       <paramlist name="networks">

--- a/app/robots/iCubLisboa01/wrappers/skin/left_arm_skin_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/skin/left_arm_skin_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <!-- La skin ha bisogno delle info presenti nella parte eln e di info per il suo wrapper, qui sotto -->
 <devices>
 	<device name="left_arm_skin_wrapper" type="skinWrapper">

--- a/app/robots/iCubLisboa01/wrappers/skin/left_hand_inertial_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/skin/left_hand_inertial_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device name="left_hand_mtb_wrapper" type="analogServer">
 		<param name="period">       10  				</param>

--- a/app/robots/iCubLisboa01/wrappers/skin/right_arm_skin_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/skin/right_arm_skin_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <!-- La skin ha bisogno delle info presenti nella parte eln e di info per il suo wrapper, qui sotto -->
 <devices>
 	<device name="right_arm_skin_wrapper" type="skinWrapper">

--- a/app/robots/iCubLisboa01/wrappers/skin/right_hand_inertial_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/skin/right_hand_inertial_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <devices>
 	<device name="right_arm_mtb_wrapper" type="analogServer">
 		<param name="period">       10  				</param>

--- a/app/robots/iCubLisboa01/wrappers/skin/torso_skin_wrapper.xml
+++ b/app/robots/iCubLisboa01/wrappers/skin/torso_skin_wrapper.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
 <!-- La skin ha bisogno delle info presenti nella parte eln e di info per il suo wrapper, qui sotto -->
 <devices>
 	<device name="torso_skin_wrapper" type="skinWrapper">


### PR DESCRIPTION
This fixes the DTD warnings reported in https://github.com/robotology/icub-support/issues/43 item 3.