### PR TITLE
adding skin part version information

### DIFF
--- a/src/libraries/skinDynLib/include/iCub/skinDynLib/skinPart.h
+++ b/src/libraries/skinDynLib/include/iCub/skinDynLib/skinPart.h
@@ -108,7 +108,7 @@ class skinPartBase
      * Sets the version ("V1" / "V2" / "V2_1")
      * @param _version 
      */
-    void setVersion(const std::string &_name);
+    void setVersion(const std::string &_version);
 
     /**
      * Gets the version

--- a/src/libraries/skinDynLib/include/iCub/skinDynLib/skinPart.h
+++ b/src/libraries/skinDynLib/include/iCub/skinDynLib/skinPart.h
@@ -58,7 +58,7 @@ class skinPartBase
                         // and number of rows in the taxel positions .txt files in
                         // icub-main/app/skinGui/conf/positions in the [calibration] group 
                         // IMPORTANT: it may differ from taxels.size()
-    std::string version; // Version of the skin part - "V1", "V2", "V2_1" (or "unknown_version"). 
+    std::string version; // Version of the skin part - "V1", "V2", "V2.1" (or "unknown_version"). 
                          // Depending on the physical version of skin on the robot. For example,
                          // forearm V2 has one triangle more compared to V1 and also partly different taxel IDs. 
     yarp::os::RecursiveMutex recursive_mutex;
@@ -105,7 +105,7 @@ class skinPartBase
     int getSize();
 
     /**
-     * Sets the version ("V1" / "V2" / "V2_1")
+     * Sets the version ("V1" / "V2" / "V2.1")
      * @param _version 
      */
     void setVersion(const std::string &_version);

--- a/src/libraries/skinDynLib/include/iCub/skinDynLib/skinPart.h
+++ b/src/libraries/skinDynLib/include/iCub/skinDynLib/skinPart.h
@@ -1,7 +1,8 @@
 /**
  * Copyright (C) 2015 iCub Facility, Istituto Italiano di Tecnologia
  * Author: Alessandro Roncone
- * email:  alessandro.roncone@iit.it
+ * email:  alessandro.roncone@yale.edu
+ * Contribution: Matej Hoffmann, matej.hoffmann@iit.it
  * website: www.robotcub.org
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any
@@ -54,9 +55,12 @@ class skinPartBase
     std::string name;
     int         size;   // theoretical maximum size of the skinPart
                         // it corresponds to the number of values on the respective port 
-                        // and number of rows in the .txt files in
-                        // icub-main/app/skinGui/conf/positions
+                        // and number of rows in the taxel positions .txt files in
+                        // icub-main/app/skinGui/conf/positions in the [calibration] group 
                         // IMPORTANT: it may differ from taxels.size()
+    std::string version; // Version of the skin part - "V1", "V2", "V2_1" (or "unknown_version"). 
+                         // Depending on the physical version of skin on the robot. For example,
+                         // forearm V2 has one triangle more compared to V1 and also partly different taxel IDs. 
     yarp::os::RecursiveMutex recursive_mutex;
   public:
     /**
@@ -101,6 +105,18 @@ class skinPartBase
     int getSize();
 
     /**
+     * Sets the version ("V1" / "V2" / "V2_1")
+     * @param _version 
+     */
+    void setVersion(const std::string &_name);
+
+    /**
+     * Gets the version
+     * @return string containing the version
+     */
+    std::string getVersion();
+    
+    /**
      * Populates the skinPartBase by reading from a file.
      * @param  _filePath   is the full absolute path of the file
      * @return true/false in case of success/failure
@@ -134,11 +150,11 @@ class skinPart : public skinPartBase
     * List of taxels that belong to the skinPart.
     **/
     std::vector<Taxel*> taxels;
