### PR TITLE
fixed triangle number 52 orientation in iCubSkinGui

### DIFF
--- a/app/skinGui/conf/skinGui/torso.ini
+++ b/app/skinGui/conf/skinGui/torso.ini
@@ -101,5 +101,5 @@ triangle_10pad	5	-50	43	120	4	0
 triangle_10pad	11	-18	43	240	4	0
 						
 						
-triangle_10pad	52	31	24	179.9997194	4	
+triangle_10pad	52	31	24	60	4	0	
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/icub-main/pull/354%23issuecomment-226715007%22%2C%20%22https%3A//github.com/robotology/icub-main/pull/354%23issuecomment-227147991%22%2C%20%22https%3A//github.com/robotology/icub-main/pull/354%23issuecomment-228001178%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/icub-main/pull/354%23issuecomment-226715007%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40matejhof%20could%20you%20have%20a%20look%20at%20this%20PR%3F%22%2C%20%22created_at%22%3A%20%222016-06-17T08%3A46%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20needs%20to%20be%20tested%20on%20more%20than%20one%20robot%20-%20%40joankangro%20%2C%20%40traversaro%2C%20can%20you%20try%20on%20the%20other%20blackie%20for%20example%3F%20We%20need%20to%20rule%20out%20the%20possibility%20that%20the%20hardware%20triangle%20has%20a%20different/wrong%20orientation.%20It%20is%20probably%20unlikely%2C%20but%20we%20should%20double%20check.%20Some%20triangles%20e.g.%20on%20upper%20arm%20changed%20orientation%20between%20skin%20version%201%20and%202%20too%2C%20I%20think.%20I%20hope%20that%20is%20not%20the%20case%20for%20the%20torso.%20%40maggia80%20may%20know%20better.%20%20%22%2C%20%22created_at%22%3A%20%222016-06-20T13%3A52%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6461061%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/matejhof%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40matejhof%20%20We%20tested%20the%20torso%20on%20iCub%20with%20%40traversaro%20and%20it%20has%20the%20same%20issue.%22%2C%20%22created_at%22%3A%20%222016-06-23T09%3A44%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5780956%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/joankangro%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/icub-main/pull/354#issuecomment-226715007'>General Comment</a></b>
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> @matejhof could you have a look at this PR?
- <a href='https://github.com/matejhof'><img border=0 src='https://avatars.githubusercontent.com/u/6461061?v=3' height=16 width=16'></a> It needs to be tested on more than one robot - @joankangro , @traversaro, can you try on the other blackie for example? We need to rule out the possibility that the hardware triangle has a different/wrong orientation. It is probably unlikely, but we should double check. Some triangles e.g. on upper arm changed orientation between skin version 1 and 2 too, I think. I hope that is not the case for the torso. @maggia80 may know better.
- <a href='https://github.com/joankangro'><img border=0 src='https://avatars.githubusercontent.com/u/5780956?v=3' height=16 width=16'></a> @matejhof  We tested the torso on iCub with @traversaro and it has the same issue.


<a href='https://www.codereviewhub.com/robotology/icub-main/pull/354?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/icub-main/pull/354?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/icub-main/pull/354'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>