### PR TITLE
Dual calib dual image

### DIFF
--- a/src/modules/dualCamCalib/include/iCub/DualCamCalibModule.h
+++ b/src/modules/dualCamCalib/include/iCub/DualCamCalibModule.h
@@ -35,6 +35,13 @@ private:
       ALIGN_HEIGHT=1
     } align;
 
+    // dualImage_mode: if true, the input port will read a single image with both frames together, left one
+    // on the left side, right one on the right side. In this case imageInLeft port will read the frame and the right
+    // port will be inactive.
+    bool dualImage_mode;
+    yarp::sig::ImageOf<yarp::sig::PixelRgb>* leftImage;
+    yarp::sig::ImageOf<yarp::sig::PixelRgb>* rightImage;
+
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > imageInLeft;
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > imageInRight;
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > imageOut;

--- a/src/modules/dualCamCalib/src/DualCamCalibModule.cpp
+++ b/src/modules/dualCamCalib/src/DualCamCalibModule.cpp
@@ -5,6 +5,7 @@
 // CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
 #include <iCub/DualCamCalibModule.h>
+#include <yarp/os/Network.h>
 
 using namespace std;
 using namespace yarp::os;
@@ -17,11 +18,13 @@ CamCalibModule::CamCalibModule()
     align=ALIGN_WIDTH;
     requested_fps=0;
     time_lastOut=yarp::os::Time::now();
+    dualImage_mode = false;
 }
 
 CamCalibModule::~CamCalibModule()
 {
-
+    calibToolLeft = NULL;
+    calibToolRight = NULL;
 }
 
 bool CamCalibModule::configure(yarp::os::ResourceFinder &rf)
@@ -100,14 +103,42 @@ bool CamCalibModule::configure(yarp::os::ResourceFinder &rf)
         }
     }
 
-    if (yarp::os::Network::exists(getName("/left:i")))
+    if(rf.check("dual"))
     {
-        yWarning() << "port " << getName("/left:i") << " already in use";
+        dualImage_mode = true;
+        yInfo() << "Dual mode activate!!";
     }
-    if (yarp::os::Network::exists(getName("/right:i")))
+
+    if(dualImage_mode)
     {
-        yWarning() << "port " << getName("/right:i") << " already in use";
+        leftImage  = new yarp::sig::ImageOf<yarp::sig::PixelRgb>;
+        rightImage = new yarp::sig::ImageOf<yarp::sig::PixelRgb>;
+
+        // open a single port with name /dual:i
+        if (yarp::os::Network::exists(getName("/dual:i")))
+        {
+            yWarning() << "port " << getName("/dual:i") << " already in use";
+        }
+        if(! imageInLeft.open(getName("/dual:i")) )
+            return false;
+        imageInLeft.setStrict(false);
     }
