### PR TITLE
fixed bug on Skin ports issue #235

### DIFF
--- a/src/libraries/icubmod/analogServer/analogServer.cpp
+++ b/src/libraries/icubmod/analogServer/analogServer.cpp
@@ -181,6 +181,7 @@ AnalogServer::AnalogServer(): RateThread(0)
 AnalogServer::~AnalogServer()
 {
     yTrace();
+    close();
     _rate = 0;
     analogSensor_p = NULL;
 }
@@ -414,7 +415,6 @@ void AnalogServer::threadRelease()
     {
         analogPorts[i].port.close();
     }
-    close();
 }
 
 void AnalogServer::run()

--- a/src/libraries/icubmod/analogServer/analogServer.cpp
+++ b/src/libraries/icubmod/analogServer/analogServer.cpp
@@ -181,7 +181,6 @@ AnalogServer::AnalogServer(): RateThread(0)
 AnalogServer::~AnalogServer()
 {
     yTrace();
-    threadRelease();
     _rate = 0;
     analogSensor_p = NULL;
 }
@@ -415,6 +414,7 @@ void AnalogServer::threadRelease()
     {
         analogPorts[i].port.close();
     }
+    close();
 }
 
 void AnalogServer::run()

--- a/src/libraries/icubmod/skinWrapper/skinWrapper.cpp
+++ b/src/libraries/icubmod/skinWrapper/skinWrapper.cpp
@@ -163,6 +163,7 @@ bool skinWrapper::close()
 {
     if (NULL != analogServer)
     {
+	analogServer->close();
         delete analogServer;
     }
     if (NULL != analog)


### PR DESCRIPTION
Introduced changes:
- closing skin ports that were remaining open : close function is now called inside threadRelease function
- threadRelease is  now called  only by RateThread, whereas before it was called twice
