### PR TITLE
Create ethResources library as shared

### DIFF
--- a/src/libraries/icubmod/embObjLib/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjLib/CMakeLists.txt
@@ -222,8 +222,10 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}
                     ${iCubDev_INCLUDE_DIRS}
                     ${CMAKE_CURRENT_SOURCE_DIR}/../motionControlLib/)
 
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+add_library(${PROJECTNAME} SHARED ${embobj_source} ${embobj_header})
 
-add_library(${PROJECTNAME} ${embobj_source} ${embobj_header})
+install(TARGET ${PROJECTNAME} DESTINATION lib)
 
 #add_dependencies(${PROJECTNAME} eBcode-download)
 TARGET_LINK_LIBRARIES(${PROJECTNAME} ${YARP_LIBRARIES} ${ACE_LIBRARIES} )


### PR DESCRIPTION
This fixes the segmentation fault at the end of `yarprobotinterface`, `yarpdev --list` and `yarp plugin --all` when more that one *embObj* device is enabled.

When the shared library is built static and linked to a plugin, all the symbols of the library are exported in the plugin. When 2 plugins are loaded at the same time, there is a symbol conflict and only the functions from one of those are called. This is ok but when the library is closed, a segmentation fault is generated, probably on some singleton/static object.
Hiding the symbols with `-fvisibility=hidden` is not ok though, because each plugin will have its own version of the singleton and therefore the second plugin loaded will not be able to create it and to bind to the ip port.

Since this library contains a singleton, and since the plugins in iCub are always built as shared, the logical thing to do is to always have this library shared as well.

In order to export all the symbols on windows, the `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` cmake variable is used. This will require **CMake 3.3** or later to work properly (untested).

CC: @marcoaccame