+    else
+    {
+        if (yarp::os::Network::exists(getName("/left:i")))
+        {
+            yWarning() << "port " << getName("/left:i") << " already in use";
+        }
+        if (yarp::os::Network::exists(getName("/right:i")))
+        {
+            yWarning() << "port " << getName("/right:i") << " already in use";
+        }
+        imageInLeft.open(getName("/left:i"));
+        imageInRight.open(getName("/right:i"));
+        imageInLeft.setStrict(false);
+        imageInRight.setStrict(false);
+    }
+
     if (yarp::os::Network::exists(getName("/out")))
     {
         yWarning() << "port " << getName("/out") << " already in use";
@@ -116,23 +147,18 @@ bool CamCalibModule::configure(yarp::os::ResourceFinder &rf)
     {
         yWarning() << "port " << getName("/conf") << " already in use";
     }
-    imageInLeft.open(getName("/left:i"));
-    imageInRight.open(getName("/right:i"));
-    imageInLeft.setStrict(false);
-    imageInRight.setStrict(false);
-
-    imageOut.open(getName("/out"));
-
+    imageOut.open(getName("/out:o"));
     configPort.open(getName("/conf"));
     attach(configPort);
-
     return true;
 }
 
 bool CamCalibModule::close()
 {
+    yTrace();
     imageInLeft.close();
-    imageInRight.close();
+    if(!dualImage_mode)
+        imageInRight.close();
     imageOut.close();
     configPort.close();
     if (calibToolLeft != NULL)
@@ -152,8 +178,10 @@ bool CamCalibModule::close()
 
 bool CamCalibModule::interruptModule()
 {
+    yTrace();
     imageInLeft.interrupt();
-    imageInRight.interrupt();
+    if(!dualImage_mode)
+        imageInRight.interrupt();
     imageOut.interrupt();
     configPort.interrupt();
     return true;
@@ -164,21 +192,70 @@ bool CamCalibModule::updateModule()
     bool lready=false;
     bool rready=false;
     bool init=false;
+
+    int dual_rowsize_pixels, dual_height_pixels, single_rowsize_pixels;
+    int dual_rowsize_bytes,  single_rowsize_bytes;
+
+    int outw = 0;
+    int outh = 0;
+
+    unsigned char *left_raw, *right_raw, *dual_raw;
+
+    std::cout << "Ciaut" << std::endl;
     while(1)
     {
-        yarp::sig::ImageOf<yarp::sig::PixelRgb>* left  = imageInLeft.read(false);
-        yarp::sig::ImageOf<yarp::sig::PixelRgb>* right = imageInRight.read(false);
+        if(dualImage_mode)
+        {
+            // read the dual image and split it up into 2 separated images for calibration
+            yarp::sig::ImageOf<yarp::sig::PixelRgb>* dual = imageInLeft.read(false);
+            if(dual == NULL)
+            {
+                yarp::os::Time::delay(0.001);
+                continue;
+            }
+
+            dual_rowsize_pixels = dual->width();
+            single_rowsize_pixels = dual_rowsize_pixels/2;
+            dual_height_pixels = dual->height();
+
+            dual_rowsize_bytes = dual->getRowSize();
+            single_rowsize_bytes = dual_rowsize_bytes/2;
+
+            leftImage->resize(dual_rowsize_pixels/2, dual_height_pixels);
+            rightImage->resize(dual_rowsize_pixels/2, dual_height_pixels);
+
+            leftImage->setQuantum(dual->getQuantum());
+            rightImage->setQuantum(dual->getQuantum());
+
+            left_raw  = leftImage->getRawImage();
+            right_raw = rightImage->getRawImage();
+            dual_raw  = dual->getRawImage();
+
+            std::cout << "dual row size: " << dual->width() << std::endl;
+            std::cout << "left row size: " << leftImage->width() << std::endl;
+
+            for(int h=0; h<dual_height_pixels; h++)
+            {
+                memcpy(left_raw+(h*single_rowsize_bytes),  dual_raw+(h*dual_rowsize_bytes),                         single_rowsize_bytes);
+                memcpy(right_raw+(h*single_rowsize_bytes), dual_raw+(h*dual_rowsize_bytes) + single_rowsize_bytes,  single_rowsize_bytes);
+            }
+        }
+        else
+        {
+            leftImage  = imageInLeft.read(false);
+            rightImage = imageInRight.read(false);
+        }
+
         yarp::sig::ImageOf<yarp::sig::PixelRgb> &calibratedImgOut=imageOut.prepare();
 
-        if (calibToolLeft!=NULL && left!=NULL)
+        if (calibToolLeft!=NULL && leftImage!=NULL)
         {
-            calibToolLeft->apply(*left,calibratedImgLeft);
+            calibToolLeft->apply(*leftImage,calibratedImgLeft);
             lready=true;
+
 
             if (init==false)
             {
-                int outw = 0;
-                int outh = 0;
                 if (align == ALIGN_WIDTH)
                 {
                     outw = calibratedImgLeft.width()*2;
@@ -200,6 +277,7 @@ bool CamCalibModule::updateModule()
                 init=true;
             }
 
+            calibratedImgOut.resize(outw, outh);
             for (int r=0; r<calibratedImgLeft.height(); r++)
             for (int c=0; c<calibratedImgLeft.width(); c++)
             {
@@ -211,9 +289,9 @@ bool CamCalibModule::updateModule()
             }
 
         }
-        if (calibToolRight!=NULL && right!=NULL)
+        if (calibToolRight!=NULL && rightImage!=NULL)
         {
-            calibToolRight->apply(*right,calibratedImgRight);
+            calibToolRight->apply(*rightImage,calibratedImgRight);
             rready=true;
 
             if (init==false)

--- a/src/modules/dualCamCalib/src/DualCamCalibModule.cpp
+++ b/src/modules/dualCamCalib/src/DualCamCalibModule.cpp
@@ -200,16 +200,14 @@ bool CamCalibModule::updateModule()
 
     unsigned char *left_raw, *right_raw, *dual_raw;
 
-    while(1)
-    {
         if(dualImage_mode)
         {
             // read the dual image and split it up into 2 separated images for calibration
-            yarp::sig::ImageOf<yarp::sig::PixelRgb>* dual = imageInLeft.read(false);
+            yarp::sig::ImageOf<yarp::sig::PixelRgb>* dual = imageInLeft.read();
             if(dual == NULL)
             {
                 yarp::os::Time::delay(0.001);
-                continue;
+                return true;
             }
 
             dual_rowsize_pixels = dual->width();
@@ -248,7 +246,6 @@ bool CamCalibModule::updateModule()
             calibToolLeft->apply(*leftImage,calibratedImgLeft);
             lready=true;
 
-
             if (init==false)
             {
                 if (align == ALIGN_WIDTH)
@@ -274,7 +271,7 @@ bool CamCalibModule::updateModule()
             for (int c=0; c<calibratedImgLeft.width(); c++)
             {
                 unsigned char *pixel = calibratedImgOut.getPixelAddress(c,r);
-                
+
                 pixel[0] = *(calibratedImgLeft.getPixelAddress(c,r)+0);
                 pixel[1] = *(calibratedImgLeft.getPixelAddress(c,r)+1);
                 pixel[2] = *(calibratedImgLeft.getPixelAddress(c,r)+2);
@@ -347,8 +344,6 @@ bool CamCalibModule::updateModule()
             }
         }
 
-        yarp::os::Time::delay(0.001);
-    }
     return true;
 }
 

--- a/src/modules/dualCamCalib/src/DualCamCalibModule.cpp
+++ b/src/modules/dualCamCalib/src/DualCamCalibModule.cpp
@@ -178,7 +178,6 @@ bool CamCalibModule::close()
 
 bool CamCalibModule::interruptModule()
 {
-    yTrace();
     imageInLeft.interrupt();
     if(!dualImage_mode)
         imageInRight.interrupt();
@@ -201,7 +200,6 @@ bool CamCalibModule::updateModule()
 
     unsigned char *left_raw, *right_raw, *dual_raw;
 
-    std::cout << "Ciaut" << std::endl;
     while(1)
     {
         if(dualImage_mode)
@@ -230,9 +228,6 @@ bool CamCalibModule::updateModule()
             left_raw  = leftImage->getRawImage();
             right_raw = rightImage->getRawImage();
             dual_raw  = dual->getRawImage();
-
-            std::cout << "dual row size: " << dual->width() << std::endl;
-            std::cout << "left row size: " << leftImage->width() << std::endl;
 
             for(int h=0; h<dual_height_pixels; h++)
             {
@@ -271,9 +266,6 @@ bool CamCalibModule::updateModule()
                     yError() << "Invalid alignment";
                 }
                 calibratedImgOut.copy(calibratedImgLeft,outw,outh);
-                yDebug() << "created output buffer from left input, size: " << outw << "x" << outh;
-                yDebug() << calibratedImgOut.width();
-                yDebug() << calibratedImgOut.height();
                 init=true;
             }
 
@@ -313,9 +305,6 @@ bool CamCalibModule::updateModule()
                     yError() << "Invalid alignment";
                 }
                 calibratedImgOut.copy(calibratedImgRight,outw,outh);
-                yDebug() << "created output buffer from right input, size: " << outw << "x" << outh;
-                yDebug() << calibratedImgOut.width();
-                yDebug() << calibratedImgOut.height();
                 init=true;
             }
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(simpleClient)
 add_subdirectory(testStereoMatch)
 add_subdirectory(fingersTuner)
 add_subdirectory(imuFilter)
+add_subdirectory(imageSplitter)
 add_subdirectory(trajectoryPlayer)
 add_subdirectory(embObjProtoTools/boardTransceiver)
 

--- a/src/tools/imageSplitter/CMakeLists.txt
+++ b/src/tools/imageSplitter/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright: (C) 2012 RobotCub Consortium
+# Authors: Sean Ryan Fanello
+# CopyPolicy: Released under the terms of the GNU GPL v2.0.
+set(PROJECTNAME imageSplitter)
+
+set(source src/main.cpp src/imageSplitter.cpp)
+set(header include/imageSplitter.h)
+
+source_group("Source Files" FILES ${source})
+source_group("Header Files" FILES ${header})
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${YARP_INCLUDE_DIRS})
+
+add_executable(${PROJECTNAME} ${source} ${header})
+target_link_libraries(${PROJECTNAME} ${YARP_LIBRARIES})
+install(TARGETS ${PROJECTNAME} DESTINATION bin)
+

--- a/src/tools/imageSplitter/include/imageSplitter.h
+++ b/src/tools/imageSplitter/include/imageSplitter.h
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 Istituto Italiano di Tecnologia - iCub Facility
+// Author: Alberto Cardellino <alberto.cardellino@iit.it>
+// CopyPolicy: Released under the terms of the GNU GPL v2.0.
+
+#include <iostream>
+#include <string>
+#include <yarp/sig/all.h>
+#include <yarp/os/all.h>
+#include <yarp/os/RFModule.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/Thread.h>
+#include <yarp/sig/Image.h>
+#include <yarp/os/BufferedPort.h>
+
+#ifndef ICUB_TOOLS_IMAGE_SPLITTER_H
+#define ICUB_TOOLS_IMAGE_SPLITTER_H
+
+
+class ImageSplitter: public yarp::os::RFModule
+{
+private:
+    int method;  // tmp, just for testing different methods of filling the output images
+    bool horizontal;
+
+    yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > inputPort;
+    yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > outLeftPort;
+    yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > outRightPort;
+
+    int inWidth, inHeight;
+    int outWidth, outHeight;
+
+public:
+    ImageSplitter();
+    ~ImageSplitter();
+    bool configure(yarp::os::ResourceFinder &rf);
+    bool interruptModule();                       
+    bool close();                                 
+    bool updateModule();
+    double getPeriod(); 
+};
+
+#endif  // ICUB_TOOLS_IMAGE_SPLITTER_H

--- a/src/tools/imageSplitter/src/imageSplitter.cpp
+++ b/src/tools/imageSplitter/src/imageSplitter.cpp
@@ -1,0 +1,306 @@
+// Copyright (C) 2016 Istituto Italiano di Tecnologia - iCub Facility
+// Author: Alberto Cardellino <alberto.cardellino@iit.it>
+// CopyPolicy: Released under the terms of the GNU GPL v2.0.
+
+#include <yarp/os/Os.h>
+#include <yarp/os/Time.h>
+#include <yarp/os/LogStream.h>
+
+#include <imageSplitter.h>
+
+using namespace std;
+using namespace yarp::os;
+using namespace yarp::sig;
+
+ImageSplitter::ImageSplitter()
+{
+    horizontal = true;
+    method = 2;
+}
+
+ImageSplitter::~ImageSplitter()
+{
+    horizontal = true;
+    method = 2;
+}
+
+bool ImageSplitter::configure(yarp::os::ResourceFinder &rf)
+{
+    // Check input parameters
+    if(rf.check("align"))
+    {
+        yarp::os::ConstString align = rf.find("align").asString();
+        if(align == "vertical")
+        {
+            horizontal = false;
+        }
+        else if(align == "horizontal")
+        {
+            horizontal = true;
+        }
+        else
+        {
+            yError() << " Incorrect parameter. Supported values for alignment are 'horizontal' or 'vertical'";
+            return false;
+        }
+    }
+
+    yarp::os::ConstString inputPortName    = "/imageSplitter/input:i";
+    yarp::os::ConstString outLeftPortName  = "/imageSplitter/left:o";
+    yarp::os::ConstString outRightPortName = "/imageSplitter/right:o";
+
+    if(rf.check("nameLeft"))
+    {
+        outLeftPortName = rf.find("nameLeft").asString();
+    }
+
+    if(rf.check("nameRight"))
+    {
+        outLeftPortName = rf.find("nameRight").asString();
+    }
+
+    if(!rf.check("remote"))
+    {
+        yError() << "Missing 'remote' parameter. Please insert the name of the port to connect to.";
+        return false;
+    }
+
+    yarp::os::ConstString remotePortName = rf.find("remote").asString();
+
+    // opening ports
+    bool ret=true;
+    ret &= inputPort.open(inputPortName);
+    ret &= outLeftPort.open(outLeftPortName);
+    ret &= outRightPort.open(outRightPortName);
+
+    if(!ret)
+    {
+        yError() << " Cannot open ports";
+        return false;
+    }
+
+    // Connections
+    if(! yarp::os::Network::connect(remotePortName, inputPortName))
+    {
+        yError() << "Cannot connect to remote port " << remotePortName;
+        return false;
+    }
+
+    // choose filling method
+    if(rf.check("m"))
+    {
+        yarp::os::ConstString align = rf.find("m").asString();
+        if(align == "pixel")
+        {
+            method = 0;
+        }
+        else if(align == "pixel2")
+        {
+            method = 1;
+        }
+        else if(align == "line")
+        {
+            method = 2;
+        }
+        else if(align == "whole")
+        {
+            if(horizontal)
+                yError() << "Cannot use 'whole' method for input image horizontally aligned";
+            method = 3;
+        }
+        else
+        {
+            yError() << "Methods are pixel, line, whole; got " << align;
+            return false;
+        }
+    }
+
+    yInfo() << "using method " << method;
+    return true;
+}
+
+bool ImageSplitter::interruptModule()
+{
+
+    return true;
+}
+
+bool ImageSplitter::close()
+{
+    return true;
+}
+
+bool ImageSplitter::updateModule()
+{
+    ImageOf<PixelRgb> *inputImage    = inputPort.read();
+    ImageOf<PixelRgb> &outLeftImage  = outLeftPort.prepare();
+    ImageOf<PixelRgb> &outRightImage = outRightPort.prepare();
+
+    inWidth  = inputImage->width();
+    inHeight = inputImage->height();
+
+    if(horizontal)  // input image is horizontally aligned
+    {
+        outWidth  = inWidth/2;
+        outHeight = inHeight;
+    }
+    else
+    {
+        outWidth  = inWidth;
+        outHeight = inHeight/2;
+    }
+
+    outLeftImage.setQuantum(inputImage->getQuantum());
+    outRightImage.setQuantum(inputImage->getQuantum());
+    outLeftImage.resize(outWidth, outHeight);
+    outRightImage.resize(outWidth, outHeight);
+
+    // alloc and compute some vars for efficency
+    int w2;
+    unsigned char *pixelLeft, *pixelRight;
+    unsigned char *pixelInputL, *pixelInputR;
+    unsigned char *pixelInput = inputImage->getRawImage();
+    int dualImage_rowSizeByte = inputImage->getRowSize();
+    int singleImage_rowSizeByte = outLeftImage.getRowSize();
+    int singleImage_wholeSizeByte = outWidth * outHeight * outLeftImage.getPixelSize();
+
+    static int counter = 0;
+    static double start = 0;
+    start = yarp::os::Time::now();
+
+    switch(method)
+    {
+        case 0: // pixel by pixel
+        {
+            if(horizontal)
+            {
+                for(int h=0; h<inHeight; h++)
+                {
+                    for(int w1=0; w1<outWidth; w1++)
+                    {
+                        w2 = w1+outWidth;
+                        pixelLeft = outLeftImage.getPixelAddress(w1, h);
+                        pixelLeft[0] = *(inputImage->getPixelAddress(w1, h)+0);
+                        pixelLeft[1] = *(inputImage->getPixelAddress(w1, h)+1);
+                        pixelLeft[2] = *(inputImage->getPixelAddress(w1, h)+2);
+
+                        pixelRight = outRightImage.getPixelAddress(w1, h);
+                        pixelRight[0] = *(inputImage->getPixelAddress(w2, h)+0);
+                        pixelRight[1] = *(inputImage->getPixelAddress(w2, h)+1);
+                        pixelRight[2] = *(inputImage->getPixelAddress(w2, h)+2);
+                    }
+                }
+            }
+            else
+            {
+
+            }
+        } break;
+
+        case 1: // pixel by pixel, a bit better
+        {
+            if(horizontal)
+            {
+                pixelLeft  = outLeftImage.getRawImage();
+                pixelRight = outRightImage.getRawImage();
+
+                pixelInputL = pixelInput;
+                pixelInputR = pixelInput+singleImage_rowSizeByte;
+                for(int h=0, idx=0, idx2=0; h<outHeight; h++)
+                {
+                    for(int w=0; w<outWidth; w++)
+                    {
+                        pixelLeft[idx++] = *(pixelInputL++);
+                        pixelLeft[idx++] = *(pixelInputL++);
+                        pixelLeft[idx++] = *(pixelInputL++);
+
+                        pixelRight[idx2++] = *(pixelInputR++);
+                        pixelRight[idx2++] = *(pixelInputR++);
+                        pixelRight[idx2++] = *(pixelInputR++);
+                    }
+                    pixelInputL += singleImage_rowSizeByte;
+                    pixelInputR += singleImage_rowSizeByte;
+                }
+            }
+            else
+            {
+
+            }
+        } break;
+
+        case 2: // line by line
+        {
+            if(horizontal)
+            {
+                pixelLeft  = outLeftImage.getRawImage();
+                pixelRight = outRightImage.getRawImage();
+
+                for(int h=0; h<inHeight; h++)
+                {
+                    memcpy(pixelLeft  + h*singleImage_rowSizeByte, pixelInput,                          singleImage_rowSizeByte);
+                    memcpy(pixelRight + h*singleImage_rowSizeByte, pixelInput+=singleImage_rowSizeByte, singleImage_rowSizeByte);
+                    pixelInput+= dualImage_rowSizeByte/2;
+                }
+            }
+            else
+            {
+                pixelLeft  = outLeftImage.getRawImage();
+                pixelRight = outRightImage.getRawImage();
+                pixelInputL = pixelInput;
+                pixelInputR = pixelInput+singleImage_wholeSizeByte;
+
+                for(int h=0; h<outHeight; h++)
+                {
+                    memcpy(pixelLeft  + h*singleImage_rowSizeByte, pixelInputL, singleImage_rowSizeByte);
+                    memcpy(pixelRight + h*singleImage_rowSizeByte, pixelInputR, singleImage_rowSizeByte);
+                    pixelInputL+= singleImage_rowSizeByte;
+                    pixelInputR+= singleImage_rowSizeByte;
+                }
+            }
+        } break;
+
+        case 3: // whole image, only if input image is vertically aligned
+        {
+            if(horizontal)
+            {
+                yError() << "Cannot use this copy method with horizontally aligned source image.";
+            }
+            else
+            {
+                pixelLeft  = outLeftImage.getRawImage();
+                pixelRight = outRightImage.getRawImage();
+
+                memcpy(pixelLeft,  pixelInput,                            singleImage_wholeSizeByte);
+                memcpy(pixelRight, pixelInput+ singleImage_wholeSizeByte, singleImage_wholeSizeByte);
+            }
+        } break;
+
+        default:
+        {
+            yError() << " @line " << __LINE__ << "unhandled switch case, we should not be here!";
+        }
+    }
+
+    static double end = 0;
+    static double elapsed = 0;
+    end = yarp::os::Time::now();
+    elapsed += (end-start);
+
+    counter++;
+    if((counter % 100) == 0)
+    {
+        yInfo() << "Elapsed time: " << elapsed;
+        elapsed = 0;
+    }
+
+    outLeftPort.write();
+    outRightPort.write();
+    return true;
+}
+
+
+double ImageSplitter::getPeriod()
+{    
+   return 0.1;
+}
+

--- a/src/tools/imageSplitter/src/imageSplitter.cpp
+++ b/src/tools/imageSplitter/src/imageSplitter.cpp
@@ -156,7 +156,7 @@ bool ImageSplitter::updateModule()
     outRightImage.resize(outWidth, outHeight);
 
     // alloc and compute some vars for efficency
-    int w2;
+    int h2, w2;
     unsigned char *pixelLeft, *pixelRight;
     unsigned char *pixelInputL, *pixelInputR;
     unsigned char *pixelInput = inputImage->getRawImage();
@@ -174,7 +174,7 @@ bool ImageSplitter::updateModule()
         {
             if(horizontal)
             {
-                for(int h=0; h<inHeight; h++)
+                for(int h=0; h<outHeight; h++)
                 {
                     for(int w1=0; w1<outWidth; w1++)
                     {
@@ -193,7 +193,22 @@ bool ImageSplitter::updateModule()
             }
             else
             {
+                for(int h1=0; h1<outHeight; h1++)
+                {
+                    for(int w=0; w<outWidth; w++)
+                    {
+                        h2 = h1+outHeight;
+                        pixelLeft = outLeftImage.getPixelAddress(w, h1);
+                        pixelLeft[0] = *(inputImage->getPixelAddress(w, h1)+0);
+                        pixelLeft[1] = *(inputImage->getPixelAddress(w, h1)+1);
+                        pixelLeft[2] = *(inputImage->getPixelAddress(w, h1)+2);
 
+                        pixelRight = outRightImage.getPixelAddress(w, h1);
+                        pixelRight[0] = *(inputImage->getPixelAddress(w, h2)+0);
+                        pixelRight[1] = *(inputImage->getPixelAddress(w, h2)+1);
+                        pixelRight[2] = *(inputImage->getPixelAddress(w, h2)+2);
+                    }
+                }
             }
         } break;
 

--- a/src/tools/imageSplitter/src/main.cpp
+++ b/src/tools/imageSplitter/src/main.cpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 Istituto Italiano di Tecnologia - iCub Facility
+// Author: Alberto Cardellino <alberto.cardellino@iit.it>
+// CopyPolicy: Released under the terms of the GNU GPL v2.0.
+
+/**
+@ingroup icub_tools
+
+Split a single image with 2 frames in it into 2 images left/right
+
+Parameters
+\code
+  align horizontal / vertical  :  input images are coupled on the horizontal / vertical way  -- default horizontal
+\endcode
+*/ 
+
+#include <yarp/dev/Drivers.h>
+#include <imageSplitter.h>
+
+
+int main(int argc, char * argv[])
+{
+   yarp::os::Network yarp;
+   ImageSplitter imageSplitter;
+   yarp::os::ResourceFinder rf;
+   rf.setVerbose(true);
+   rf.configure(argc, argv);
+
+   imageSplitter.runModule(rf);
+   return 0;
+}


### PR DESCRIPTION
Modified dualCamCalib to accept a dual image as an input (also fix a segfault).
Add imageSplitter module to split a dual image (either verically or horizontally aligned) into left and right single frames.