### PR TITLE
Code to address iCub Head v2.5

### DIFF
--- a/src/libraries/iKin/ChangeLog
+++ b/src/libraries/iKin/ChangeLog
@@ -1,3 +1,6 @@
+2016-12-01 Ugo Pattacini <ugo.pattacini@iit.it>
+      * Added head version 2.5
+
 2016-11-18 Ugo Pattacini <ugo.pattacini@iit.it>
       * failure conditions streamlined via yAssert()
 

--- a/src/libraries/iKin/include/iCub/iKin/iKinFwd.h
+++ b/src/libraries/iKin/include/iCub/iKin/iKinFwd.h
@@ -1282,7 +1282,7 @@ public:
     * Constructor. 
     * @param _type is a string to discriminate between "left" and 
     *              "right" eye. Further available options are
-    *              "[left|right]_v[1|2]".
+    *              "[left|right]_v[1|2|2.5]".
     */
     iCubEye(const std::string &_type);
 
@@ -1318,7 +1318,7 @@ public:
     * Constructor. 
     * @param _type is a string to discriminate between "left" and 
     *              "right" eye. Further available options are
-    *              "left_v2" and "right_v2".
+    *              "[left|right]_v[1|2|2.5]".
     */
     iCubEyeNeckRef(const std::string &_type);
 };
@@ -1345,7 +1345,7 @@ public:
     * Constructor. 
     * @param _type is a string to discriminate between "left" and 
     *              "right" eye. Further available options are
-    *              "[left|right]_v[1|2]".
+    *              "[left|right]_v[1|2|2.5]".
     */
     iCubHeadCenter(const std::string &_type);
 };
@@ -1370,7 +1370,7 @@ public:
 
     /**
     * Constructor. 
-    * @param _type is a string to discriminate between "v1" and "v2" 
+    * @param _type is a string discriminating among "v[1|2|2.5]" 
     *              hardware versions.
     */
     iCubInertialSensor(const std::string &_type);

--- a/src/libraries/iKin/src/iKinFwd.cpp
+++ b/src/libraries/iKin/src/iKinFwd.cpp
@@ -2193,7 +2193,7 @@ void iCubEye::allocate(const string &_type)
         pushLink(new iKinLink(    0.0,  -0.034, -M_PI/2.0,       0.0, -35.0*CTRL_DEG2RAD, 15.0*CTRL_DEG2RAD));
         pushLink(new iKinLink(    0.0,     0.0,  M_PI/2.0, -M_PI/2.0, -50.0*CTRL_DEG2RAD, 50.0*CTRL_DEG2RAD));
     }
