### PR TITLE
DragonFly2: change error message to info since it is not an error

### DIFF
--- a/src/libraries/icubmod/dragonfly2/linux/FirewireCameraDC1394-DR2_2.cpp
+++ b/src/libraries/icubmod/dragonfly2/linux/FirewireCameraDC1394-DR2_2.cpp
@@ -488,7 +488,7 @@ bool CFWCamera_DR2_2::Create(yarp::os::Searchable& config)
 		    }
             else
             {
-                yError("Feature %d not present\n",f);
+                yInfo("Feature %d not supported by this camera model.\n", f);
             }
         }
         else

--- a/src/libraries/icubmod/dragonfly2/winnt/FirewireCameraDC1394-DR2_2.cpp
+++ b/src/libraries/icubmod/dragonfly2/winnt/FirewireCameraDC1394-DR2_2.cpp
@@ -394,7 +394,7 @@ bool CFWCamera_DR2_2::Create(yarp::os::Searchable& config)
             }
             else
             {
-                yError("Feature %d not present\n");
+                yInfo("Feature %d not supported by this camera model.\n", f);
             }
         }
         else


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/icub-main/pull/359?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/icub-main/pull/359'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>