### PR TITLE
frameGrabberGui: fixing valgrind error, int uninitialised

### DIFF
--- a/src/tools/frameGrabberGui2-qt/loadingwidget.cpp
+++ b/src/tools/frameGrabberGui2-qt/loadingwidget.cpp
@@ -6,6 +6,7 @@ LoadingWidget::LoadingWidget(QWidget *parent) :
     ui(new Ui::LoadingWidget)
 {
     ui->setupUi(this);
+    counter=0;
 
     setWindowFlags(Qt::FramelessWindowHint | Qt::Dialog);
     setAttribute(Qt::WA_TranslucentBackground);


### PR DESCRIPTION
Fix the following valgrind error get opening FrameGrabber gui:
```
==30575== Conditional jump or move depends on uninitialised value(s)
==30575==    at 0x6666225: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.5.1)
==30575==    by 0x66683FF: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.5.1)
==30575==    by 0x66699A2: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.5.1)
==30575==    by 0x6669F0B: QResource::isCompressed() const (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.5.1)
==30575==    by 0x666A1EE: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.5.1)
==30575==    by 0x669ECCF: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.5.1)
==30575==    by 0x669EE6B: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.5.1)
==30575==    by 0x663DA9E: QFileInfo::QFileInfo(QString const&) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.5.1)
==30575==    by 0x60AFC57: QPixmap::load(QString const&, char const*, QFlags<Qt::ImageConversionFlag>) (in /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5.5.1)
==30575==    by 0x60B03CF: QPixmap::QPixmap(QString const&, char const*, QFlags<Qt::ImageConversionFlag>) (in /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5.5.1)
==30575==    by 0x41FDF4: LoadingWidget::onSplashTimer() (loadingwidget.cpp:33)
==30575==    by 0x4300F8: LoadingWidget::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) (moc_loadingwidget.cpp:69)
==30575== 
==30575== Use of uninitialised value of size 8
==30575==    at 0x60B1C02: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5.5.1)
==30575==    by 0x60B1E4E: QPixmapCache::find(QString const&, QPixmap*) (in /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5.5.1)
==30575==    by 0x60B0119: QPixmap::load(QString const&, char const*, QFlags<Qt::ImageConversionFlag>) (in /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5.5.1)
==30575==    by 0x60B03CF: QPixmap::QPixmap(QString const&, char const*, QFlags<Qt::ImageConversionFlag>) (in /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5.5.1)
==30575==    by 0x41FDF4: LoadingWidget::onSplashTimer() (loadingwidget.cpp:33)
==30575==    by 0x4300F8: LoadingWidget::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) (moc_loadingwidget.cpp:69)
==30575==    by 0x674AD29: QMetaObject::activate(QObject*, int, int, void**) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.5.1)
==30575==    by 0x67575C7: QTimer::timerEvent(QTimerEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.5.1)
==30575==    by 0x674BBB2: QObject::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.5.1)
==30575==    by 0x5A1C05B: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.5.1)
==30575==    by 0x5A21515: QApplication::notify(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.5.1)
==30575==    by 0x671C38A: QCoreApplication::notifyInternal(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.5.1)

```