### PR TITLE
Support using IPOPT from the coinor-libipopt-dev system package in Ubuntu 16.04 / Debian Jessie/sid 

### DIFF
--- a/conf/FindIPOPT.cmake
+++ b/conf/FindIPOPT.cmake
@@ -4,8 +4,12 @@
 #
 # Try to locate the IPOPT library
 #
-# If the IPOPT_DIR is set, try to locate the package in the given
-# directory, otherwise use pkg-config to locate it
+# On non Windows systems, use pkg-config to try to locate the library,
+# if this fails then try to locate the library in the directory pointed by
+# the IPOPT_DIR enviromental variable.
+#
+# On Windows systems,  just try to find the library using the IPOPT_DIR 
+# enviromental variable.  
 #
 # Create the following variables::
 #
@@ -32,10 +36,8 @@
 #  License text for the above reference.)
 
 
-if(APPLE)
-
-  # On APPLE we use PkgConfig to find IPOPT
-  # TODO use it on UNIX as well
+if(NOT WIN32)
+  # On non Windows systems we use PkgConfig to find IPOPT
   find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
 
@@ -58,7 +60,9 @@ if(APPLE)
         find_library(${_LIBRARY}_PATH
                      NAMES ${_LIBRARY}
                      PATHS ${_PC_IPOPT_LIBRARY_DIRS})
-                    list(APPEND IPOPT_LIBRARIES ${${_LIBRARY}_PATH})
+        # find library in 
+        message(STATUS "Found ${_LIBRARY} in ${_PC_IPOPT_LIBRARY_DIRS} : ${${_LIBRARY}_PATH}")
+        list(APPEND IPOPT_LIBRARIES ${${_LIBRARY}_PATH})
       endforeach()
     else()
       set(IPOPT_DEFINITIONS "")
@@ -68,57 +72,56 @@ if(APPLE)
 
   set(IPOPT_LINK_FLAGS "")
 
-elseif(UNIX)
+  # If pkg-config fails, try to find the package using IPOPT_DIR
+  if(NOT _PC_IPOPT_FOUND)
+    set(IPOPT_DIR_TEST $ENV{IPOPT_DIR})
+    if(IPOPT_DIR_TEST)
+      set(IPOPT_DIR $ENV{IPOPT_DIR} CACHE PATH "Path to IPOPT build directory")
+    else()
+      set(IPOPT_DIR /usr            CACHE PATH "Path to IPOPT build directory")
+    endif()
 
