### PR TITLE
Fix build on Windows

### DIFF
--- a/src/tools/canLoader/canLoaderLib/downloader.cpp
+++ b/src/tools/canLoader/canLoaderLib/downloader.cpp
@@ -95,7 +95,7 @@ cDownloader::cDownloader(bool verbose)
     set_canbus_id(-1);
 }
 
-bool cDownloader::set_verbose(bool verbose)
+void cDownloader::set_verbose(bool verbose)
 {
     _verbose = verbose;
 }

--- a/src/tools/canLoader/canLoaderLib/downloader.h
+++ b/src/tools/canLoader/canLoaderLib/downloader.h
@@ -225,7 +225,7 @@ int sg6_set_amp_gain      (int bus, int target_id, char channel, unsigned int  g
 
 cDownloader(bool verbose = true);
 
-bool set_verbose(bool verbose);
+void set_verbose(bool verbose);
 
 
 private:

--- a/src/tools/canLoader/canLoaderLib/driver.h
+++ b/src/tools/canLoader/canLoaderLib/driver.h
@@ -155,7 +155,7 @@ public:
     int send_message(vector<CanPacket> &canpackets, int n);
     iDriver2Type type() { return eth_driver2; }
 
-    bool set_verbose(bool v);
+    void set_verbose(bool v);
 private:
     CanSocket *mSocket;
     ACE_UINT32 mBoardAddr;


### PR DESCRIPTION
Due to a missing return in the implementation of setVerbose function in canLoaderLib, building icub-main on Windows failed (VS2013-64bit).

If there are no reasons for keeping the return value and returning something, please merge the pull request.