### PR TITLE
[cmake] Do not pollute cache of downstream projects part 2

### DIFF
--- a/conf/iCubExportBuildTree.cmake
+++ b/conf/iCubExportBuildTree.cmake
@@ -1,29 +1,29 @@
 # Copyright: (C) 2010 RobotCub Consortium
 # Authors: Lorenzo Natale
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
-# 
-# Code to export the project build tree. Note this is similar to the code 
+#
+# Code to export the project build tree. Note this is similar to the code
 # that export the installed project but is also different in important aspects.
 # For this reason the code is more complicated and produces separate files.
 #
-# This produces a file called icub-config.cmake in ${CMAKE_BINARY_DIR} that 
+# This produces a file called icub-config.cmake in ${CMAKE_BINARY_DIR} that
 # other projects should execute (with find_package) to use the project.
 #
-# This files assumes that each target you want to export has previously 
+# This files assumes that each target you want to export has previously
 # called icub_export_library.
 #
-# Files: 
-# EXPORT_INCLUDE_FILE: this file contains a list of all the targets in the 
-# build, and a corresponding include directories. This is generated from 
-# information in each target that is listed in the property ICUB_TARGETS. For each 
+# Files:
+# EXPORT_INCLUDE_FILE: this file contains a list of all the targets in the
+# build, and a corresponding include directories. This is generated from
+# information in each target that is listed in the property ICUB_TARGETS. For each
 # target get property INCLUDE_DIRS. The list ICUB_TARGETS is populated
-# by each target by calling icub_export_library in iCubHelpers.cmake. The same 
-# function created a given target the property INCLUDE_DIRS that contains the list 
+# by each target by calling icub_export_library in iCubHelpers.cmake. The same
+# function created a given target the property INCLUDE_DIRS that contains the list
 # of include directories required by the target.
-# 
+#
 # EXPORT_CONFIG_FILE: in build directory, store libraries and dependenecies
 # automatically generated with CMake export command.
-# 
+#
 # BUILD_CONFIG_TEMPLATE: template for the real config file (icub-config.cmake)
 # that exports the build tree
 #
@@ -41,11 +41,12 @@ file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "# This file is automatic
 file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "###################\n")
 file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "# List of include directories for exported targets\n\n")
 set(include_dirs "")
-foreach (t ${ICUB_TARGETS})  
+foreach (t ${ICUB_TARGETS})
     get_property(target_INCLUDE_DIRS TARGET ${t} PROPERTY INCLUDE_DIRS)
     #some targets do not export include directory
     if (target_INCLUDE_DIRS)
-        file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(${t}_INCLUDE_DIRS \"${target_INCLUDE_DIRS}\" CACHE STRING \"include dir for target ${t}\")\n")
+        file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "unset(${t}_INCLUDE_DIRS CACHE)\n")
+        file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(${t}_INCLUDE_DIRS \"${target_INCLUDE_DIRS}\")\n")
         set(include_dirs ${include_dirs} ${target_INCLUDE_DIRS})
     endif()
 endforeach(t)
@@ -55,11 +56,11 @@ list(REMOVE_DUPLICATES include_dirs)
 #message(STATUS "Header files global directory: ${include_dirs}")
 file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(ICUB_INCLUDE_DIRS \"${include_dirs}\" CACHE STRING \"list of include directories, all exported targets\")\n\n")
 
-### now write to file the list of dependencies with which iCub was compiled 
+### now write to file the list of dependencies with which iCub was compiled
 get_property(dependency_flags GLOBAL PROPERTY ICUB_DEPENDENCIES_FLAGS)
 foreach (t ${dependency_flags})
-		file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "unset(${t} CACHE)\n")
-		file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(${t} \"${${t}}\")\n")
+    file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "unset(${t} CACHE)\n")
+    file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(${t} \"${${t}}\")\n")
 endforeach()
 
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/${BUILD_CONFIG_TEMPLATE}

