### PR TITLE
ctrlLib inherits math constants from cmath and publish them with cmake

### DIFF
--- a/src/libraries/ctrlLib/CMakeLists.txt
+++ b/src/libraries/ctrlLib/CMakeLists.txt
@@ -14,7 +14,7 @@ set(folder_source src/math.cpp
                   src/functionEncoder.cpp
                   src/optimalControl.cpp
                   src/neuralNetworks.cpp
-				          src/outliersDetection.cpp)
+                  src/outliersDetection.cpp)
 
 set(folder_header include/iCub/ctrl/math.h
                   include/iCub/ctrl/filters.h
@@ -26,7 +26,7 @@ set(folder_header include/iCub/ctrl/math.h
                   include/iCub/ctrl/functionEncoder.h
                   include/iCub/ctrl/optimalControl.h
                   include/iCub/ctrl/neuralNetworks.h
-				          include/iCub/ctrl/outliersDetection.h)
+                  include/iCub/ctrl/outliersDetection.h)
 
 source_group("Source Files" FILES ${folder_source})
 source_group("Header Files" FILES ${folder_header})

--- a/src/libraries/ctrlLib/CMakeLists.txt
+++ b/src/libraries/ctrlLib/CMakeLists.txt
@@ -2,11 +2,9 @@
 # Authors: Ugo Pattacini
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-SET(PROJECTNAME ctrlLib)
+project(ctrlLib)
 
-PROJECT(${PROJECTNAME})
-
-SET(folder_source src/math.cpp
+set(folder_source src/math.cpp
                   src/filters.cpp
                   src/kalman.cpp
                   src/pids.cpp
@@ -16,9 +14,9 @@ SET(folder_source src/math.cpp
                   src/functionEncoder.cpp
                   src/optimalControl.cpp
                   src/neuralNetworks.cpp
-				  src/outliersDetection.cpp)
+				          src/outliersDetection.cpp)
 
-SET(folder_header include/iCub/ctrl/math.h
+set(folder_header include/iCub/ctrl/math.h
                   include/iCub/ctrl/filters.h
                   include/iCub/ctrl/kalman.h
                   include/iCub/ctrl/pids.h
@@ -28,21 +26,24 @@ SET(folder_header include/iCub/ctrl/math.h
                   include/iCub/ctrl/functionEncoder.h
                   include/iCub/ctrl/optimalControl.h
                   include/iCub/ctrl/neuralNetworks.h
-				  include/iCub/ctrl/outliersDetection.h)
+				          include/iCub/ctrl/outliersDetection.h)
 
-SOURCE_GROUP("Source Files" FILES ${folder_source})
-SOURCE_GROUP("Header Files" FILES ${folder_header})
+source_group("Source Files" FILES ${folder_source})
+source_group("Header Files" FILES ${folder_header})
 
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/include
+include_directories(${PROJECT_SOURCE_DIR}/include
                     ${GSL_INCLUDE_DIRS}
                     ${YARP_INCLUDE_DIRS})
 
-ADD_LIBRARY(${PROJECTNAME} ${folder_source} ${folder_header})
+add_library(${PROJECT_NAME} ${folder_source} ${folder_header})
 
-TARGET_LINK_LIBRARIES(${PROJECTNAME} ${GSL_LIBRARIES}
-                                     ${YARP_LIBRARIES})
-                 
-icub_export_library(${PROJECTNAME} INTERNAL_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include
-                                   DESTINATION include/iCub/ctrl
-                                   FILES ${folder_header})
+if(MSVC)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC _USE_MATH_DEFINES)
+endif()
+
+target_link_libraries(${PROJECT_NAME} ${GSL_LIBRARIES} ${YARP_LIBRARIES})
+
+icub_export_library(${PROJECT_NAME} INTERNAL_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include
+                                    DESTINATION include/iCub/ctrl
+                                    FILES ${folder_header})
 

--- a/src/libraries/ctrlLib/include/iCub/ctrl/math.h
+++ b/src/libraries/ctrlLib/include/iCub/ctrl/math.h
@@ -45,16 +45,15 @@
 #ifndef __CTRLMATH_H__
 #define __CTRLMATH_H__
 
+#include <cmath>
+
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/math/Math.h>
 
-#ifndef M_PI
-    #define M_PI        3.14159265358979323846264338328
-#endif
-
 #define CTRL_RAD2DEG    (180.0/M_PI)
 #define CTRL_DEG2RAD    (M_PI/180.0)
+
 
 namespace iCub
 {

--- a/src/libraries/iKin/CMakeLists.txt
+++ b/src/libraries/iKin/CMakeLists.txt
@@ -2,8 +2,7 @@
 # Authors: Ugo Pattacini
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-set(PROJECTNAME iKin)
-project(${PROJECTNAME})
+project(iKin)
 
 set(folder_source src/iKinFwd.cpp
                   src/iKinInv.cpp
@@ -36,17 +35,17 @@ if(ICUB_USE_IPOPT)
    add_definitions(${IPOPT_DEFINITIONS})
 endif()
 
-add_library(${PROJECTNAME} ${folder_source} ${folder_header})
-target_link_libraries(${PROJECTNAME} ctrlLib ${YARP_LIBRARIES})
+add_library(${PROJECT_NAME} ${folder_source} ${folder_header})
+target_link_libraries(${PROJECT_NAME} ctrlLib ${YARP_LIBRARIES})
 
 if(ICUB_USE_IPOPT)
-   set_property(TARGET ${PROJECTNAME} APPEND_STRING PROPERTY LINK_FLAGS " ${IPOPT_LINK_FLAGS}")
-   target_link_libraries(${PROJECTNAME} ${IPOPT_LIBRARIES})
+   set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS " ${IPOPT_LINK_FLAGS}")
+   target_link_libraries(${PROJECT_NAME} ${IPOPT_LIBRARIES})
 endif()
 
-icub_export_library(${PROJECTNAME} INTERNAL_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include
-                                   DEPENDS ctrlLib
-                                   DESTINATION include/iCub/iKin
-                                   FILES ${folder_header})                                    
+icub_export_library(${PROJECT_NAME} INTERNAL_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include
+                                    DEPENDS ctrlLib
+                                    DESTINATION include/iCub/iKin
+                                    FILES ${folder_header})                                    
 
 

--- a/src/modules/camCalibWithPose/CMakeLists.txt
+++ b/src/modules/camCalibWithPose/CMakeLists.txt
@@ -25,7 +25,10 @@ include_directories(${PROJECT_SOURCE_DIR}/include
                     ${OpenCV_INCLUDE_DIRS}
                     ${YARP_INCLUDE_DIRS})
 
-add_definitions(-D_USE_MATH_DEFINES)
+if(MSVC)
+  add_definitions(-D_USE_MATH_DEFINES)
+endif()
+
 add_executable(${PROJECT_NAME} ${folder_source} ${folder_header})
 target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES} ${YARP_LIBRARIES})
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/src/simulators/iCubSimulation/CMakeLists.txt
+++ b/src/simulators/iCubSimulation/CMakeLists.txt
@@ -87,6 +87,10 @@ ELSE ()
    ADD_DEFINITIONS(-DOMIT_LOGPOLAR)
 ENDIF ()
 
