### PR TITLE
[gravityCompensator, WBD] use --head_version instead of --headV2

### DIFF
--- a/app/iCubStartup/scripts/iCubStartup.xml.template
+++ b/app/iCubStartup/scripts/iCubStartup.xml.template
@@ -65,7 +65,7 @@
         <!-- Enable/disable wholeBodyDynamics if you do/don't have torque sensors -->
         <module>
                 <name>wholeBodyDynamics</name>
-                <!-- Remember to add the "--headV2" parameter for robots equipped with head v. 2.0 -->
+                <!-- Remember to add the "--head_version 2.0" (or 2.5) parameter for robots equipped with head 2.0 (or 2.5) -->
                 <parameters>--autoconnect</parameters>
                 <node>pwrNode6</node>
                 <dependencies>
@@ -76,7 +76,7 @@
         <!-- Enable/disable gravityCompensator if you do/don't have torque sensors -->
         <module>
                 <name>gravityCompensator</name>
-                <!-- Remember to add the "--headV2" parameter for robots equipped with head v. 2.0 -->
+                <!-- Remember to add the "--head_version 2.0" (or 2.5) parameter for robots equipped with head 2.0 (or 2.5) -->
                 <parameters></parameters>
                 <node>pwrNode6</node>
                 <dependencies>

--- a/src/modules/gravityCompensator/main.cpp
+++ b/src/modules/gravityCompensator/main.cpp
@@ -227,12 +227,31 @@ public:
 
         //------------SPECIAL PARAM TP DEFINE THE HEAD TYPE-----//
         version_tag icub_type;
-        if (rf.check("headV2"))
+        // set icub_type.head_version int to 1 (default) or 2
+        if (rf.check("head_version"))
         {
-            yInfo("'headV2' option found. Using icubV2 head kinematics.\n");
-            icub_type.head_version = 2;
+            if (rf.find("head_version").asDouble()==1.0)
+            {
+                yInfo("\"head_version\" %g requested => Using V1 head kinematics.\n",
+                      rf.find("head_version").asDouble());
+            }
+            else if (rf.find("head_version").asDouble()==2.0 ||
+                rf.find("head_version").asDouble()==2.5)
+            {
+                yInfo("\"head_version\" %g requested => Using V2 head kinematics.\n",
+                      rf.find("head_version").asDouble());
+                icub_type.head_version = 2;
+            }
+            else
+            {
+                yWarning("Unknown \"head_version\" %g requested => Using V1 head kinematics.\n",
+                         rf.find("head_version").asDouble());
+            }
         }
-
+        else
+        {
+            yInfo("No \"head_version\" specified => Using V1 head kinematics.\n");
+        }
         //------------------CHECK IF LEGS ARE ENABLED-----------//
         if (rf.check("no_legs"))
         {
@@ -526,7 +545,7 @@ int main(int argc, char * argv[])
         yInfo() << "--from       from: the name of the file.ini to be used for calibration";
         yInfo() << "--rate       rate: the period used by the module. default 100ms (not less than 15ms)";
         yInfo() << "--no_legs    this option disables the gravity compensation for the legs joints" ;
-        yInfo() << "--headV2     use the model of the headV2";
+        yInfo() << "--head_version v:  head structure, v is one of 1.0 (default), 2.0 or 2.5";
         yInfo() << "--no_left_arm      disables the left arm";
         yInfo() << "--no_right_arm     disables the right arm";
         yInfo() << "--no_legs          disables the legs";

--- a/src/modules/wholeBodyDynamics/main.cpp
+++ b/src/modules/wholeBodyDynamics/main.cpp
@@ -360,10 +360,30 @@ public:
         icub_type.head_version = 1;
         icub_type.legs_version = 1;
 
-        if (rf.check("headV2"))
+        // set icub_type.head_version int to 1 (default) or 2
+        if (rf.check("head_version"))
         {
-            yInfo("'headV2' option found. Using icubV2 head kinematics.\n");
-            icub_type.head_version = 2;
+            if (rf.find("head_version").asDouble()==1.0)
+            {
+                yInfo("\"head_version\" %g requested => Using V1 head kinematics.\n",
+                      rf.find("head_version").asDouble());
+            }
+            else if (rf.find("head_version").asDouble()==2.0 ||
+                rf.find("head_version").asDouble()==2.5)
+            {
+                yInfo("\"head_version\" %g requested => Using V2 head kinematics.\n",
+                      rf.find("head_version").asDouble());
+                icub_type.head_version = 2;
+            }
+            else
+            {
+                yWarning("Unknown \"head_version\" %g requested => Using V1 head kinematics.\n",
+                         rf.find("head_version").asDouble());
+            }
+        }
+        else
+        {
+            yInfo("No \"head_version\" specified => Using V1 head kinematics.\n");
         }
 
         //----------SPECIAL PARAM TO DEFINE LEGS VERSION--------//
@@ -762,7 +782,7 @@ int main(int argc, char * argv[])
         cout << "\t--local      name: the prefix of the ports opened by the module. defualt: wholeBodyDynamics"                  << endl;
         cout << "\t--autoconnect     automatically connects the module ports to iCubInterface"                                   << endl;
         cout << "\t--no_legs         this option disables the dynamics computation for the legs joints"                          << endl;  
-        cout << "\t--headV2          use the model of the headV2"                                                                << endl;
+        cout << "\t--head_version v: head structure, v is one of 1.0 (default), 2.0 or 2.5"                                      << endl;
         cout << "\t--legsV2          use the model of legsV2"                                                                    << endl;
         cout << "\t--no_left_arm     disables the left arm"                                                                      << endl;
         cout << "\t--no_right_arm    disables the right arm"                                                                     << endl;


### PR DESCRIPTION
Replaced the option `--headV2` with `--head_version 2.0` (or `2.5`), to be consistent with the recent change in `iKinGazeCtrl` (https://github.com/robotology/icub-main/pull/391).

If the option `--head_version` is absent or has an invalid argument, the head v1 model is used and a message is printed.

/cc https://github.com/robotology/icub-main/issues/285 https://github.com/robotology/icub-main/issues/405