-    else if (getType()=="right_v2")
+    else if ((getType()=="right_v2") || (getType()=="right_v2.5"))
     {
         pushLink(new iKinLink(  0.032,     0.0,  M_PI/2.0,       0.0, -22.0*CTRL_DEG2RAD, 84.0*CTRL_DEG2RAD));
         pushLink(new iKinLink(    0.0, -0.0055,  M_PI/2.0, -M_PI/2.0, -39.0*CTRL_DEG2RAD, 39.0*CTRL_DEG2RAD));
@@ -2206,7 +2206,9 @@ void iCubEye::allocate(const string &_type)
     }
     else
     {
-        type="left_v2";
+        if ((type!="left_v2") && (type!="left_v2.5"))
+            type="left_v2";
+
         pushLink(new iKinLink(  0.032,     0.0,  M_PI/2.0,       0.0, -22.0*CTRL_DEG2RAD, 84.0*CTRL_DEG2RAD));
         pushLink(new iKinLink(    0.0, -0.0055,  M_PI/2.0, -M_PI/2.0, -39.0*CTRL_DEG2RAD, 39.0*CTRL_DEG2RAD));
         pushLink(new iKinLink(    0.0, -0.2233, -M_PI/2.0, -M_PI/2.0, -59.0*CTRL_DEG2RAD, 59.0*CTRL_DEG2RAD));
@@ -2338,7 +2340,7 @@ void iCubInertialSensor::allocate(const string &_type)
     H0(3,3)=1.0;
     setH0(H0);
 
-    if (getType()=="v2")
+    if ((getType()=="v2") || (getType()=="v2.5"))
     {
         pushLink(new iKinLink(  0.032,     0.0,  M_PI/2.0,       0.0, -22.0*CTRL_DEG2RAD, 84.0*CTRL_DEG2RAD));
         pushLink(new iKinLink(    0.0, -0.0055,  M_PI/2.0, -M_PI/2.0, -39.0*CTRL_DEG2RAD, 39.0*CTRL_DEG2RAD));
@@ -2358,11 +2360,24 @@ void iCubInertialSensor::allocate(const string &_type)
         pushLink(new iKinLink( 0.0225,  0.1005, -M_PI/2.0,  M_PI/2.0, -55.0*CTRL_DEG2RAD, 55.0*CTRL_DEG2RAD));
     }
 
-    // virtual link that describes T_nls (see http://wiki.icub.org/wiki/ICubInertiaSensorKinematics )
-    pushLink(new iKinLink(        0.0,  0.0066,  M_PI/2.0,       0.0,   0.0*CTRL_DEG2RAD,  0.0*CTRL_DEG2RAD));
+    // T_nls (see http://wiki.icub.org/wiki/ICubInertiaSensorKinematics )
+    Matrix HN(4,4);
+    HN.zero();
+    HN(0,0)=1.0;
+    HN(2,1)=1.0;
+    HN(1,2)=-1.0;
+    HN(2,3)=0.0066;
+    HN(3,3)=1.0;
+    setHN(HN);
 
-    // block virtual links
-    blockLink(6,0.0);
+    if (getType()=="v2.5")
+    {
+        Matrix HN=eye(4,4);
+        HN(0,3)=0.0087;
+        HN(1,3)=0.01795;
+        HN(2,3)=-0.0105;
+        setHN(getHN()*HN);
+    }
 }
 
 

--- a/src/modules/iKinGazeCtrl/include/iCub/utils.h
+++ b/src/modules/iKinGazeCtrl/include/iCub/utils.h
@@ -127,6 +127,8 @@ public:
     Matrix  get_fpFrame();
     Vector  get_imu();
 
+    string  headVersion2String();
+
     // data members that do not need protection
     xdPort         *port_xd;
     string          robotName;

