### PR TITLE
ctrlLib defines math symbols to avoid referring to M_PI in the headers

### DIFF
--- a/src/libraries/ctrlLib/CMakeLists.txt
+++ b/src/libraries/ctrlLib/CMakeLists.txt
@@ -35,10 +35,8 @@ include_directories(${PROJECT_SOURCE_DIR}/include
                     ${GSL_INCLUDE_DIRS}
                     ${YARP_INCLUDE_DIRS})
 
-if(MSVC)
-  add_definitions(-D_USE_MATH_DEFINES)
-endif()
-
+# import math symbols from standard cmath
+add_definitions(-D_USE_MATH_DEFINES)
 add_library(${PROJECT_NAME} ${folder_source} ${folder_header})
 target_link_libraries(${PROJECT_NAME} ${GSL_LIBRARIES} ${YARP_LIBRARIES})
 

--- a/src/libraries/ctrlLib/CMakeLists.txt
+++ b/src/libraries/ctrlLib/CMakeLists.txt
@@ -35,12 +35,11 @@ include_directories(${PROJECT_SOURCE_DIR}/include
                     ${GSL_INCLUDE_DIRS}
                     ${YARP_INCLUDE_DIRS})
 
-add_library(${PROJECT_NAME} ${folder_source} ${folder_header})
-
 if(MSVC)
-  target_compile_definitions(${PROJECT_NAME} PUBLIC _USE_MATH_DEFINES)
+  add_definitions(-D_USE_MATH_DEFINES)
 endif()
 
