### PR TITLE
iCubCluster ssh settings fix

### DIFF
--- a/app/iCubCluster/scripts/icub-cluster.py
+++ b/app/iCubCluster/scripts/icub-cluster.py
@@ -520,7 +520,7 @@ if __name__ == '__main__':
                 else:
                     newNode=Node(node.firstChild.data, False, "", nodeuser, ssh_options)
             else:
-                newNode=Node(node.firstChild.data, False, "", user, ssh_options)
+                newNode=Node(node.firstChild.data, False, "", user, "")
 
             nodeList.append(newNode)
 


### PR DESCRIPTION
@pattacini Using the latest version of the icub cluster I get 
...
||| found /exports/code/icub-main/build/share/iCub/contexts/iCubCluster
||| checking [/exports/code/icub-main/build/share/iCub/contexts/iCubCluster/icub-cluster-icon.png] (context)
||| found /exports/code/icub-main/build/share/iCub/contexts/iCubCluster/icub-cluster-icon.png
||| finding file [from]
Traceback (most recent call last):
  File "/home/icub/software_shared/icub-main/build/bin/icub-cluster.py", line 523, in <module>
    newNode=Node(node.firstChild.data, False, "", user, ssh_options)
NameError: name 'ssh_options' is not defined.

I think that the ssh_options are indented to be empty if the node has no attributes. Setting the string to empty fixes my problem but I am not sure if that should be a global fix or it only affects my setup
