### PR TITLE
The thread EthReceiver checks presence of ETH boards as specified in …

### DIFF
--- a/src/libraries/icubmod/embObjLib/ethManager.h
+++ b/src/libraries/icubmod/embObjLib/ethManager.h
@@ -215,6 +215,8 @@ public:
 
     bool Transmission(void);
 
+    bool CheckPresence(void);
+
     bool Reception(ACE_INET_Addr adr, uint64_t* data, ssize_t size, bool collectStatistics);
 
     EthResource* getEthResource(eOipv4addr_t ipv4);

--- a/src/libraries/icubmod/embObjLib/ethResource.h
+++ b/src/libraries/icubmod/embObjLib/ethResource.h
@@ -147,6 +147,41 @@ public:
 };
 
 
+class EthMonitorPresence
+{
+public:
+
+    struct Config
+    {
+        bool    enabled;
+        double  timeout;                // in seconds
+        double  periodmissingreport;    // in seconds
+        std::string name;
+        Config() : enabled(true), timeout(0.020), periodmissingreport(30.0), name("generic") {}
+        Config(bool en, double t, double p, const std::string& na) : enabled(en), timeout(t), periodmissingreport(p), name(na) {}
+    };
+
+    EthMonitorPresence();
+    ~EthMonitorPresence();
+
+    void config(const Config &cfg);
+    void enable(bool en);
+    bool isenabled();
+
+    void tick();
+    bool check();   // returns true if ok, false if missing
+
+private:
+
+    Config configuration;
+
+    double lastTickTime;
+    double lastMissingReportTime;
+    double lastHeardTime;
+    bool reportedMissing;
+};
+
+
 // -- class EthNetworkQuery
 // -- it is used to wait for a reply from a board.
 
@@ -248,6 +283,8 @@ public:
 
     bool serviceStop(eOmn_serv_category_t category, double timeout = 0.500);
 
+    bool Tick();
+    bool Check();
 
     // -- not used at the moment
     void checkIsAlive(double curr_time);
@@ -290,6 +327,10 @@ private:
     can_string_eth*     c_string_handler[16];
 
     TheEthManager       *ethManager;
+
+    EthMonitorPresence monitorpresence;
+
+    bool regularsAreSet;
 
 private:
 


### PR DESCRIPTION
This commit fixes a feature gone missing some time ago and it adds xml configuration to it.
The thread EthReceiver checks presence of ETH boards in a way that is described by parameters
inside the group ETH_BOARD/ETH_BOARD_ACTIONS/MONITOR_ITS_PRESENCE.
If the section is not present, default values are used.
