### PR TITLE
candiscovery diagnostics

### DIFF
--- a/src/libraries/icubmod/embObjLib/usrcbk/embObjLib_mngmnt_callback.c
+++ b/src/libraries/icubmod/embObjLib/usrcbk/embObjLib_mngmnt_callback.c
@@ -401,7 +401,7 @@ const char * eoboard_get_name(eObrd_cantype_t type)
     static const char *none = "NONE";
 
 
-    if(type <= eobrd_cantype_mais)
+    if(type <= eobrd_cantype_1foc)
     {
         return(names[type]);
     }

--- a/src/libraries/icubmod/embObjLib/usrcbk/embObjLib_mngmnt_callback.c
+++ b/src/libraries/icubmod/embObjLib/usrcbk/embObjLib_mngmnt_callback.c
@@ -40,6 +40,7 @@
 
 #include "EoProtocolMN.h"
 
+#include "EoBoards.h"
 
 // --------------------------------------------------------------------------------------------------------------------
 // - declaration of extern hidden interface 
@@ -57,17 +58,32 @@
 // --------------------------------------------------------------------------------------------------------------------
 // - typedef with internal scope
 // --------------------------------------------------------------------------------------------------------------------
-// empty-section
+
+typedef struct
+{
+    uint32_t    sec;
+    uint32_t    msec;
+    uint32_t    usec;
+} timeofmessage_t;
 
 
 // --------------------------------------------------------------------------------------------------------------------
 // - declaration of static functions
 // --------------------------------------------------------------------------------------------------------------------
 
+static void s_print_string(char *str, eOmn_info_type_t errortype);
 
 static void s_eoprot_print_mninfo_status(eOmn_info_basic_t* infobasic, uint8_t * extra, const EOnv* nv, const eOropdescriptor_t* rd);
 
+static void s_process_CANPRINT(eOmn_info_basic_t* infobasic, uint8_t * extra, const EOnv* nv, const eOropdescriptor_t* rd);
 
