### PR TITLE
V4L_camera: fix potential memory leak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
   #install yarp from master
   - git clone https://github.com/robotology/yarp
   - cd yarp
-  - git checkout devel
+  - git checkout master
   - mkdir build
   - cd build
   - cmake ../ -DCREATE_GUIS:BOOL=ON -DCREATE_LIB_MATH:BOOL=ON -DCREATE_OPTIONAL_CARRIERS:BOOL=ON -DENABLE_yarpcar_bayer_carrier:BOOL=ON

--- a/src/libraries/icubmod/usbCamera/linux/V4L_camera.cpp
+++ b/src/libraries/icubmod/usbCamera/linux/V4L_camera.cpp
@@ -11,7 +11,7 @@
 #include <list.hpp>
 #include <yarp/os/Time.h>
 #include <yarp/os/Value.h>
-#include "libv4lconvert.h"
+
 
 
 #include <opencv2/core/core.hpp>
@@ -23,7 +23,6 @@
 
 //#include <Leopard_MT9M021C.h>
 
-struct v4lconvert_data *_v4lconvert_data;
 
 using namespace yarp::os;
 using namespace yarp::dev;
@@ -87,6 +86,7 @@ V4L_camera::V4L_camera() : RateThread(1000/DEFAULT_FRAMERATE), doCropping(false)
     param.dst_image = NULL;
     param.n_buffers = 0;
     param.buffers = NULL;
+    _v4lconvert_data = NULL;
     param.camModel = SEE3CAMCU50;
     myCounter = 0;
     timeTot = 0;
@@ -522,6 +522,11 @@ bool V4L_camera::deviceUninit()
     
     if(param.buffers != 0)
         free(param.buffers);
+    if(_v4lconvert_data != NULL)
+    {
+        v4lconvert_destroy(_v4lconvert_data);
+        _v4lconvert_data=NULL;
+    }
     return ret;
 }
 

--- a/src/libraries/icubmod/usbCamera/linux/V4L_camera.hpp
+++ b/src/libraries/icubmod/usbCamera/linux/V4L_camera.hpp
@@ -42,6 +42,7 @@
 #include <linux/videodev2.h>
 #include <jpeglib.h>
 #include <libv4l2.h>
+#include <libv4lconvert.h>
 
 #include <cv.h>
 
@@ -194,6 +195,7 @@ public:
 
 private:
 
+    v4lconvert_data *_v4lconvert_data;
     yarp::os::Stamp timeStamp;
     Video_params param;
     yarp::os::Semaphore mutex;


### PR DESCRIPTION
We found and fixed a memory leak triggered when you open two devices `usbCamera`.
Please review code.