### PR TITLE
iCubCluster

### DIFF
--- a/app/iCubCluster/conf/cluster-config.xml
+++ b/app/iCubCluster/conf/cluster-config.xml
@@ -1,9 +1,6 @@
 <cluster name="icub01" user="icub">
 
-<!-- specify type="yarpserver" or type="yarpserver3" to use the old or new nameserver default behavior is to use yarpserver3 -->
-<!-- nameserver namespace="/root" node="icubsrv" type="yarpserver"> </nameserver> -->
-<!-- nameserver namespace="/root" node="icubsrv" type="yarpserver3"> </nameserver> -->
-<nameserver namespace="/root" node="icubsrv" type="yarpserver"> </nameserver>
+<nameserver namespace="/root" node="icubsrv"> </nameserver>
 
 <!-- specify nodes, if you want to enable display on desktop please specify which desktop to use
 this is usually the value of the DISPLAY variable when logged on -->

--- a/app/iCubCluster/scripts/icub-cluster-server.sh
+++ b/app/iCubCluster/scripts/icub-cluster-server.sh
@@ -29,13 +29,11 @@ case "$1" in
 	        ;;
 	stop)
 		echo "Stopping yarp server"
-		killall yarpserver3
 		killall yarpserver
 		;;
 
 	kill)
 		echo "Killing yarp server"
-		killall -9 yarpserver3
 		killall -9 yarpserver
 		;;
 	*)

--- a/app/iCubCluster/scripts/icub-cluster-server.sh
+++ b/app/iCubCluster/scripts/icub-cluster-server.sh
@@ -17,12 +17,12 @@ case "$1" in
 		case "$2" in
 			ros) # ros option
 				echo "Starting up yarp server with ros option"
-				yarpserver --portdb /tmp/ports.db --subdb /tmp/subs.db --ros >/dev/null 2>&1 &
+				yarpserver --portdb :memory: --subdb :memory: --ros >/dev/null 2>&1 &
 				echo "done!"
 				;;
 			*) #yarpserver without ros is the default
 				echo "Starting up yarp server"
-				yarpserver --portdb /tmp/ports.db --subdb /tmp/subs.db >/dev/null 2>&1 &
+				yarpserver --portdb :memory: --subdb :memory: >/dev/null 2>&1 &
 				echo "done!"
 				;;
 		esac

--- a/app/iCubCluster/scripts/icub-cluster.py
+++ b/app/iCubCluster/scripts/icub-cluster.py
@@ -111,19 +111,17 @@ class RemoteExecWindow:
             i=i+1
 
 class Cluster:
-    def __init__(self, name, user, namespace, nsNode, nsType, nodes):
+    def __init__(self, name, user, namespace, nsNode, nodes):
         self.name=name
         self.user=user
         self.namespace=namespace
         self.nsNode=nsNode
         self.nodes=nodes
-        self.nsType=nsType
 
     def display(self):
         print "--- Cluster %s:" %self.name
         print "User is: %s" % self.user
         print "Nameserver %s " %self.namespace,
-        print "type: %s " %self.nsType,
         print "is on %s" % self.nsNode
 
         print "Nodes are:"
@@ -404,10 +402,6 @@ class App:
         self.checkNs()
         if self.nsFlag.get()==0:
             cmd = Util.getSshCmd(self.clusterUser.get(), self.clusterNsNode.get()) + ['icub-cluster-server.sh', ' start']
-#            if (self.cluster.nsType=='yarpserver3'):
-#                cmd.append('yarpserver3')
-#            elif(self.cluster.nsType=='yarpserver'):
-#                 cmd.append('yarpserver')
 
 	    if self.ROSoption.get()==1:
 		cmd.append('ros')
@@ -498,7 +492,6 @@ if __name__ == '__main__':
         nameserver=cluster.getElementsByTagName("nameserver")[0]
         namespace=nameserver.getAttribute("namespace")
         namespaceNode=nameserver.getAttribute("node")
-        namespaceType=nameserver.getAttribute("type")
         nodes=cluster.getElementsByTagName("node")
 
         nodeList=[]
@@ -523,7 +516,7 @@ if __name__ == '__main__':
 
             nodeList.append(newNode)
 