+static void s_process_category_Default(eOmn_info_basic_t* infobasic, uint8_t * extra, const EOnv* nv, const eOropdescriptor_t* rd);
+
+static void s_process_category_Config(eOmn_info_basic_t* infobasic, uint8_t * extra, const EOnv* nv, const eOropdescriptor_t* rd);
+
+static void s_get_timeofmessage(eOmn_info_basic_t* infobasic, timeofmessage_t *t);
+
+static const char * s_get_sourceofmessage(eOmn_info_basic_t* infobasic, uint8_t *address);
 
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of static variables
@@ -229,6 +245,7 @@ static void s_eoprot_print_mninfo_status(eOmn_info_basic_t* infobasic, uint8_t *
 #define CAN_PRINT_FULL_PARSING
 
     static const eOerror_code_t codecanprint = EOERRORCODE(eoerror_category_System, eoerror_value_SYS_canservices_canprint);
+    eOerror_category_t category = eoerror_code2category(infobasic->properties.code);
 
 #if defined(DROPCODES_FROM_LIST)
     static const eOerror_code_t codes2drop_value[] =
@@ -252,151 +269,368 @@ static void s_eoprot_print_mninfo_status(eOmn_info_basic_t* infobasic, uint8_t *
     }
 #endif
 
+    if(codecanprint == infobasic->properties.code)
     {
-        char str[512] = {0};
-        static const char * const sourcestrings[] =
-        {
-            "LOCAL",
-            "CAN1",
-            "CAN2",
-            "UNKNOWN"
-        };
-    
-        static const char nullverbalextra[] = "no extra info despite we are in verbal mode";
-        static const char emptyextra[] = "NO MORE";
-    
-        uint32_t sec = infobasic->timestamp / 1000000;
-        uint32_t msec = (infobasic->timestamp % 1000000) / 1000;
-        uint32_t usec = infobasic->timestamp % 1000;
-    
-        eOmn_info_type_t    type        = EOMN_INFO_PROPERTIES_FLAGS_get_type(infobasic->properties.flags);
-        eOmn_info_source_t  source      = EOMN_INFO_PROPERTIES_FLAGS_get_source(infobasic->properties.flags);
-        uint16_t address                = EOMN_INFO_PROPERTIES_FLAGS_get_address(infobasic->properties.flags);
-        eOmn_info_extraformat_t extraf  = EOMN_INFO_PROPERTIES_FLAGS_get_extraformat(infobasic->properties.flags);
-        uint16_t forfutureuse           = EOMN_INFO_PROPERTIES_FLAGS_get_futureuse(infobasic->properties.flags);
-        
-        const char * str_source = NULL;
-        const char * str_code = NULL;
-        const char * str_extra = NULL;
-        uint8_t *p64 = NULL;
-    
-        str_source         = (source > eomn_info_source_can2) ? (sourcestrings[3]) : (sourcestrings[source]);
-        str_code           = eoerror_code2string(infobasic->properties.code);
-        str_extra          = NULL;
-    
-        if(eomn_info_extraformat_verbal == extraf)
-        {
-            str_extra = (NULL == extra) ? (nullverbalextra) : ((const char *)extra);
-        }
-        else
-        {
-            str_extra = emptyextra;
-        }
-    
-        p64 = (uint8_t*)&(infobasic->properties.par64);
-
-        int boardnum = eo_nv_GetBRD(nv)+1;
-        const char *boardstr = feat_embObj_GetBoardName(eo_nv_GetBRD(nv));
-    
-        if(codecanprint == infobasic->properties.code)
-        {
-            uint16_t len = 0;
-            char canframestring[7] = {0};
-    
-    #if defined(CAN_PRINT_FULL_PARSING)
-            feat_embObjCANPrintHandler(eo_nv_GetBRD(nv), infobasic);
-            return;
-    #endif
-            // it is a canprint: treat it in a particular way.
-            // in first step: just print the 6 bytes (at most) of the payload: now on 03/03/15 we have implemented first step
-            // in second step: do the same inside ethResources
-            // in third step: inside ethResources it is called the proper class can_string_generic with one instance per can board.
-            //                maybe to save memory, we can instantiate the can_string_generic in runtime only when the can board sends a canprint.
-            //                this third step allows to concatenate the can print frames into a single message as robotInterface
-            //                does with can-based robots
-    
-            len = infobasic->properties.par16;
-            if((len > 2) && (len <=8))
-            {
-                // we have a valid canframe
-                memcpy(canframestring, &p64[2], len-2);
-                canframestring[len-2] = 0;  // string terminator
-                snprintf(str, sizeof(str), " from BOARD 10.0.1.%d (%s), src %s, adr %d, time %ds %dm %du: CANPRINT: %s [size = %d, D0 = 0x%.2x, D1 = 0x%.2x]",
-                                            boardnum,
-                                            boardstr,
-                                            str_source,
-                                            address,
-                                            sec, msec, usec,
-                                            canframestring,
-                                            len, p64[0], p64[1]
-                                            );
-            }
-            else
-            {
-                snprintf(str, sizeof(str), " from BOARD 10.0.1.%d (%s), src %s, adr %d, time %ds %dm %du: CANPRINT is malformed (code 0x%.8x, par16 0x%.4x par64 0x%.2x%.2x%.2x%.2x%.2x%.2x%.2x%.2x) -> %s + INFO = %s",
-                                            boardnum,
-                                            boardstr,
-                                            str_source,
-                                            address,
-                                            sec, msec, usec,
-                                            infobasic->properties.code,
-                                            infobasic->properties.par16,
-                                            p64[7], p64[6], p64[5], p64[4], p64[3], p64[2], p64[1], p64[0],
-                                            str_code,
-                                            str_extra
-                                            );
-    
-            }
-    
-    
-        }
-        else
-        {   // treat it as the normal case
-    
-            snprintf(str, sizeof(str), " from BOARD 10.0.1.%d (%s), src %s, adr %d, time %ds %dm %du: (code 0x%.8x, par16 0x%.4x par64 0x%.2x%.2x%.2x%.2x%.2x%.2x%.2x%.2x) -> %s + INFO = %s",
-                                        boardnum,
-                                        boardstr,
-                                        str_source,
-                                        address,
-                                        sec, msec, usec,
-                                        infobasic->properties.code,
-                                        infobasic->properties.par16,
-                                        p64[7], p64[6], p64[5], p64[4], p64[3], p64[2], p64[1], p64[0],
-                                        str_code,
-                                        str_extra
-                                        );
-        }
-    
-        if(type == eomn_info_type_debug)
-        {
-            embObjPrintDebug(str);
-        }
-    
-        if(type == eomn_info_type_info)
-        {
-            embObjPrintInfo(str);
-        }
-    
-        if(type == eomn_info_type_warning)
-        {
-            embObjPrintWarning(str);
-        }
-    
-        if(type == eomn_info_type_error)
-        {
-            embObjPrintError(str);
-        }
-    
-        if(type == eomn_info_type_fatal)
-        {
-            embObjPrintFatal(str);
-        }
+        s_process_CANPRINT(infobasic, extra, nv, rd);
     }
+    else if(eoerror_category_Config == category)
+    {
+        s_process_category_Config(infobasic, extra, nv, rd);
+    }
+    else
+    {
+        s_process_category_Default(infobasic, extra, nv, rd);
+    }
+
 }
 
 