+if(MSVC)
+  add_definitions(-D_USE_MATH_DEFINES)
+endif()
+
 ADD_EXECUTABLE(${PROJECTNAME} ${folder_source} ${folder_header})
 
 TARGET_LINK_LIBRARIES(${PROJECTNAME} ${YARP_LIBRARIES} iKin)

--- a/src/simulators/iCubSimulation/wrapper/iCubSimulationControl.cpp
+++ b/src/simulators/iCubSimulation/wrapper/iCubSimulationControl.cpp
@@ -20,7 +20,6 @@
 
 #ifdef _MSC_VER
 #pragma warning(disable:4355)  //for VC++, no precision loss complaints
-#define _USE_MATH_DEFINES      // for M_PI
 #endif
 /// general purpose stuff.
 #include <yarp/os/Time.h>

--- a/src/tools/iCubGui/src/CMakeLists.txt
+++ b/src/tools/iCubGui/src/CMakeLists.txt
@@ -63,6 +63,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
 # Set defines
 add_definitions(${QT_DEFINITIONS})
+if(MSVC)
+  add_definitions(-D_USE_MATH_DEFINES)
+endif()
 
 # Compile and link
 add_executable(iCubGui WIN32 ${iCubGui_HDRS}

--- a/src/tools/iCubGui/src/mesh.h
+++ b/src/tools/iCubGui/src/mesh.h
@@ -28,7 +28,6 @@
 #include <GL/glu.h>
 #endif
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
As discussed in https://github.com/robotology/QA/issues/81, **`ctrlLib`** now depends on **`cmath`** to import mathematical constants (e.g. `M_PI`) instead of re-defining them from scratch.

This dependency is then published by means of suitable cmake macro for systems using **MSVC** compilers. In this respect, I have explicitly avoided referring to corresponding Cmake versions in order not to retain some unnecessary leftover in Windows (as said, Windows users have more recent versions of Cmake). Let's see if this will suffice.

I've also given a go to the compilation of `wysiwyd`, `karma` and `iol` sister repositories without any problem related to this specific change.

/cc @traversaro 