--- a/src/modules/iKinGazeCtrl/src/controller.cpp
+++ b/src/modules/iKinGazeCtrl/src/controller.cpp
@@ -34,10 +34,10 @@ Controller::Controller(PolyDriver *_drvTorso, PolyDriver *_drvHead, ExchangeData
                        printAccTime(0.0)
 {
     // Instantiate objects
-    neck=new iCubHeadCenter(commData->head_version>1.0?"right_v2":"right");
-    eyeL=new iCubEye(commData->head_version>1.0?"left_v2":"left");
-    eyeR=new iCubEye(commData->head_version>1.0?"right_v2":"right");
-    imu=new iCubInertialSensor(commData->head_version>1.0?"v2":"v1");
+    neck=new iCubHeadCenter("right_"+commData->headVersion2String());
+    eyeL=new iCubEye("left_"+commData->headVersion2String());
+    eyeR=new iCubEye("right_"+commData->headVersion2String());
+    imu=new iCubInertialSensor(commData->headVersion2String());
 
     // remove constraints on the links: logging purpose
     imu->setAllConstraints(false);

--- a/src/modules/iKinGazeCtrl/src/localizer.cpp
+++ b/src/modules/iKinGazeCtrl/src/localizer.cpp
@@ -28,9 +28,9 @@
 Localizer::Localizer(ExchangeData *_commData, const unsigned int _period) :
                      RateThread(_period), commData(_commData), period(_period)
 {
-    iCubHeadCenter eyeC(commData->head_version>1.0?"right_v2":"right");
-    eyeL=new iCubEye(commData->head_version>1.0?"left_v2":"left");
-    eyeR=new iCubEye(commData->head_version>1.0?"right_v2":"right");
+    iCubHeadCenter eyeC("right_"+commData->headVersion2String());
+    eyeL=new iCubEye("left_"+commData->headVersion2String());
+    eyeR=new iCubEye("right_"+commData->headVersion2String());
 
     // remove constraints on the links
     // we use the chains for logging purpose

--- a/src/modules/iKinGazeCtrl/src/main.cpp
+++ b/src/modules/iKinGazeCtrl/src/main.cpp
@@ -96,8 +96,8 @@ Factors</a>.
 --context \e dir
 - Resource finder default searching directory for configuration
   files; if not specified, \e iKinGazeCtrl is assumed. Beware of
-  the <a href="http://www.yarp.it/yarp_data_dirs.html">context  
-  search policy</a>.  
+  the <a href="http://www.yarp.it/yarp_data_dirs.html">context
+  search policy</a>.
 
 --from \e file
 - Resource finder default configuration file; if not specified,
@@ -208,9 +208,10 @@ Factors</a>.
   controller will implement a bang-bang approach whenever the
   velocity to be delivered goes under the minimum threshold.
 
---headV2
-- When this options is specified then the kinematic structure of
-  the hardware v2 of the head is referred.
+--head_version \e ver
+- This option specifies the kinematic structure of the head; the value
+  \e ver is a double in the set {1.0, 2.0, 2.5}, being 1.0 the default
+  version.
 
 --verbose
 - Enable some output print-out.
@@ -543,6 +544,8 @@ Windows, Linux
 \author Ugo Pattacini, Alessandro Roncone
 */
 
+#include <cmath>
+#include <algorithm>
 #include <fstream>
 #include <iomanip>
 #include <map>
@@ -992,6 +995,22 @@ protected:
         }
     }
 
+    /************************************************************************/
+    double constrainHeadVersion(const double ver_in)
+    {
+        map<double,double> d;
+        d[fabs(1.0-ver_in)]=1.0;
+        d[fabs(2.0-ver_in)]=2.0;
+        d[fabs(2.5-ver_in)]=2.5;
+
+        double ver_out=d.begin()->second;
+        if (ver_out!=ver_in)
+            yWarning("Unknown \"head_version\"=%g => used \"head_version\"=%g",
+                     ver_in,ver_out);
+
+        return ver_out;
+    }
+
 public:
     /************************************************************************/
     GazeModule()
@@ -1038,20 +1057,20 @@ public:
         torsoName=rf.check("torso",Value("torso")).asString().c_str();
         neckTime=trajTimeGroup.check("neck",Value(0.75)).asDouble();
         eyesTime=trajTimeGroup.check("eyes",Value(0.25)).asDouble();
-        min_abs_vel=CTRL_DEG2RAD*rf.check("min_abs_vel",Value(0.0)).asDouble();
+        min_abs_vel=CTRL_DEG2RAD*fabs(rf.check("min_abs_vel",Value(0.0)).asDouble());
         ping_robot_tmo=rf.check("ping_robot_tmo",Value(40.0)).asDouble();
 
         commData.robotName=rf.check("robot",Value("icub")).asString().c_str();
         commData.eyeTiltLim[0]=eyeTiltGroup.check("min",Value(-12.0)).asDouble();
         commData.eyeTiltLim[1]=eyeTiltGroup.check("max",Value(15.0)).asDouble();
-        commData.head_version=rf.check("headV2")?2.0:1.0;
+        commData.head_version=constrainHeadVersion(rf.check("head_version",Value(1.0)).asDouble());
         commData.verbose=rf.check("verbose");
         commData.saccadesOn=(rf.check("saccades",Value("on")).asString()=="on");
         commData.neckPosCtrlOn=(rf.check("neck_position_control",Value("on")).asString()=="on");
         commData.stabilizationOn=(imuGroup.check("mode",Value("on")).asString()=="on");
         commData.stabilizationGain=imuGroup.check("stabilization_gain",Value(11.0)).asDouble();
         commData.gyro_noise_threshold=CTRL_DEG2RAD*imuGroup.check("gyro_noise_threshold",Value(5.0)).asDouble();
-        commData.debugInfoEnabled=rf.check("debugInfo",Value("off")).asString()=="on";
+        commData.debugInfoEnabled=rf.check("debugInfo",Value("off")).asString()=="on";        
 
         if (commData.stabilizationOn)
         {
@@ -1063,11 +1082,6 @@ public:
             counterRotGain[0]=imuGroup.check("vor",Value(0.0)).asDouble();
             counterRotGain[1]=rf.check("ocr",Value(1.0)).asDouble();
         }
-
-        // min_abs_vel is given in absolute form
-        // hence it must be positive
-        if (min_abs_vel<0.0)
-            min_abs_vel=-min_abs_vel;
 
         if (camerasGroup.check("file"))
         {

--- a/src/modules/iKinGazeCtrl/src/main.cpp
+++ b/src/modules/iKinGazeCtrl/src/main.cpp
@@ -1005,7 +1005,7 @@ protected:
 
         double ver_out=d.begin()->second;
         if (ver_out!=ver_in)
-            yWarning("Unknown \"head_version\"=%g => used \"head_version\"=%g",
+            yWarning("Unknown \"head_version\" %g requested => used \"head_version\" %g instead",
                      ver_in,ver_out);
 
         return ver_out;

--- a/src/modules/iKinGazeCtrl/src/solver.cpp
+++ b/src/modules/iKinGazeCtrl/src/solver.cpp
@@ -32,10 +32,10 @@ EyePinvRefGen::EyePinvRefGen(PolyDriver *_drvTorso, PolyDriver *_drvHead,
                              Ts(_period/1000.0),  counterRotGain(_counterRotGain)
 {
     // Instantiate objects
-    neck=new iCubHeadCenter(commData->head_version>1.0?"right_v2":"right");
-    eyeL=new iCubEye(commData->head_version>1.0?"left_v2":"left");
-    eyeR=new iCubEye(commData->head_version>1.0?"right_v2":"right");
-    imu=new iCubInertialSensor(commData->head_version>1.0?"v2":"v1");
+    neck=new iCubHeadCenter("right_"+commData->headVersion2String());
+    eyeL=new iCubEye("left_"+commData->headVersion2String());
+    eyeR=new iCubEye("right_"+commData->headVersion2String());
+    imu=new iCubInertialSensor(commData->headVersion2String());
 
     // remove constraints on the links: logging purpose
     imu->setAllConstraints(false);
@@ -456,10 +456,10 @@ Solver::Solver(PolyDriver *_drvTorso, PolyDriver *_drvHead, ExchangeData *_commD
                ctrl(_ctrl),         period(_period),         Ts(_period/1000.0)
 {
     // Instantiate objects
-    neck=new iCubHeadCenter(commData->head_version>1.0?"right_v2":"right");
-    eyeL=new iCubEye(commData->head_version>1.0?"left_v2":"left");
-    eyeR=new iCubEye(commData->head_version>1.0?"right_v2":"right");
-    imu=new iCubInertialSensor(commData->head_version>1.0?"v2":"v1");
+    neck=new iCubHeadCenter("right_"+commData->headVersion2String());
+    eyeL=new iCubEye("left_"+commData->headVersion2String());
+    eyeR=new iCubEye("right_"+commData->headVersion2String());
+    imu=new iCubInertialSensor(commData->headVersion2String());
 
     // remove constraints on the links: logging purpose
     imu->setAllConstraints(false);

--- a/src/modules/iKinGazeCtrl/src/utils.cpp
+++ b/src/modules/iKinGazeCtrl/src/utils.cpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <limits>
 #include <algorithm>
+#include <sstream>
 
 #include <iCub/utils.h>
 #include <iCub/solver.h>
@@ -361,6 +362,15 @@ Vector ExchangeData::get_imu()
     LockGuard lg(mutex[MUTEX_IMU]);
     Vector _imu=imu;
     return _imu;
+}
+
+
+/************************************************************************/
+string ExchangeData::headVersion2String()
+{
+    ostringstream str;
+    str<<"v"<<head_version;
+    return str.str();
 }
 
 


### PR DESCRIPTION
Following up discussion in #285, I've prepared these changes to:

1. Update `iKin` to deal with new kinematic structures (the so-called version `2.5`).

2. Streamline `iKinGazeCtrl` to the use of new command-line parameters `--head_version` in place of `--headV2`.
    In the new context of diverse head versions, `--headV2` was quite limiting, also considering future hardware releases.

I'm going to create a corresponding PR in [**robots-configuration**](https://github.com/robotology/robots-configuration) to update `iKinGazeCtrl` parameters.

Once done, I'll send around an announcement.

@traversaro could you please have a look here?