-  # in linux if the env var IPOPT_DIR is not set
-  # we know we are dealing with an installed iCub package
-  set(IPOPT_DIR_TEST $ENV{IPOPT_DIR})
-  if(IPOPT_DIR_TEST)
-    set(IPOPT_DIR $ENV{IPOPT_DIR} CACHE PATH "Path to IPOPT build directory")
-  else()
-    set(IPOPT_DIR /usr            CACHE PATH "Path to IPOPT build directory")
-  endif()
-
-  set(IPOPT_INCLUDE_DIRS ${IPOPT_DIR}/include/coin)
-  find_library(IPOPT_LIBRARIES ipopt ${IPOPT_DIR}/lib
+    set(IPOPT_INCLUDE_DIRS ${IPOPT_DIR}/include/coin)
+    find_library(IPOPT_LIBRARIES ipopt ${IPOPT_DIR}/lib
                                      ${IPOPT_DIR}/lib/coin
                                      NO_DEFAULT_PATH)
 
-  if(IPOPT_LIBRARIES)
-    find_file(IPOPT_DEP_FILE ipopt_addlibs_cpp.txt ${IPOPT_DIR}/share/doc/coin/Ipopt
-                                                   ${IPOPT_DIR}/share/coin/doc/Ipopt
-                                                   NO_DEFAULT_PATH)
-    mark_as_advanced(IPOPT_DEP_FILE)
+    if(IPOPT_LIBRARIES)
+      find_file(IPOPT_DEP_FILE ipopt_addlibs_cpp.txt ${IPOPT_DIR}/share/doc/coin/Ipopt
+                                                     ${IPOPT_DIR}/share/coin/doc/Ipopt
+                                                     NO_DEFAULT_PATH)
+      mark_as_advanced(IPOPT_DEP_FILE)
 
-    if(IPOPT_DEP_FILE)
-      # parse the file and acquire the dependencies
-      file(READ ${IPOPT_DEP_FILE} IPOPT_DEP)
-      string(REGEX REPLACE "-[^l][^ ]* " "" IPOPT_DEP ${IPOPT_DEP})
-      string(REPLACE "-l"                "" IPOPT_DEP ${IPOPT_DEP})
-      string(REPLACE "\n"                "" IPOPT_DEP ${IPOPT_DEP})
-      string(REPLACE "ipopt"             "" IPOPT_DEP ${IPOPT_DEP})       # remove any possible auto-dependency
-      separate_arguments(IPOPT_DEP)
+      if(IPOPT_DEP_FILE)
+        # parse the file and acquire the dependencies
+        file(READ ${IPOPT_DEP_FILE} IPOPT_DEP)
+        string(REGEX REPLACE "-[^l][^ ]* " "" IPOPT_DEP ${IPOPT_DEP})
+        string(REPLACE "-l"                "" IPOPT_DEP ${IPOPT_DEP})
+        string(REPLACE "\n"                "" IPOPT_DEP ${IPOPT_DEP})
+        string(REPLACE "ipopt"             "" IPOPT_DEP ${IPOPT_DEP})       # remove any possible auto-dependency
+        separate_arguments(IPOPT_DEP)
 
-      # use the find_library command in order to prepare rpath correctly
-      foreach(LIB ${IPOPT_DEP})
-        find_library(IPOPT_SEARCH_FOR_${LIB} ${LIB} ${IPOPT_DIR}/lib
-                                                    ${IPOPT_DIR}/lib/coin
-                                                    ${IPOPT_DIR}/lib/coin/ThirdParty
-                                                    NO_DEFAULT_PATH)
-        if(IPOPT_SEARCH_FOR_${LIB})
-          # handle non-system libraries (e.g. coinblas)
-          set(IPOPT_LIBRARIES ${IPOPT_LIBRARIES} ${IPOPT_SEARCH_FOR_${LIB}})
-        else()
-          # handle system libraries (e.g. gfortran)
-          set(IPOPT_LIBRARIES ${IPOPT_LIBRARIES} ${LIB})
-        endif()
-        mark_as_advanced(IPOPT_SEARCH_FOR_${LIB})
-      endforeach()
+        # use the find_library command in order to prepare rpath correctly
+        foreach(LIB ${IPOPT_DEP})
+          find_library(IPOPT_SEARCH_FOR_${LIB} ${LIB} ${IPOPT_DIR}/lib
+                                                      ${IPOPT_DIR}/lib/coin
+                                                      ${IPOPT_DIR}/lib/coin/ThirdParty
+                                                      NO_DEFAULT_PATH)
+          if(IPOPT_SEARCH_FOR_${LIB})
+            # handle non-system libraries (e.g. coinblas)
+            set(IPOPT_LIBRARIES ${IPOPT_LIBRARIES} ${IPOPT_SEARCH_FOR_${LIB}})
+          else()
+            # handle system libraries (e.g. gfortran)
+            set(IPOPT_LIBRARIES ${IPOPT_LIBRARIES} ${LIB})
+          endif()
+          mark_as_advanced(IPOPT_SEARCH_FOR_${LIB})
+        endforeach()
+      endif()
     endif()
-  endif()
 
-  set(IPOPT_DEFINITIONS "")
-  set(IPOPT_LINK_FLAGS "")
+    set(IPOPT_DEFINITIONS "")
+    set(IPOPT_LINK_FLAGS "")
+  endif()
 
 # Windows platforms
 else()

--- a/src/modules/iKinGazeCtrl/CMakeLists.txt
+++ b/src/modules/iKinGazeCtrl/CMakeLists.txt
@@ -29,7 +29,7 @@ include_directories(${PROJECT_SOURCE_DIR}/include
                     ${YARP_INCLUDE_DIRS})
 
 # import math symbols from standard cmath
-add_definitions(-D_USE_MATH_DEFINES)
+add_definitions(-D_USE_MATH_DEFINES ${IPOPT_DEFINITIONS})
 add_executable(${PROJECTNAME} ${folder_header} ${folder_source})
 target_link_libraries(${PROJECTNAME} ctrlLib iKin ${YARP_LIBRARIES})
 install(TARGETS ${PROJECTNAME} DESTINATION bin)


### PR DESCRIPTION
I had to setup a new machine with the `codyco-superbuild` on Ubuntu 16.04, and I took the occasion to fix the cmake and get rid of the dependency on the `icub-common` package. This drastically simplifies the installation of the `codyco-superbuild` on Ubuntu 16.04, because now you just need to install a bunch of packages and compile the superbuild. 

The change should be completely back-compatible, for more info check directly the updated documentation of the `FindIPOPT.cmake` module to see how its behavior changed. [1]

The only problem is that currently the `coinor-libipopt-dev` package is missing a dependency on the `libblas-dev` and `liblapack-dev`, so this two packages should be installed with the rest of the necessary packages (for more on this check [2]). 

[1] : https://github.com/robotology/icub-main/commit/4102ff19ae8a64fb7b2c70f454dfd5bbfb1e4ace
[2] : https://github.com/ghorn/debian-coinor-ipopt/issues/2
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/icub-main/pull/340%23discussion_r63862803%22%2C%20%22https%3A//github.com/robotology/icub-main/pull/340%23issuecomment-220305148%22%2C%20%22https%3A//github.com/robotology/icub-main/pull/340%23issuecomment-220330616%22%2C%20%22https%3A//github.com/robotology/icub-main/pull/340%23issuecomment-220409384%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/icub-main/pull/340%23issuecomment-220305148%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Travis%20is%20failing%20because%20precise%20still%20has%20an%20old%20icub-common%20package%20with%20a%20wrong%20pkg-config%20%28see%20https%3A//github.com/robotology/robotology.github.io/issues/3%29.%20It%20is%20ok%20to%20upgrade%20travis%20to%20trusty%20and%20finally%20deprecate%20precise%3F%20%40drdanz%20%40pattacini%20%40randaz81%22%2C%20%22created_at%22%3A%20%222016-05-19T12%3A07%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%5Cr%5CnDo%20you%20mind%20syncing%20the%20FindIPOPT.cmake%20file%20with%20YCM%20after%20this%20is%20merged%3F%22%2C%20%22created_at%22%3A%20%222016-05-19T13%3A52%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20%40traversaro%20%5Cr%5Cn%5Cr%5CnI%27ve%20just%20made%20a%20change%20%281703092%29%20to%20%60iKinGazeCtrl/CMakeLists.txt%60%20you%20should%20consider%20integrating%20in%20this%20PR%2C%20I%20think.%22%2C%20%22created_at%22%3A%20%222016-05-19T18%3A19%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%207571eddc34a972683b682ee67c5f8bfb25ff5482%20conf/FindIPOPT.cmake%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/icub-main/pull/340%23discussion_r63862803%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22debug%20message%22%2C%20%22created_at%22%3A%20%222016-05-19T11%3A36%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20conf/FindIPOPT.cmake%3AL60-69%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 7571eddc34a972683b682ee67c5f8bfb25ff5482 conf/FindIPOPT.cmake 34'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/icub-main/pull/340#discussion_r63862803'>File: conf/FindIPOPT.cmake:L60-69</a></b>
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> debug message
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/icub-main/pull/340#issuecomment-220305148'>General Comment</a></b>
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> Travis is failing because precise still has an old icub-common package with a wrong pkg-config (see https://github.com/robotology/robotology.github.io/issues/3). It is ok to upgrade travis to trusty and finally deprecate precise? @drdanz @pattacini @randaz81
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> :+1:
Do you mind syncing the FindIPOPT.cmake file with YCM after this is merged?
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> Hi @traversaro
I've just made a change (1703092) to `iKinGazeCtrl/CMakeLists.txt` you should consider integrating in this PR, I think.


<a href='https://www.codereviewhub.com/robotology/icub-main/pull/340?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/icub-main/pull/340?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/icub-main/pull/340'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>