+static void s_process_category_Default(eOmn_info_basic_t* infobasic, uint8_t * extra, const EOnv* nv, const eOropdescriptor_t* rd)
+{
+    char str[512] = {0};
+
+    static const char nullverbalextra[] = "no extra info despite we are in verbal mode";
+    static const char emptyextra[] = ".";
+    timeofmessage_t tom = {0};
+    s_get_timeofmessage(infobasic, &tom);
 
 
+    eOmn_info_type_t    type        = EOMN_INFO_PROPERTIES_FLAGS_get_type(infobasic->properties.flags);
+    uint8_t address = 0;
+    eOmn_info_extraformat_t extraf  = EOMN_INFO_PROPERTIES_FLAGS_get_extraformat(infobasic->properties.flags);
+    //uint16_t forfutureuse           = EOMN_INFO_PROPERTIES_FLAGS_get_futureuse(infobasic->properties.flags);
+
+    const char * str_source = NULL;
+    const char * str_code = NULL;
+    const char * str_extra = NULL;
+    uint8_t *p64 = NULL;
+
+    str_source         = s_get_sourceofmessage(infobasic, &address);
+    str_code           = eoerror_code2string(infobasic->properties.code);
+    str_extra          = NULL;
+
+    if(eomn_info_extraformat_verbal == extraf)
+    {
+        str_extra = (NULL == extra) ? (nullverbalextra) : ((const char *)extra);
+    }
+    else
+    {
+        str_extra = emptyextra;
+    }
+
+    p64 = (uint8_t*)&(infobasic->properties.par64);
+
+
+    int boardnum = eo_nv_GetBRD(nv)+1;
+    const char *boardstr = feat_embObj_GetBoardName(eo_nv_GetBRD(nv));
+
+
+    snprintf(str, sizeof(str), " from BOARD 10.0.1.%d (%s), src %s, adr %d, time %ds %dm %du: (code 0x%.8x, par16 0x%.4x par64 0x%.2x%.2x%.2x%.2x%.2x%.2x%.2x%.2x) -> %s + %s",
+                                boardnum,
+                                boardstr,
+                                str_source,
+                                address,
+                                tom.sec, tom.msec, tom.usec,
+                                infobasic->properties.code,
+                                infobasic->properties.par16,
+                                p64[7], p64[6], p64[5], p64[4], p64[3], p64[2], p64[1], p64[0],
+                                str_code,
+                                str_extra
+                                );
+
+    s_print_string(str, type);
+}
+
+
+static void s_print_string(char *str, eOmn_info_type_t errortype)
+{
+    switch(errortype)
+    {
+        case eomn_info_type_info:
+        {
+            embObjPrintInfo(str);
+        } break;
+
+        case eomn_info_type_debug:
+        {
+            embObjPrintDebug(str);
+        } break;
+
+        case eomn_info_type_warning:
+        {
+            embObjPrintWarning(str);
+        } break;
+
+        case eomn_info_type_error:
+        {
+            embObjPrintError(str);
+        } break;
+
+        case eomn_info_type_fatal:
+        {
+            embObjPrintFatal(str);
+        } break;
+
+        default:
+        {
+            embObjPrintError(str);
+        } break;
+    }
+
+}
+
+
+static void s_process_CANPRINT(eOmn_info_basic_t* infobasic, uint8_t * extra, const EOnv* nv, const eOropdescriptor_t* rd)
+{
+    feat_embObjCANPrintHandler(eo_nv_GetBRD(nv), infobasic);
+}
+
+//#warning --> do a proper function in EoBoards.c
+const char * eoboard_get_name(eObrd_cantype_t type)
+{
+    static const char * names[] =
+    {
+        "UNKNOWN", "UNKNOWN", "UNKNOWN",
+        "MC4",
+        "UNKNOWN"
+        "MTB",
+        "STRAIN",
+        "MAIS",
+        "FOC"
+    };
+    static const char *none = "NONE";
+
+
+    if(type <= eobrd_cantype_mais)
+    {
+        return(names[type]);
+    }
+    else if(eobrd_cantype_none == type)
+    {
+        return(none);
+    }
+    else
+    {
+        return(names[0]);
+    }
+
+}
+
+static void s_process_category_Config(eOmn_info_basic_t* infobasic, uint8_t * extra, const EOnv* nv, const eOropdescriptor_t* rd)
+{
+    char str[512] = {0};
+
+
+    // here is the basic oscure print
+    //s_process_category_Default(infobasic, extra, nv, rd);
+
+    // but now we do a better parsing
+
+    eOmn_info_type_t type = EOMN_INFO_PROPERTIES_FLAGS_get_type(infobasic->properties.flags);
+    int ethboardnum = eo_nv_GetBRD(nv)+1;
+    const char *ethboardname = feat_embObj_GetBoardName(eo_nv_GetBRD(nv));
+    timeofmessage_t tom = {0};
+    s_get_timeofmessage(infobasic, &tom);
+
+    eOerror_value_t value = eoerror_code2value(infobasic->properties.code);
+
+    switch(value)
+    {
+        case eoerror_value_CFG_candiscovery_ok:
+        {
+            uint8_t num = infobasic->properties.par16 & 0x000f;
+            const char *canboardname = eoboard_get_name(infobasic->properties.par16 >> 8);
+            uint64_t searchtime = (infobasic->properties.par64 & 0xffff000000000000) >> 48;
+            eObrd_version_t prot = {0};
+            eObrd_version_t appl = {0};
+            uint64_t reqpr = (infobasic->properties.par64 & 0x00000000ffff0000) >> 16;
+            uint64_t reqfw = (infobasic->properties.par64 & 0x000000000000ffff);
+            prot.major = reqpr >> 8;
+            prot.minor = reqpr & 0xff;
+            appl.major = reqfw >> 8;
+            appl.minor = reqfw & 0xff;
+
+            snprintf(str, sizeof(str), " from BOARD 10.0.1.%d (%s) @ %ds %dm %du: successful CAN discovery of %d %s boards with target can protocol ver %d.%d and application ver %d.%d. Search time was %d ms",
+                                        ethboardnum,
+                                        ethboardname,
+                                        tom.sec, tom.msec, tom.usec,
+
+                                        num, canboardname,
+                                        prot.major, prot.minor,
+                                        appl.major, appl.minor,
+                                        (int)searchtime
+                                        );
+
+            s_print_string(str, type);
+
+        } break;
+
+        case eoerror_value_CFG_candiscovery_detectedboard:
+        {
+            const char *canboardname = eoboard_get_name(infobasic->properties.par16 >> 8);
+            uint64_t searchtime = (infobasic->properties.par64 & 0xffff000000000000) >> 48;
+            eObrd_version_t prot = {0};
+            eObrd_version_t appl = {0};
+            uint64_t reqpr = (infobasic->properties.par64 & 0x00000000ffff0000) >> 16;
+            uint64_t reqfw = (infobasic->properties.par64 & 0x000000000000ffff);
+            prot.major = reqpr >> 8;
+            prot.minor = reqpr & 0xff;
+            appl.major = reqfw >> 8;
+            appl.minor = reqfw & 0xff;
+            uint8_t address = infobasic->properties.par16 & 0x000f;
+            const char *source = s_get_sourceofmessage(infobasic, NULL);
+
+
+            snprintf(str, sizeof(str), " from BOARD 10.0.1.%d (%s) @ %ds %dm %du: CAN discovery has detected a %s board in %s addr %d with can protocol ver %d.%d and application ver %d.%d. Search time was %d ms",
+                                        ethboardnum,
+                                        ethboardname,
+                                        tom.sec, tom.msec, tom.usec,
+
+                                        canboardname,
+                                        source, address,
+                                        prot.major, prot.minor,
+                                        appl.major, appl.minor,
+                                        (int)searchtime
+                                        );
+            s_print_string(str, type);
+
+        } break;
+
+        case eoerror_value_CFG_candiscovery_boardsmissing:
+        {
+            uint8_t numofmissing = infobasic->properties.par16 & 0x00ff;
+            const char *canboardname = eoboard_get_name(infobasic->properties.par16 >> 8);
+            uint64_t searchtime = (infobasic->properties.par64 & 0xffff000000000000) >> 48;
+            uint16_t maskofmissing = infobasic->properties.par64 & 0x000000000000ffff;
+            const char *source = s_get_sourceofmessage(infobasic, NULL);
+
+
+            snprintf(str, sizeof(str), " from BOARD 10.0.1.%d (%s) @ %ds %dm %du: CAN discovery after %d ms has detected %d missing %s boards in %s:",
+                                        ethboardnum,
+                                        ethboardname,
+                                        tom.sec, tom.msec, tom.usec,
+
+                                        (int)searchtime,
+                                        numofmissing,
+                                        canboardname,
+                                        source
+                                        );
+            s_print_string(str, type);
+
+
+            uint8_t n = 1;
+            uint8_t i = 0;
+            for(i=1; i<15; i++)
+            {
+                if(eobool_true == eo_common_hlfword_bitcheck(maskofmissing, i))
+                {
+                    snprintf(str, sizeof(str), "%d of %d: missing %s BOARD 10.0.1.%d:%s:%d",
+                                                n, numofmissing, canboardname,
+                                                ethboardnum, source, i
+                                                );
+                    s_print_string(str, type);
+                    n++;
+
+                }
+            }
+
+        } break;
+
+        case eoerror_value_CFG_candiscovery_boardsinvalid:
+        {
+            uint8_t numofinvalid = infobasic->properties.par16 & 0x00ff;
+            const char *canboardname = eoboard_get_name(infobasic->properties.par16 >> 8);
+            uint64_t invalidmask = infobasic->properties.par64;
+            const char *source = s_get_sourceofmessage(infobasic, NULL);
+
+
+            snprintf(str, sizeof(str), " from BOARD 10.0.1.%d (%s) @ %ds %dm %du: CAN discovery has detected %d invalid %s boards in %s:",
+                                        ethboardnum,
+                                        ethboardname,
+                                        tom.sec, tom.msec, tom.usec,
+
+                                        numofinvalid,
+                                        canboardname,
+                                        source
+                                        );
+            s_print_string(str, type);
+
+
+            uint8_t n = 1;
+            uint8_t i = 0;
+            const char *empty = "";
+            const char *wrongtype = "WRONG BOARD TYPE";
+            const char *wrongprot = "WRONG PROTOCOL VERSION";
+            const char *wrongappl = "WRONG APPLICATION VERSION";
+            for(i=1; i<15; i++)
+            {
+                uint64_t val = (invalidmask >> (4*i)) & 0x0f;
+                if(0 != val)
+                {
+                    snprintf(str, sizeof(str), "%d of %d: wrong %s BOARD 10.0.1.%d:%s:%d because it has: %s %s %s",
+                                                n, numofinvalid, canboardname,
+                                                ethboardnum, source, i,
+                                                ((val & 0x1) == 0x1) ? (wrongtype) : (empty),
+                                                ((val & 0x2) == 0x2) ? (wrongappl) : (empty),
+                                                ((val & 0x4) == 0x4) ? (wrongprot) : (empty)
+                                                );
+                    s_print_string(str, type);
+                    n++;
+
+                }
+            }
+
+        } break;
+
+        default:
+        {
+            s_process_category_Default(infobasic, extra, nv, rd);
+
+        } break;
+
+        case EOERROR_VALUE_DUMMY:
+        {
+            snprintf(str, sizeof(str), " from BOARD 10.0.1.%d (%s) @ %ds %dm %du: unrecognised eoerror_category_Config error value:",
+                                    ethboardnum,
+                                    ethboardname,
+                                    tom.sec, tom.msec, tom.usec
+                                    );
+            s_print_string(str, type);
+
+        } break;
+
+    }
+
+}
+
+
+static void s_get_timeofmessage(eOmn_info_basic_t* infobasic, timeofmessage_t *t)
+{
+    t->sec  = infobasic->timestamp / 1000000;
+    t->msec = (infobasic->timestamp % 1000000) / 1000;
+    t->usec = infobasic->timestamp % 1000;
+}
+
+
+static const char * s_get_sourceofmessage(eOmn_info_basic_t* infobasic, uint8_t *address)
+{
+    static const char * const sourcenames[] =
+    {
+        "LOCAL",
+        "CAN1",
+        "CAN2",
+        "UNKNOWN"
+    };
+
+    eOmn_info_source_t source = EOMN_INFO_PROPERTIES_FLAGS_get_source(infobasic->properties.flags);
+
+    if(NULL != address)
+    {
+        *address = EOMN_INFO_PROPERTIES_FLAGS_get_address(infobasic->properties.flags);
+    }
+
+    return((source > eomn_info_source_can2) ? (sourcenames[3]) : (sourcenames[source]));
+}
 
 // --------------------------------------------------------------------------------------------------------------------
 // - end-of-file (leave a blank line after)

--- a/src/libraries/icubmod/embObjLib/usrcbk/embObjLib_mngmnt_callback.c
+++ b/src/libraries/icubmod/embObjLib/usrcbk/embObjLib_mngmnt_callback.c
@@ -392,11 +392,12 @@ const char * eoboard_get_name(eObrd_cantype_t type)
     {
         "UNKNOWN", "UNKNOWN", "UNKNOWN",
         "MC4",
-        "UNKNOWN"
+        "UNKNOWN",
         "MTB",
         "STRAIN",
         "MAIS",
-        "FOC"
+        "FOC",
+        "ERROR09", "ERROR10"
     };
     static const char *none = "NONE";
 


### PR DESCRIPTION
Now it is easier to understand which CAN boards are missing because robotInterface parses the diagnostics messages coming from ETH boards and prints them in human readable form.