-
+      
     /**
      * Spatial_sampling used in building up the skinPart class. 
-     * It can be either "full" or "patch", the latter of which remaps the taxels onto the center
-     * of their respective triangular patch
+     * It can be either full, i.e. "taxel", or "triangle", where the latter remaps the individual taxels onto the center taxels
+     * of their respective triangular module (composed of 10 taxels, but 12 values on the port - 2 are thermal pads)
      */
     std::string spatial_sampling;
 
@@ -166,7 +182,7 @@ class skinPart : public skinPartBase
     /**
      * Maps the taxels onto themselves, performing a 1:1 mapping. This has been
      * made in order for the "taxel" spatial_sampling modality to be consistent
-     * with the "patch" sampling, thus maintaining integrity into taxel2Repr and repr2TaxelList
+     * with the "triangle" sampling, thus maintaining integrity into taxel2Repr and repr2TaxelList
      * @return true/false in case of success/failure
      */
     bool mapTaxelsOntoThemselves();
@@ -200,7 +216,7 @@ class skinPart : public skinPartBase
      * @param  _filePath   is the full absolute path of the file
      * @param  _spatial_sampling is the type of spatial sampling to perform (default "default")
      *                           if "default", the spatial_sampling will be read from file
-     *                           if "taxel" or "patch", this will be the spatial_sampling performed 
+     *                           if "taxel" or "triangle", this will be the spatial_sampling performed 
      * @return true/false in case of success/failure
      */
     bool setTaxelPosesFromFile(const std::string &_filePath,

--- a/src/libraries/skinDynLib/src/skinPart.cpp
+++ b/src/libraries/skinDynLib/src/skinPart.cpp
@@ -137,7 +137,7 @@ using namespace iCub::skinDynLib;
         else
         {
             yWarning("[skinPart::setTaxelPosesFromFile] no name field found. Using filename.");
-            // Assign the name of the skinPart according to the filename (hardcoded)
+            // Assign the name and version of the skinPart according to the filename (hardcoded)
             if      (filename == "left_forearm_mesh.txt")    { setName(SkinPart_s[SKIN_LEFT_FOREARM]);    setVersion("V1");   }
             else if (filename == "left_forearm_nomesh.txt")  { setName(SkinPart_s[SKIN_LEFT_FOREARM]);    setVersion("V1");   }
             else if (filename == "left_forearm_V2.txt")      { setName(SkinPart_s[SKIN_LEFT_FOREARM]);    setVersion("V2");   }

--- a/src/libraries/skinDynLib/src/skinPart.cpp
+++ b/src/libraries/skinDynLib/src/skinPart.cpp
@@ -6,7 +6,7 @@ using namespace iCub::skinDynLib;
 /****************************************************************/
 /* SKINPARTBASE WRAPPER
 *****************************************************************/
-    skinPartBase::skinPartBase() : name("unknown_skin_part"), size(0) {}
+    skinPartBase::skinPartBase() : name("unknown_skin_part"), size(0), version("unknown_version") {}
 
     skinPartBase::skinPartBase(const skinPartBase &_spb)
     {
@@ -23,6 +23,7 @@ using namespace iCub::skinDynLib;
 
         name = _spb.name;
         size = _spb.size;
+        version = _spb.version;
         return *this;
     }
 
@@ -46,17 +47,29 @@ using namespace iCub::skinDynLib;
         return size;
     }
 
+    void skinPartBase::setVersion(const std::string &_version)
+    {
+        version = _version;
+    }
+
+    std::string skinPartBase::getVersion()
+    {
+        return version;
+    }
+
+    
     void skinPartBase::print(int verbosity)
     {
         yDebug("**********\n");
         yDebug("name: %s\t", name.c_str());
         yDebug("total number of taxels: %i\n", size);
+        yDebug("version: %s\n", version.c_str());
     }
 
     std::string skinPartBase::toString(int precision)
     {
         std::stringstream res;
-        res << "**********\n" << "Name: " << name << "\tSize: "<< size << std::endl;
+        res << "**********\n" << "Name: " << name << "\tSize: "<< size << "\tVersion: "<< version << std::endl;
         return res.str();
     }
 
@@ -65,7 +78,7 @@ using namespace iCub::skinDynLib;
 *****************************************************************/
     skinPart::skinPart()
     {
-        spatial_sampling = "taxel";
+        spatial_sampling = "taxel";        
     }
 
     skinPart::skinPart(const std::string &_filePath)
@@ -125,15 +138,17 @@ using namespace iCub::skinDynLib;
         {
             yWarning("[skinPart::setTaxelPosesFromFile] no name field found. Using filename.");
             // Assign the name of the skinPart according to the filename (hardcoded)
-            if      (filename == "left_forearm_mesh.txt")    { setName(SkinPart_s[SKIN_LEFT_FOREARM]);    }
-            else if (filename == "left_forearm_nomesh.txt")  { setName(SkinPart_s[SKIN_LEFT_FOREARM]);    }
-            else if (filename == "right_forearm_mesh.txt")   { setName(SkinPart_s[SKIN_RIGHT_FOREARM]);   }
-            else if (filename == "right_forearm_nomesh.txt") { setName(SkinPart_s[SKIN_RIGHT_FOREARM]);   }
-            else if (filename == "left_hand_V2_1.txt")       { setName(SkinPart_s[SKIN_LEFT_HAND]);       }
-            else if (filename == "right_hand_V2_1.txt")      { setName(SkinPart_s[SKIN_RIGHT_HAND]);      }
-            else if (filename == "left_arm_mesh.txt")        { setName(SkinPart_s[SKIN_LEFT_UPPER_ARM]);  }
-            else if (filename == "right_arm_mesh.txt")       { setName(SkinPart_s[SKIN_RIGHT_UPPER_ARM]); }
-            else if (filename == "torso.txt")                { setName(SkinPart_s[SKIN_FRONT_TORSO]);     }
+            if      (filename == "left_forearm_mesh.txt")    { setName(SkinPart_s[SKIN_LEFT_FOREARM]);    setVersion("V1");   }
+            else if (filename == "left_forearm_nomesh.txt")  { setName(SkinPart_s[SKIN_LEFT_FOREARM]);    setVersion("V1");   }
+            else if (filename == "left_forearm_V2.txt")      { setName(SkinPart_s[SKIN_LEFT_FOREARM]);    setVersion("V2");   }
+            else if (filename == "right_forearm_mesh.txt")   { setName(SkinPart_s[SKIN_RIGHT_FOREARM]);   setVersion("V1");   }
+            else if (filename == "right_forearm_nomesh.txt") { setName(SkinPart_s[SKIN_RIGHT_FOREARM]);   setVersion("V1");   }
+            else if (filename == "right_forearm_V2.txt")     { setName(SkinPart_s[SKIN_RIGHT_FOREARM]);   setVersion("V2");   }
+            else if (filename == "left_hand_V2_1.txt")       { setName(SkinPart_s[SKIN_LEFT_HAND]);       setVersion("V2_1"); }
+            else if (filename == "right_hand_V2_1.txt")      { setName(SkinPart_s[SKIN_RIGHT_HAND]);      setVersion("V2_1"); }
+            else if (filename == "left_arm_mesh.txt")        { setName(SkinPart_s[SKIN_LEFT_UPPER_ARM]);  setVersion("V1");   }
+            else if (filename == "right_arm_mesh.txt")       { setName(SkinPart_s[SKIN_RIGHT_UPPER_ARM]); setVersion("V1");   }
+            else if (filename == "torso.txt")                { setName(SkinPart_s[SKIN_FRONT_TORSO]);     setVersion("V1");   }
             else
             {
                 yError("[skinPart::setTaxelPosesFromFile] Unexpected skin part file name: %s.\n",filename.c_str());
@@ -147,16 +162,16 @@ using namespace iCub::skinDynLib;
             std::string _ss=rf.find("spatial_sampling").asString();
 
             // This lets us override the field without touching the .ini file
-            if (_spatial_sampling=="default" && (_ss=="taxel" || _ss=="patch"))
+            if (_spatial_sampling=="default" && (_ss=="taxel" || _ss=="triangle"))
             {
                 spatial_sampling = _ss;
             }
-            else if (_spatial_sampling=="taxel" || _spatial_sampling=="patch")
+            else if (_spatial_sampling=="taxel" || _spatial_sampling=="triangle")
             {
                 spatial_sampling = _spatial_sampling;
             }
             else if ((_spatial_sampling!="default" && _spatial_sampling!="taxel" &&
-                      _spatial_sampling!="patch") && (_ss=="taxel" || _ss=="patch"))
+                      _spatial_sampling!="triangle") && (_ss=="taxel" || _ss=="triangle"))
             {
                 spatial_sampling = _ss;   
             }
@@ -194,7 +209,7 @@ using namespace iCub::skinDynLib;
             }
         }
 
