### PR TITLE
Update xml template for using the new ServerGrabber

### DIFF
--- a/app/default/scripts/cameras_calib.xml.template
+++ b/app/default/scripts/cameras_calib.xml.template
@@ -4,12 +4,7 @@
 </dependencies> 
 <module>
   <name>yarpdev</name>
-      <parameters> --from camera/dragonfly2_config_left.ini</parameters>
-  <node>pc104</node>
-</module>
-<module>
-  <name>yarpdev</name>
-      <parameters> --from camera/dragonfly2_config_right.ini</parameters>
+      <parameters> --from camera/ServerGrabberDualDragon.ini --split true</parameters>
   <node>pc104</node>
 </module>
 <module>
@@ -51,22 +46,22 @@
 <connection>
   <from>/icub/cam/left</from>
   <to>/icub/camcalib/left/in</to>
-  <protocol>tcp</protocol>
+  <protocol>udp</protocol>
 </connection>
 <connection>
   <from>/icub/cam/right</from>
   <to>/icub/camcalib/right/in</to>
-  <protocol>tcp</protocol>
+  <protocol>udp</protocol>
 </connection>
 <connection>
   <from>/icub/camcalib/left/out</from>
   <to>/icub/view/left</to>
-  <protocol>tcp</protocol>
+  <protocol>udp</protocol>
 </connection>
 <connection>
   <from>/icub/camcalib/right/out</from>
   <to>/icub/view/right</to>
-  <protocol>tcp</protocol>
+  <protocol>udp</protocol>
 </connection>
 </application>
 

--- a/app/default/scripts/cameras_calib_bayer_320_240.xml.template
+++ b/app/default/scripts/cameras_calib_bayer_320_240.xml.template
@@ -4,13 +4,8 @@
 </dependencies>
    <module>
       <name>yarpdev</name>
-      <parameters> --from camera/dragonfly2_config_left_bayer_320_240.ini</parameters>
+      <parameters> --from camera/ServerGrabberDualDragonBayer.ini --split true</parameters>
 	  <node>pc104</node>
-   </module>
-   <module>
-      <name>yarpdev</name>
-      <parameters> --from camera/dragonfly2_config_left_bayer_320_240.ini</parameters>
-      <node>pc104</node>
    </module>
     <module>
         <name>camCalib</name>

--- a/app/default/scripts/cameras_calib_bayer_640_480.xml.template
+++ b/app/default/scripts/cameras_calib_bayer_640_480.xml.template
@@ -4,13 +4,8 @@
 </dependencies>
 <module>
       <name>yarpdev</name>
-      <parameters> --from camera/dragonfly2_config_left_bayer_640_480 </parameters>
+      <parameters> --from camera/ServerGrabberDualDragonBayer640_480.ini --split true</parameters>
 	  <node>pc104</node>
-   </module>
-   <module>
-      <name>yarpdev</name>
-      <parameters> --from camera/dragonfly2_config_right_bayer_640_480</parameters>
-      <node>pc104</node>
    </module>
     <module>
         <name>camCalib</name>


### PR DESCRIPTION
This PR update the templates for using the new `grabberDual` through `yarpmanager`.
