### PR TITLE
[cmake][msvc] (optional) support for producing shared libraries (dll)

### DIFF
--- a/conf/iCubOptions.cmake
+++ b/conf/iCubOptions.cmake
@@ -90,7 +90,10 @@ icub_install_with_rpath() #from icubHelpers
 # Shared library option (hide on windows for now)
 
 # The CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS was added in CMake 3.4
-if(NOT MSVC OR CMAKE_VERSION VERSION_GREATER "3.3.5")
+if(NOT ${CMAKE_MINIMUM_REQUIRED_VERSION} VERSION_LESS 3.4)
+  message(AUTHOR_WARNING "CMAKE_MINIMUM_REQUIRED_VERSION is now ${CMAKE_MINIMUM_REQUIRED_VERSION}. This check can be removed.")
+endif()
+if(NOT MSVC OR NOT CMAKE_VERSION VERSION_LESS 3.4)
     option(ICUB_SHARED_LIBRARY "Compile shared libraries rather than static libraries" FALSE)
     if(ICUB_SHARED_LIBRARY)
         set(BUILD_SHARED_LIBS ON)

--- a/conf/iCubOptions.cmake
+++ b/conf/iCubOptions.cmake
@@ -89,10 +89,14 @@ icub_install_with_rpath() #from icubHelpers
 #########################################################################
 # Shared library option (hide on windows for now)
 
-if(NOT MSVC)
+# The CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS was added in CMake 3.4
+if(NOT MSVC OR CMAKE_VERSION VERSION_GREATER "3.3.5")
     option(ICUB_SHARED_LIBRARY "Compile shared libraries rather than static libraries" FALSE)
     if(ICUB_SHARED_LIBRARY)
         set(BUILD_SHARED_LIBS ON)
+        if(MSVC)
+            set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
Add support for compiling the libraries in icub-main as shared libraries, using the new feature of cmake 3.4 `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` .

See http://www.kitware.com/blog/home/post/939 for more info on this feature.

This enables the `ICUB_SHARED_LIBRARY` option on Windows with CMake >= 3.4 , but  its default value remains OFF. 