-    cl=Cluster(name, user, namespace, namespaceNode, namespaceType, nodeList)
+    cl=Cluster(name, user, namespace, namespaceNode, nodeList)
     cl.display()
 
     root = Tk()

--- a/app/iCubCluster/scripts/icub-cluster.py
+++ b/app/iCubCluster/scripts/icub-cluster.py
@@ -174,12 +174,12 @@ class App:
         self.bCheckNs.config(state=DISABLED,disabledforeground="#00A000")
         self.bCheckNs.grid(row=1, column=1, sticky=W)
 
-	self.bROSoption = Entry(tmpFrame)
-	self.ROSoption=IntVar()
-	self.ROSoption.set(0)
-	self.bROSoption=Checkbutton(tmpFrame, variable=self.ROSoption)
-	self.bROSoption.grid(row=1, column=2)
-	Label(tmpFrame, text="--ros").grid(row=0, column=2)
+        self.bROSoption = Entry(tmpFrame)
+        self.ROSoption=IntVar()
+        self.ROSoption.set(0)
+        self.bROSoption=Checkbutton(tmpFrame, variable=self.ROSoption)
+        self.bROSoption.grid(row=1, column=2)
+        Label(tmpFrame, text="--ros").grid(row=0, column=2)
         tmpFrame=Frame(nsFrame)
         tmpFrame.pack()
         buttonCheckNs=Button(tmpFrame, text="Check", width=8, command=self.checkNs)
@@ -403,8 +403,8 @@ class App:
         if self.nsFlag.get()==0:
             cmd = Util.getSshCmd(self.clusterUser.get(), self.clusterNsNode.get()) + ['icub-cluster-server.sh', ' start']
 
-	    if self.ROSoption.get()==1:
-		cmd.append('ros')
+            if self.ROSoption.get()==1:
+                cmd.append('ros')
             print 'Running',
             print " ".join(cmd)
             ret=subprocess.Popen(cmd).wait()


### PR DESCRIPTION
* iCubCluster: Remove unused "type" option and references to yarpserver3. The "type" option is actually unused, and yarpserver3 will be soon removed from yarp (see robotology/yarp#780)

* icub-cluster-server.sh: Use memory instead /tmp for yarpserver portdb and and subdb. Memory should be faster. @lornat75 What do you think about this change?
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/icub-main/pull/350%23issuecomment-225122399%22%2C%20%22https%3A//github.com/robotology/icub-main/pull/350%23issuecomment-225350502%22%2C%20%22https%3A//github.com/robotology/icub-main/pull/350%23issuecomment-225362462%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/icub-main/pull/350%23issuecomment-225122399%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20fine%20for%20me%2C%20maybe%20we%20can%20check%20with%20the%20users%20of%20the%20robot%20to%20see%20if%20they%20ever%20need%20to%20re-use%20the%20cache%20of%20the%20nameserver%3A%20%40pattacini%20%40vtikha%20%40randaz81%20%22%2C%20%22created_at%22%3A%20%222016-06-10T08%3A26%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1403333%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lornat75%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40lornat75%20I%27ve%20never%20re-used%20the%20cache%2C%20actually.%5Cr%5CnFine%20with%20me.%22%2C%20%22created_at%22%3A%20%222016-06-11T10%3A24%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22Actually%20I%20never%20used%20this%20feature...%22%2C%20%22created_at%22%3A%20%222016-06-11T13%3A40%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2869969%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/randaz81%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/icub-main/pull/350#issuecomment-225122399'>General Comment</a></b>
- <a href='https://github.com/lornat75'><img border=0 src='https://avatars.githubusercontent.com/u/1403333?v=3' height=16 width=16'></a> Looks fine for me, maybe we can check with the users of the robot to see if they ever need to re-use the cache of the nameserver: @pattacini @vtikha @randaz81
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> @lornat75 I've never re-used the cache, actually.
Fine with me.
- <a href='https://github.com/randaz81'><img border=0 src='https://avatars.githubusercontent.com/u/2869969?v=3' height=16 width=16'></a> Actually I never used this feature...


<a href='https://www.codereviewhub.com/robotology/icub-main/pull/350?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/icub-main/pull/350?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/icub-main/pull/350'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>