+add_library(${PROJECT_NAME} ${folder_source} ${folder_header})
 target_link_libraries(${PROJECT_NAME} ${GSL_LIBRARIES} ${YARP_LIBRARIES})
 
 icub_export_library(${PROJECT_NAME} INTERNAL_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include

--- a/src/libraries/ctrlLib/include/iCub/ctrl/math.h
+++ b/src/libraries/ctrlLib/include/iCub/ctrl/math.h
@@ -45,14 +45,9 @@
 #ifndef __CTRLMATH_H__
 #define __CTRLMATH_H__
 
-#include <cmath>
-
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/math/Math.h>
-
-#define CTRL_RAD2DEG    (180.0/M_PI)
-#define CTRL_DEG2RAD    (M_PI/180.0)
 
 
 namespace iCub
@@ -60,6 +55,21 @@ namespace iCub
 
 namespace ctrl
 {
+
+/**
+ * The PI constant.
+ */
+extern const double CTRL_PI;
+
+/**
+ * 180/PI.
+ */
+extern const double CTRL_RAD2DEG;
+
+/**
+ * PI/180.
+ */
+extern const double CTRL_DEG2RAD;
 
 /**
 * \ingroup Maths

--- a/src/libraries/ctrlLib/src/math.cpp
+++ b/src/libraries/ctrlLib/src/math.cpp
@@ -30,6 +30,16 @@ using namespace yarp::math;
 
 
 /************************************************************************/
+namespace iCub {
+    namespace ctrl {
+        const double CTRL_PI=M_PI;
+        const double CTRL_RAD2DEG=180.0/M_PI;
+        const double CTRL_DEG2RAD=M_PI/180.0;
+    }
+}
+
+
+/************************************************************************/
 double iCub::ctrl::dot(const Matrix &A, int colA, const Matrix &B, int colB)
 {
     double ret=0.0;

--- a/src/libraries/iDyn/CMakeLists.txt
+++ b/src/libraries/iDyn/CMakeLists.txt
@@ -25,10 +25,8 @@ include_directories(${PROJECT_SOURCE_DIR}/include
                     ${GSL_INCLUDE_DIRS}
                     ${YARP_INCLUDE_DIRS})
 
-if(MSVC)
-  add_definitions(-D_USE_MATH_DEFINES)
-endif()
-
+# import math symbols from standard cmath
+add_definitions(-D_USE_MATH_DEFINES)
 add_library(${PROJECT_NAME} ${folder_source} ${folder_header})
 target_link_libraries(${PROJECT_NAME} iKin
                                       skinDynLib

--- a/src/libraries/iDyn/CMakeLists.txt
+++ b/src/libraries/iDyn/CMakeLists.txt
@@ -2,41 +2,42 @@
 # Authors: Matteo Fumagalli, Serena Ivaldi
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-SET(PROJECTNAME iDyn)
+project(iDyn)
 
-PROJECT(${PROJECTNAME})
-
-SET(folder_source src/iDyn.cpp
+set(folder_source src/iDyn.cpp
                   src/iDynInv.cpp
                   src/iDynBody.cpp
                   src/iDynTransform.cpp
                   src/iDynContact.cpp)
 
-SET(folder_header include/iCub/iDyn/iDyn.h
+set(folder_header include/iCub/iDyn/iDyn.h
                   include/iCub/iDyn/iDynInv.h
                   include/iCub/iDyn/iDynBody.h
                   include/iCub/iDyn/iDynTransform.h
                   include/iCub/iDyn/iDynContact.h)
 
-SOURCE_GROUP("Source Files" FILES ${folder_source})
-SOURCE_GROUP("Header Files" FILES ${folder_header})
+source_group("Source Files" FILES ${folder_source})
+source_group("Header Files" FILES ${folder_header})
 
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/include
+include_directories(${PROJECT_SOURCE_DIR}/include
                     ${iKin_INCLUDE_DIRS}
                     ${skinDynLib_INCLUDE_DIRS}
                     ${GSL_INCLUDE_DIRS}
                     ${YARP_INCLUDE_DIRS})
 
-ADD_LIBRARY(${PROJECTNAME} ${folder_source} ${folder_header})
+if(MSVC)
+  add_definitions(-D_USE_MATH_DEFINES)
+endif()
 
-TARGET_LINK_LIBRARIES(${PROJECTNAME} iKin
-                                     skinDynLib
-                                     ${GSL_LIBRARIES}
-                                     ${YARP_LIBRARIES})
+add_library(${PROJECT_NAME} ${folder_source} ${folder_header})
+target_link_libraries(${PROJECT_NAME} iKin
+                                      skinDynLib
+                                      ${GSL_LIBRARIES}
+                                      ${YARP_LIBRARIES})
 
-icub_export_library(${PROJECTNAME} INTERNAL_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include
-                                   DEPENDS iKin skinDynLib
-                                   DESTINATION include/iCub/iDyn
-                                   FILES ${folder_header})
+icub_export_library(${PROJECT_NAME} INTERNAL_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include
+                                    DEPENDS iKin skinDynLib
+                                    DESTINATION include/iCub/iDyn
+                                    FILES ${folder_header})
 
 

--- a/src/libraries/iDyn/include/iCub/iDyn/iDyn.h
+++ b/src/libraries/iDyn/include/iCub/iDyn/iDyn.h
@@ -456,7 +456,7 @@ public:
     * @param _Min is the joint angle lower bound in [-pi,pi] (-pi by default)
     * @param _Max is the joint angle higher bound in [-pi,pi] (pi by default)
     */
-    iDynLink(double _A, double _D, double _Alpha, double _Offset, double _Min=-M_PI, double _Max=M_PI);
+    iDynLink(double _A, double _D, double _Alpha, double _Offset, double _Min=-iCub::ctrl::CTRL_PI, double _Max=iCub::ctrl::CTRL_PI);
      
     /**
      * Constructor, with initialization of kinematic and dynamic data
@@ -470,7 +470,7 @@ public:
     * @param _Min is the joint angle lower bound in [-pi,pi] (-pi by default)
     * @param _Max is the joint angle higher bound in [-pi,pi] (pi by default)
      */
-    iDynLink(const double _m, const yarp::sig::Matrix &_HC, const yarp::sig::Matrix &_I, double _A, double _D, double _Alpha, double _Offset, double _Min=-M_PI, double _Max=M_PI);
+    iDynLink(const double _m, const yarp::sig::Matrix &_HC, const yarp::sig::Matrix &_I, double _A, double _D, double _Alpha, double _Offset, double _Min=-iCub::ctrl::CTRL_PI, double _Max=iCub::ctrl::CTRL_PI);
 
     /**
     * Constructor, with initialization of kinematic and dynamic data
@@ -484,7 +484,7 @@ public:
     * @param _Min is the joint angle lower bound in [-pi,pi] (-pi by default)
     * @param _Max is the joint angle higher bound in [-pi,pi] (pi by default)
      */
-    iDynLink(const double _m, const yarp::sig::Vector &_C, const yarp::sig::Matrix &_I, double _A, double _D, double _Alpha, double _Offset, double _Min=-M_PI, double _Max=M_PI);
+    iDynLink(const double _m, const yarp::sig::Vector &_C, const yarp::sig::Matrix &_I, double _A, double _D, double _Alpha, double _Offset, double _Min=-iCub::ctrl::CTRL_PI, double _Max=iCub::ctrl::CTRL_PI);
 
     /**
     * Constructor, with initialization of kinematic and dynamic data
@@ -505,7 +505,7 @@ public:
     * @param _Min is the joint angle lower bound in [-pi,pi] (-pi by default)
     * @param _Max is the joint angle higher bound in [-pi,pi] (pi by default)
      */
-    iDynLink(const double _m, const double _rCx, const double _rCy, const double _rCz, const double Ixx, const double Ixy, const double Ixz, const double Iyy, const double Iyz, const double Izz, double _A, double _D, double _Alpha, double _Offset, double _Min=-M_PI, double _Max=M_PI);
+    iDynLink(const double _m, const double _rCx, const double _rCy, const double _rCz, const double Ixx, const double Ixy, const double Ixz, const double Iyy, const double Iyz, const double Izz, double _A, double _D, double _Alpha, double _Offset, double _Min=-iCub::ctrl::CTRL_PI, double _Max=iCub::ctrl::CTRL_PI);
 
     /**
      * Copy constructor

--- a/src/libraries/iDyn/src/iDyn.cpp
+++ b/src/libraries/iDyn/src/iDyn.cpp
@@ -16,12 +16,15 @@
 * Public License for more details
 */
 
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+#include <iomanip>
+
+#include <yarp/os/Log.h>
 #include <iCub/iDyn/iDyn.h>
 #include <iCub/ctrl/math.h>
-#include <stdio.h>
-#include <iostream>
-#include <yarp/os/Log.h>
-#include <iomanip>
+
 
 using namespace std;
 using namespace yarp::os;

--- a/src/libraries/iKin/CMakeLists.txt
+++ b/src/libraries/iKin/CMakeLists.txt
@@ -35,6 +35,10 @@ if(ICUB_USE_IPOPT)
    add_definitions(${IPOPT_DEFINITIONS})
 endif()
 
+if(MSVC)
+  add_definitions(-D_USE_MATH_DEFINES)
+endif()
+
 add_library(${PROJECT_NAME} ${folder_source} ${folder_header})
 target_link_libraries(${PROJECT_NAME} ctrlLib ${YARP_LIBRARIES})
 

--- a/src/libraries/iKin/CMakeLists.txt
+++ b/src/libraries/iKin/CMakeLists.txt
@@ -35,10 +35,8 @@ if(ICUB_USE_IPOPT)
    add_definitions(${IPOPT_DEFINITIONS})
 endif()
 
-if(MSVC)
-  add_definitions(-D_USE_MATH_DEFINES)
-endif()
-
+# import math symbols from standard cmath
+add_definitions(-D_USE_MATH_DEFINES)
 add_library(${PROJECT_NAME} ${folder_source} ${folder_header})
 target_link_libraries(${PROJECT_NAME} ctrlLib ${YARP_LIBRARIES})
 

--- a/src/libraries/iKin/include/iCub/iKin/iKinFwd.h
+++ b/src/libraries/iKin/include/iCub/iKin/iKinFwd.h
@@ -140,7 +140,7 @@ public:
     *             default).
     */
     iKinLink(double _A, double _D, double _Alpha, double _Offset,
-             double _Min=-M_PI, double _Max=M_PI);
+             double _Min=-iCub::ctrl::CTRL_PI, double _Max=iCub::ctrl::CTRL_PI);
 
     /**
     * Creates a new Link from an already existing Link object.

--- a/src/libraries/optimization/CMakeLists.txt
+++ b/src/libraries/optimization/CMakeLists.txt
@@ -23,11 +23,8 @@ include_directories(${PROJECT_SOURCE_DIR}/include
                     ${IPOPT_INCLUDE_DIRS}
                     ${YARP_INCLUDE_DIRS})
 
-add_definitions(${IPOPT_DEFINITIONS})
-if(MSVC)
-  add_definitions(-D_USE_MATH_DEFINES)
-endif()
-
+# import math symbols from standard cmath
+add_definitions(${IPOPT_DEFINITIONS} -D_USE_MATH_DEFINES)
 add_library(${PROJECTNAME} ${folder_source} ${folder_header})
 
 set_property(TARGET ${PROJECTNAME} APPEND_STRING PROPERTY LINK_FLAGS " ${IPOPT_LINK_FLAGS}")

--- a/src/libraries/optimization/CMakeLists.txt
+++ b/src/libraries/optimization/CMakeLists.txt
@@ -24,6 +24,10 @@ include_directories(${PROJECT_SOURCE_DIR}/include
                     ${YARP_INCLUDE_DIRS})
 
 add_definitions(${IPOPT_DEFINITIONS})
+if(MSVC)
+  add_definitions(-D_USE_MATH_DEFINES)
+endif()
+
 add_library(${PROJECTNAME} ${folder_source} ${folder_header})
 
 set_property(TARGET ${PROJECTNAME} APPEND_STRING PROPERTY LINK_FLAGS " ${IPOPT_LINK_FLAGS}")

--- a/src/libraries/optimization/src/calibReference.cpp
+++ b/src/libraries/optimization/src/calibReference.cpp
@@ -15,6 +15,7 @@
  * Public License for more details
 */
 
+#include <cmath>
 #include <algorithm>
 
 #include <yarp/math/Math.h>

--- a/src/modules/camCalibWithPose/CMakeLists.txt
+++ b/src/modules/camCalibWithPose/CMakeLists.txt
@@ -25,10 +25,8 @@ include_directories(${PROJECT_SOURCE_DIR}/include
                     ${OpenCV_INCLUDE_DIRS}
                     ${YARP_INCLUDE_DIRS})
 
-if(MSVC)
-  add_definitions(-D_USE_MATH_DEFINES)
-endif()
-
+# import math symbols from standard cmath
+add_definitions(-D_USE_MATH_DEFINES)
 add_executable(${PROJECT_NAME} ${folder_source} ${folder_header})
 target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES} ${YARP_LIBRARIES})
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/src/modules/iKinGazeCtrl/CMakeLists.txt
+++ b/src/modules/iKinGazeCtrl/CMakeLists.txt
@@ -28,6 +28,10 @@ include_directories(${PROJECT_SOURCE_DIR}/include
                     ${IPOPT_INCLUDE_DIRS}
                     ${YARP_INCLUDE_DIRS})
 
+if(MSVC)
+  add_definitions(-D_USE_MATH_DEFINES)
+endif()
+
 add_executable(${PROJECTNAME} ${folder_header} ${folder_source})
 target_link_libraries(${PROJECTNAME} ctrlLib iKin ${YARP_LIBRARIES})
 install(TARGETS ${PROJECTNAME} DESTINATION bin)

--- a/src/modules/iKinGazeCtrl/CMakeLists.txt
+++ b/src/modules/iKinGazeCtrl/CMakeLists.txt
@@ -28,10 +28,8 @@ include_directories(${PROJECT_SOURCE_DIR}/include
                     ${IPOPT_INCLUDE_DIRS}
                     ${YARP_INCLUDE_DIRS})
 
-if(MSVC)
-  add_definitions(-D_USE_MATH_DEFINES)
-endif()
-
+# import math symbols from standard cmath
+add_definitions(-D_USE_MATH_DEFINES)
 add_executable(${PROJECTNAME} ${folder_header} ${folder_source})
 target_link_libraries(${PROJECTNAME} ctrlLib iKin ${YARP_LIBRARIES})
 install(TARGETS ${PROJECTNAME} DESTINATION bin)

--- a/src/modules/wholeBodyDynamics/CMakeLists.txt
+++ b/src/modules/wholeBodyDynamics/CMakeLists.txt
@@ -3,25 +3,25 @@
 # Author: Matteo Fumagalli, Marco Randazzo
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
- 
-SET(PROJECTNAME wholeBodyDynamics)
+project(wholeBodyDynamics)
 
-PROJECT(${PROJECTNAME})
+file(GLOB folder_source main.cpp observerThread.cpp)
+file(GLOB folder_header observerThread.h)
 
-FILE(GLOB folder_source main.cpp observerThread.cpp)
-FILE(GLOB folder_header observerThread.h)
+source_group("Source Files" FILES ${folder_source})
+source_group("Header Files" FILES ${folder_header})
 
-SOURCE_GROUP("Source Files" FILES ${folder_source})
-SOURCE_GROUP("Header Files" FILES ${folder_header})
-
-INCLUDE_DIRECTORIES(${iDyn_INCLUDE_DIRS}
+include_directories(${iDyn_INCLUDE_DIRS}
                     ${YARP_INCLUDE_DIRS}
                     ${skinDynLib_INCLUDE_DIRS})
 
-ADD_EXECUTABLE(${PROJECTNAME} ${folder_source} ${folder_header})
+if(MSVC)
+  add_definitions(-D_USE_MATH_DEFINES)
+endif()
 
-TARGET_LINK_LIBRARIES(${PROJECTNAME} iDyn
-                                     ${YARP_LIBRARIES}
-                                     skinDynLib)
+add_executable(${PROJECT_NAME} ${folder_source} ${folder_header})
+target_link_libraries(${PROJECT_NAME} iDyn
+                                      ${YARP_LIBRARIES}
+                                      skinDynLib)
+install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 
-INSTALL(TARGETS ${PROJECTNAME} DESTINATION bin)

--- a/src/modules/wholeBodyDynamics/CMakeLists.txt
+++ b/src/modules/wholeBodyDynamics/CMakeLists.txt
@@ -15,10 +15,8 @@ include_directories(${iDyn_INCLUDE_DIRS}
                     ${YARP_INCLUDE_DIRS}
                     ${skinDynLib_INCLUDE_DIRS})
 
-if(MSVC)
-  add_definitions(-D_USE_MATH_DEFINES)
-endif()
-
+# import math symbols from standard cmath
+add_definitions(-D_USE_MATH_DEFINES)
 add_executable(${PROJECT_NAME} ${folder_source} ${folder_header})
 target_link_libraries(${PROJECT_NAME} iDyn
                                       ${YARP_LIBRARIES}

--- a/src/modules/wholeBodyDynamics/observerThread.cpp
+++ b/src/modules/wholeBodyDynamics/observerThread.cpp
@@ -16,6 +16,11 @@
  * Public License for more details
 */
 
+#include <cmath>
+#include <iostream>
+#include <iomanip>
+#include <string>
+
 #include <yarp/os/all.h>
 #include <yarp/sig/all.h>
 #include <yarp/dev/all.h>
@@ -25,9 +30,6 @@
 #include <iCub/iDyn/iDynBody.h>
 #include <iCub/skinDynLib/skinContact.h>
 
-#include <iostream>
-#include <iomanip>
-#include <string.h>
 #include "observerThread.h"
 
 using namespace yarp::os;

--- a/src/simulators/iCubSimulation/CMakeLists.txt
+++ b/src/simulators/iCubSimulation/CMakeLists.txt
@@ -87,10 +87,8 @@ ELSE ()
    ADD_DEFINITIONS(-DOMIT_LOGPOLAR)
 ENDIF ()
 
-if(MSVC)
-  add_definitions(-D_USE_MATH_DEFINES)
-endif()
-
+# import math symbols from standard cmath
+add_definitions(-D_USE_MATH_DEFINES)
 ADD_EXECUTABLE(${PROJECTNAME} ${folder_source} ${folder_header})
 
 TARGET_LINK_LIBRARIES(${PROJECTNAME} ${YARP_LIBRARIES} iKin)

--- a/src/tools/depth2kin/CMakeLists.txt
+++ b/src/tools/depth2kin/CMakeLists.txt
@@ -33,12 +33,9 @@ include_directories(${PROJECT_SOURCE_DIR}/include
                     ${iKin_INCLUDE_DIRS}
                     ${optimization_INCLUDE_DIRS}
                     ${learningMachine_INCLUDE_DIRS})
-                    
-add_definitions(${IPOPT_DEFINITIONS})
-if(MSVC)
-  add_definitions(-D_USE_MATH_DEFINES)
-endif()
 
+# import math symbols from standard cmath
+add_definitions(${IPOPT_DEFINITIONS} -D_USE_MATH_DEFINES)
 add_executable(${PROJECTNAME} ${header_files} ${source_files} ${idl_files} ${doc_files})
 set_property(TARGET ${PROJECTNAME} APPEND_STRING PROPERTY LINK_FLAGS " ${IPOPT_LINK_FLAGS}")
 target_link_libraries(${PROJECTNAME} ${YARP_LIBRARIES}

--- a/src/tools/depth2kin/CMakeLists.txt
+++ b/src/tools/depth2kin/CMakeLists.txt
@@ -35,6 +35,10 @@ include_directories(${PROJECT_SOURCE_DIR}/include
                     ${learningMachine_INCLUDE_DIRS})
                     
 add_definitions(${IPOPT_DEFINITIONS})
+if(MSVC)
+  add_definitions(-D_USE_MATH_DEFINES)
+endif()
+
 add_executable(${PROJECTNAME} ${header_files} ${source_files} ${idl_files} ${doc_files})
 set_property(TARGET ${PROJECTNAME} APPEND_STRING PROPERTY LINK_FLAGS " ${IPOPT_LINK_FLAGS}")
 target_link_libraries(${PROJECTNAME} ${YARP_LIBRARIES}

--- a/src/tools/depth2kin/src/nlp.cpp
+++ b/src/tools/depth2kin/src/nlp.cpp
@@ -15,6 +15,7 @@
  * Public License for more details
 */
 
+#include <cmath>
 #include <algorithm>
 #include <string>
 #include <deque>

--- a/src/tools/iCubGui/src/CMakeLists.txt
+++ b/src/tools/iCubGui/src/CMakeLists.txt
@@ -62,10 +62,8 @@ include_directories(${GLUT_INCLUDE_DIRS}
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
 # Set defines
-add_definitions(${QT_DEFINITIONS})
-if(MSVC)
-  add_definitions(-D_USE_MATH_DEFINES)
-endif()
+# import math symbols from standard cmath
+add_definitions(${QT_DEFINITIONS} -D_USE_MATH_DEFINES)
 
 # Compile and link
 add_executable(iCubGui WIN32 ${iCubGui_HDRS}

--- a/src/tools/stereoCalib/src/stereoCalibThread.cpp
+++ b/src/tools/stereoCalib/src/stereoCalibThread.cpp
@@ -101,7 +101,7 @@ bool stereoCalibThread::threadInit()
     for(size_t i=0; i<head_angles.length()-2; i++)
         qL[i+torso_angles.length()]=head_angles[i];
     qL[7]=head_angles[4]+(0.5-(LEFT))*head_angles[5];
-    qL=CTRL_DEG2RAD*qL;
+    qL=iCub::ctrl::CTRL_DEG2RAD*qL;
 
     qR.resize(torso_angles.length()+head_angles.length()-1);
     for(size_t i=0; i<torso_angles.length(); i++)
@@ -110,7 +110,7 @@ bool stereoCalibThread::threadInit()
     for(size_t i=0; i<head_angles.length()-2; i++)
         qR[i+torso_angles.length()]=head_angles[i];
     qR[7]=head_angles[4]+(0.5-(RIGHT))*head_angles[5];
-    qR=CTRL_DEG2RAD*qR;
+    qR=iCub::ctrl::CTRL_DEG2RAD*qR;
 
    return true;
 }


### PR DESCRIPTION
Following up discussions in https://github.com/robotology/QA/issues/81, `ctrlLib` declares now math symbols within its own namespace to avoid referring explicitly to e.g. `M_PI` in the public headers.

To get `icub-main` compiled I had to apply changes here and there. I'm afraid that this new approach will have an impact on sister projects: I think it is no longer guaranteed that they'll compile smoothly.