### PR TITLE
[cmake] Do not pollute cache of downstream projects

### DIFF
--- a/conf/iCubExportBuildTree.cmake
+++ b/conf/iCubExportBuildTree.cmake
@@ -58,7 +58,8 @@ file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(ICUB_INCLUDE_DIRS \"
 ### now write to file the list of dependencies with which iCub was compiled 
 get_property(dependency_flags GLOBAL PROPERTY ICUB_DEPENDENCIES_FLAGS)
 foreach (t ${dependency_flags})
-		file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(${t} \"${${t}}\" CACHE BOOL \"dependency flag\" FORCE)\n")
+		file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "unset(${t} CACHE)\n")
+		file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(${t} \"${${t}}\")\n")
 endforeach()
 
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/${BUILD_CONFIG_TEMPLATE}

--- a/conf/iCubExportForInstall.cmake
+++ b/conf/iCubExportForInstall.cmake
@@ -68,7 +68,8 @@ file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(ICUB_INCLUDE_DIRS \"
 ### now write to file the list of dependencies with which iCub was compiled 
 get_property(dependency_flags GLOBAL PROPERTY ICUB_DEPENDENCIES_FLAGS)
 foreach (t ${dependency_flags})
-		file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(${t} \"${${t}}\" CACHE BOOL \"dependency flag\" FORCE)\n")
+		file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "unset(${t} CACHE)\n")
+		file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(${t} \"${${t}}\")\n")
 endforeach()
 
 install(EXPORT icub-targets DESTINATION lib/ICUB FILE ${EXPORT_CONFIG_FILE} COMPONENT Development)


### PR DESCRIPTION
Before this change, icub-main polluted the CMake cache of all
the downstream projects with fake "options" such as ICUB_USE_GSL,
ICUB_USE_OpenCV, etc . This flags appeared as editable options in ccmake
or cmake-gui of the downstream projects, causing confusion among the users.

With this change the dependency flags are still exposed to the downstream
projects, but without polluting the cache, as done in YARP
(see https://github.com/robotology/yarp/blob/6598fc3d643b334b1afd312acf4734c5d3eb8d1e/conf/template/YARPConfig.cmake.in#L89 )
An additional unset(ICUB_USE_**) is added to clean the existing caches of downstream projects.