### PR TITLE
V4L camera: fix enum name after typo fix in yarp

### DIFF
--- a/src/libraries/icubmod/usbCamera/linux/V4L_camera.hpp
+++ b/src/libraries/icubmod/usbCamera/linux/V4L_camera.hpp
@@ -199,7 +199,7 @@ private:
     yarp::os::Semaphore mutex;
     bool doCropping;
     bool dual;
-    bool isActive_vector[YARP_FEATURE_NUMEBR_OF];
+    bool isActive_vector[YARP_FEATURE_NUMBER_OF];
     double timeStart, timeTot, timeNow, timeElapsed;
     int myCounter;
     int frameCounter;


### PR DESCRIPTION
Fix enum name typo in yarp triggered update in icub's device using it.