### PR TITLE
iCubCluster: set installation destination to yarpmanager context

### DIFF
--- a/app/iCubCluster/CMakeLists.txt
+++ b/app/iCubCluster/CMakeLists.txt
@@ -1,4 +1,3 @@
-set(appname iCubCluster)
 
 set(conf ${CMAKE_CURRENT_SOURCE_DIR}/conf/cluster-config.xml)
-yarp_install(FILES ${conf} DESTINATION ${ICUB_CONTEXTS_INSTALL_DIR}/${appname})
+yarp_install(FILES ${conf} DESTINATION ${ICUB_CONTEXTS_INSTALL_DIR}/yarpmanager)


### PR DESCRIPTION
This PR change the destination of the installation of the cluster-config.xml to the `yarpmanager` context, to use the `iCubCluster` integrated in `yarpamanger`.
Please review code.