### PR TITLE
Better handling of homing gaze in ARE

### DIFF
--- a/src/modules/actionsRenderingEngine/include/iCub/MotorThread.h
+++ b/src/modules/actionsRenderingEngine/include/iCub/MotorThread.h
@@ -41,7 +41,6 @@
 #define HEAD_MODE_TRACK_TEMP        3
 #define HEAD_MODE_TRACK_CART        4
 #define HEAD_MODE_TRACK_FIX         5
-#define HEAD_MODE_LOOK              6
 
 #define ARM_MODE_IDLE               0
 #define ARM_MODE_LEARN_ACTION       1


### PR DESCRIPTION
The way **actionsRenderingEngine** (ARE) is currently homing the gaze is somewhat mazy. The `goHome()` method triggers homing by changing the state of a internal variable which in turn is handled within `run()`.

Instead, this PR brings everything inside `goHome()`.