### PR TITLE
Include Value.h after yarp commit removing Value.h from Bottle.h

### DIFF
--- a/src/libraries/icubmod/cfw2Can/Cfw2Can.cpp
+++ b/src/libraries/icubmod/cfw2Can/Cfw2Can.cpp
@@ -13,6 +13,7 @@
 #include "libcfw002.h"
 #include <yarp/dev/CanBusInterface.h>
 #include <yarp/os/Bottle.h>
+#include <yarp/os/Value.h>
 #include "Cfw2Can.h"
 
 using namespace yarp::dev;

--- a/src/libraries/icubmod/dragonfly2/linux/FirewireCameraDC1394-DR2_2.h
+++ b/src/libraries/icubmod/dragonfly2/linux/FirewireCameraDC1394-DR2_2.h
@@ -28,6 +28,7 @@
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/os/Value.h>
 
 #define NUM_DMA_BUFFERS 4
 


### PR DESCRIPTION
These changes have been made in response to issue #268. As indicated by @traversaro the bug is the result of `yarp` commit https://github.com/robotology/yarp/commit/31bdd9ab4f8cc9a2e0e9089afffdfc67b6159f69 

It is totally possible that other files that compile only on the pc104 may be affected by this change in `yarp` but I have no way of testing this.