### PR TITLE
[iCubLisboa01]: right hand thumb opposition (j8) calibration

### DIFF
--- a/app/robots/iCubLisboa01/calibrators/right_hand_calib.xml
+++ b/app/robots/iCubLisboa01/calibrators/right_hand_calib.xml
@@ -12,7 +12,7 @@
 <group name="CALIBRATION">   
  
 <param name="calibrationType">            3             4             4             4             4             4             4             4             </param>       
-<param name="calibration1">               1710.00       238.00        60.00         238.00        105.00        242.00        20.00         705.00        </param>       
+<param name="calibration1">               2166.67       238.00        60.00         238.00        105.00        242.00        20.00         705.00        </param>       
 <param name="calibration2">               10.00         10.00         30.00         10.00         10.00         10.00         10.00         10.00         </param>       
 <param name="calibration3">               0.00          6000.00       8000.00       6000.00       -7400.00      6000.00       7400.00       14000.00      </param>       
 <param name="startupPosition">               30            3             0             0             0             0             0             0             </param>       

--- a/app/robots/iCubLisboa01/hardware/motorControl/icub_right_hand.xml
+++ b/app/robots/iCubLisboa01/hardware/motorControl/icub_right_hand.xml
@@ -33,8 +33,8 @@
 <param name="AxisMap">      0             1             2             3             4             5             6             7             </param>       
 <param name="AxisName"> "r_thumb_oppose" "r_thumb_proximal" "r_thumb_distal" "r_index_proximal" "r_index_distal" "r_middle_proximal" "r_middle_distal" "r_pinky" </param>
 <param name="AxisType"> "revolute" "revolute" "revolute" "revolute" "revolute" "revolute" "revolute" "revolute" </param>
-<param name="Encoder">      8.00          -2.42         -2.42         -2.53         -2.08         -2.52         -2.39         -2.30         </param>       
-<param name="Zeros">        203.75        -98.26        -204.83       -93.95        -230.40       -95.95        -188.37       -306.52       </param>       
+<param name="Encoder">      16.67         -2.42         -2.42         -2.53         -2.08         -2.52         -2.39         -2.30         </param>       
+<param name="Zeros">        120.00        -98.26        -204.83       -93.95        -230.40       -95.95        -188.37       -306.52       </param>       
 <param name="TorqueId">     0             0             0             0             0             0             0             0             </param>       
 <param name="TorqueChan">   0             0             0             0             0             0             0             0             </param>       
 <param name="TorqueMax">    0             0             0             0             0             0             0             0             </param>       


### PR DESCRIPTION
Tested on the real robot.

These calibration values were obtained with the new replacement magnet in May 2016 and the standard Excel procedure using the following raw measurements:

* thumb at 0 deg (finger open) => raw encoder value "Vmin" = 2000
* thumb at 90 deg (perpendicular to palm) => raw encoder value "Vmax" = 3500

This time the orientation of the magnet is standard, so Vmin<Vmax, so the PID gains have the correct signs according to specs. Just for reference, here was the previously rejected Pull Request: https://github.com/robotology/icub-main/pull/307

See https://github.com/robotology/icub-support/issues/195

TODO: update the Excel sheet iCub_Calibration_V1_3_1_iCubLisboa01.xls with the new values of Vmin, Vmax (not sure which is the policy or good practice there, perhaps @randaz81 or @maggia80 know)