--- a/conf/iCubExportForInstall.cmake
+++ b/conf/iCubExportForInstall.cmake
@@ -1,22 +1,22 @@
 # Copyright: (C) 2010 RobotCub Consortium
 # Authors: Lorenzo Natale
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
-# 
+#
 # Code to export the installd project
-# 
-# Files: 
+#
+# Files:
 # EXPORT_CONFIG_FILE: in build directory, store libraries and dependenecies
 # automatically generated with CMake export command.
 # EXPORT_INCLUDE_FILE: in build directory, store include directories for each library,
 # this is installed in CMAKE_INSTALL_PREFIX
-# INSTALL_CONFIG_FILE: tmp file, it is generated from a template and will 
+# INSTALL_CONFIG_FILE: tmp file, it is generated from a template and will
 # become the real icub-config.cmake that is installed in CMAKE_INSTALL_PREFIX
 # INSTALL_CONFIG_TEMPLATE: INSTALL_CONFIG_FILE template
 #
-# In the template the variable $ICUB_INCLUDE_DIRS is substituted with the 
+# In the template the variable $ICUB_INCLUDE_DIRS is substituted with the
 # correct value which is a combination of:
-# - ${CMAKE_INSTALL_PREFIX}/include (this is the general include directory where header files 
-# are installed 
+# - ${CMAKE_INSTALL_PREFIX}/include (this is the general include directory where header files
+# are installed
 # - a list of external directories, as specified in the target's EXTERNAL_INCLUDE_DIRS property
 # set in icub_export_library inside iCubHelpers.cmake
 #
@@ -43,16 +43,17 @@ file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "# List of include direct
 set(include_dirs "")
 foreach (t ${ICUB_TARGETS})
   get_property(target_INCLUDE_DIRS TARGET ${t} PROPERTY EXTERNAL_INCLUDE_DIRS)
-  set(include_dirs ${include_dirs} ${target_INCLUDE_DIRS}) 
+  set(include_dirs ${include_dirs} ${target_INCLUDE_DIRS})
 
   if (ICUB_VERBOSE)
 	message(STATUS "Header files for ${t}: ${target_INCLUDE_DIRS}")
   endif()
 
+  file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "unset(${t}_INCLUDE_DIRS CACHE)\n")
   if (target_INCLUDE_DIRS)
-      file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(${t}_INCLUDE_DIRS \"${CMAKE_INSTALL_PREFIX}/include\" \"${target_INCLUDE_DIRS}\" CACHE STRING \"include dir for target ${t}\")\n")
+      file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(${t}_INCLUDE_DIRS \"${CMAKE_INSTALL_PREFIX}/include\" \"${target_INCLUDE_DIRS}\")\n")
   else()
-      file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(${t}_INCLUDE_DIRS \"${CMAKE_INSTALL_PREFIX}/include\" CACHE STRING \"include dir for target ${t}\")\n")
+      file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(${t}_INCLUDE_DIRS \"${CMAKE_INSTALL_PREFIX}/include\")\n")
  endif()
 endforeach(t)
 
@@ -65,7 +66,7 @@ file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "set(ICUB_INCLUDE_DIRS \"
 
 #message(STATUS "Header files global directory: ${ICUB_INCLUDE_DIRS}")
 
-### now write to file the list of dependencies with which iCub was compiled 
+### now write to file the list of dependencies with which iCub was compiled
 get_property(dependency_flags GLOBAL PROPERTY ICUB_DEPENDENCIES_FLAGS)
 foreach (t ${dependency_flags})
 		file(APPEND ${CMAKE_BINARY_DIR}/${EXPORT_INCLUDE_FILE} "unset(${t} CACHE)\n")


### PR DESCRIPTION
I noticed that the include_DIRS were still polluting the cmake cache.

Some trailing whitespace cleaning done in the meanwhile, PR without whitespaces changes available at `https://github.com/robotology/icub-main/pull/280?w=1` .

Just a duplication of https://github.com/robotology/icub-main/pull/267 , if nobody has nothing to comment I will merge it this evening. 
