### PR TITLE
[iCubLisboa01]: right hand thumb opposition (j8) calibration

### DIFF
--- a/app/robots/iCubLisboa01/calibrators/right_hand_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/right_hand_calib.xml
@@ -12,11 +12,11 @@
 <group name="CALIBRATION">   
  
 <param name="calibrationType">            3             4             4             4             4             4             4             4             </param>       
-<param name="calibration1">               1710.00       238.00        60.00         238.00        105.00        242.00        20.00         705.00        </param>       
+<param name="calibration1">               2888.89       238.00        60.00         238.00        105.00        242.00        20.00         705.00        </param>       
 <param name="calibration2">               10.00         10.00         30.00         10.00         10.00         10.00         10.00         10.00         </param>       
 <param name="calibration3">               0.00          6000.00       8000.00       6000.00       -7400.00      6000.00       7400.00       14000.00      </param>       
 <param name="positionZero">               30            3             0             0             0             0             0             0             </param>       
-<param name="velocityZero">               100           100           100           100           100           100           100           100           </param>       
+<param name="velocityZero">               20            100           100           100           100           100           100           100           </param>       
 <param name="maxPwm">                     0             0             0             0             0             0             0             0             </param>       
 <param name="posZeroThreshold">           90            90            90            90            90            90            90            90            </param>       
 </group>       

--- a/app/robots/iCubLisboa01/hardware/motorControl/icub_right_hand.xml
+++ b/app/robots/iCubLisboa01/hardware/motorControl/icub_right_hand.xml
@@ -33,8 +33,8 @@
 <param name="AxisMap">      0             1             2             3             4             5             6             7             </param>       
 <param name="AxisName"> "r_thumb_oppose" "r_thumb_proximal" "r_thumb_distal" "r_index_proximal" "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky" </param>
 <param name="AxisType"> "revolute" "revolute" "revolute" "revolute" "revolute" "revolute" "revolute" "revolute" </param>
-<param name="Encoder">      8.00          -2.42         -2.42         -2.53         -2.08         -2.52         -2.39         -2.30         </param>       
-<param name="Zeros">        203.75        -98.26        -204.83       -93.95        -230.40       -95.95        -188.37       -306.52       </param>       
+<param name="Encoder">      -11.111       -2.42         -2.42         -2.53         -2.08         -2.52         -2.39         -2.30         </param>       
+<param name="Zeros">        -270.00       -98.26        -204.83       -93.95        -230.40       -95.95        -188.37       -306.52       </param>       
 <param name="TorqueId">     0             0             0             0             0             0             0             0             </param>       
 <param name="TorqueChan">   0             0             0             0             0             0             0             0             </param>       
 <param name="TorqueMax">    0             0             0             0             0             0             0             0             </param>       
@@ -60,9 +60,9 @@
 </group>       
  
 <group name="POS_PIDS">      
-<param name="kp">           -8000         -8000         8000          -8000         -8000         -8000         8000          -120          </param>       
-<param name="kd">           -32000        -32000        32000         -32000        -32000        -32000        32000         -1250         </param>       
-<param name="ki">           -5            -5            5             -5            -5            -5            5             0             </param>       
+<param name="kp">           10000         -8000         8000          -8000         -8000         -8000         8000          -120          </param>       
+<param name="kd">           32000         -32000        32000         -32000        -32000        -32000        32000         -1250         </param>       
+<param name="ki">           5             -5            5             -5            -5            -5            5             0             </param>       
 <param name="maxOutput">       1333          1333          1333          1333          1333          1333          1333          1333          </param>       
 <param name="maxInt">       1333          1333          1333          1333          1333          1333          1333          1333          </param>       
 <param name="shift">        10            10            10            10            10            10            10            4             </param>       


### PR DESCRIPTION
Tested on the real robot.

"Encoders" and "Zeros" values were determined with the standard Excel procedure using the measurements:
* thumb at 0 deg => raw encoder value "Vmin" = 3000
* thumb at 90 deg (perpendicular to palm) => raw encoder value "Vmax" = 2000

Then, because in our case Vmax<Vmin (poles in the magnet are inverted with respect to the common situation, and it is not an option to spin the magnet because it is glued), the Excel formula for "calibration1" was wrong for us. We calculated the correct value like this:
* "calibration1" = "Vmin" - (10 deg expressed in raw units)
* then we had to switch the signs of the three PID control terms "kp", "kd", "ki"
* then we adjusted the value of "kp" to compensate overshooting

TODO: update iCub_Calibration_V1_3_1_iCubLisboa01.xls with (i) values of Vmin, Vmax; (ii) macro that works for our magnet orientation.

See https://github.com/robotology/icub-support/issues/195, cc @lorejam