-        // Let's read the mapping of the taxels onto the center of their patch
+        // Let's read the mapping of the taxels onto the center of their triangle
         // even if the spatial_sampling variable is "taxel"
         // (it might come useful later)
         if (rf.check("taxel2Repr"))
@@ -338,7 +353,7 @@ using namespace iCub::skinDynLib;
         skinPartBase::print(verbosity);
         yDebug("number of valid taxels: %i", getTaxelsSize());
         yDebug("spatial_sampling:       %s", spatial_sampling.c_str());
-        if ((verbosity>=1 && spatial_sampling == "patch") ||
+        if ((verbosity>=1 && spatial_sampling == "triangle") ||
             (verbosity>=3 && spatial_sampling == "taxel"))
         {
             yDebug("Taxel ID -> Representative ID:");

--- a/src/libraries/skinDynLib/src/skinPart.cpp
+++ b/src/libraries/skinDynLib/src/skinPart.cpp
@@ -144,8 +144,8 @@ using namespace iCub::skinDynLib;
             else if (filename == "right_forearm_mesh.txt")   { setName(SkinPart_s[SKIN_RIGHT_FOREARM]);   setVersion("V1");   }
             else if (filename == "right_forearm_nomesh.txt") { setName(SkinPart_s[SKIN_RIGHT_FOREARM]);   setVersion("V1");   }
             else if (filename == "right_forearm_V2.txt")     { setName(SkinPart_s[SKIN_RIGHT_FOREARM]);   setVersion("V2");   }
-            else if (filename == "left_hand_V2_1.txt")       { setName(SkinPart_s[SKIN_LEFT_HAND]);       setVersion("V2_1"); }
-            else if (filename == "right_hand_V2_1.txt")      { setName(SkinPart_s[SKIN_RIGHT_HAND]);      setVersion("V2_1"); }
+            else if (filename == "left_hand_V2_1.txt")       { setName(SkinPart_s[SKIN_LEFT_HAND]);       setVersion("V2.1"); }
+            else if (filename == "right_hand_V2_1.txt")      { setName(SkinPart_s[SKIN_RIGHT_HAND]);      setVersion("V2.1"); }
             else if (filename == "left_arm_mesh.txt")        { setName(SkinPart_s[SKIN_LEFT_UPPER_ARM]);  setVersion("V1");   }
             else if (filename == "right_arm_mesh.txt")       { setName(SkinPart_s[SKIN_RIGHT_UPPER_ARM]); setVersion("V1");   }
             else if (filename == "torso.txt")                { setName(SkinPart_s[SKIN_FRONT_TORSO]);     setVersion("V1");   }


### PR DESCRIPTION
- enhancing `skinDynLib` with skin part version ("V1" / "V2" ...). N.B. For skin parts that to my knowledge have only one version, like torso, I set it to "V1".
- fixing spatial_sampling variable -> "triangle" instead of "patch"
- some improved comments

@alecive please have a look.
maybe also @traversaro 