### PR TITLE
strain2support

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -33,7 +33,7 @@ message(STATUS "CMake modules directory: ${CMAKE_MODULE_PATH}")
 # the requested one.
 find_package(icub_firmware_shared COMPONENTS canProtocolLib QUIET)
 if(icub_firmware_shared_FOUND)
-  find_package(icub_firmware_shared 4.0.0 COMPONENTS canProtocolLib)
+  find_package(icub_firmware_shared 4.0.1 COMPONENTS canProtocolLib)
 endif()
 
 find_package(GSL)

--- a/src/libraries/icubmod/embObjLib/serviceParser.cpp
+++ b/src/libraries/icubmod/embObjLib/serviceParser.cpp
@@ -954,8 +954,9 @@ bool ServiceParser::parseService(Searchable &config, servConfigStrain_t &strainc
     memset(&strainconfig.ethservice.configuration, 0, sizeof(strainconfig.ethservice.configuration));
 
     strainconfig.ethservice.configuration.type = eomn_serv_AS_strain;
-    memcpy(&strainconfig.ethservice.configuration.data.as.strain.version.protocol, &thestrain_props.protocol, sizeof(eObrd_protocolversion_t));
-    memcpy(&strainconfig.ethservice.configuration.data.as.strain.version.firmware, &thestrain_props.firmware, sizeof(eObrd_firmwareversion_t));
+    strainconfig.ethservice.configuration.data.as.strain.boardtype.type = thestrain_props.type;
+    memcpy(&strainconfig.ethservice.configuration.data.as.strain.boardtype.protocol, &thestrain_props.protocol, sizeof(eObrd_protocolversion_t));
+    memcpy(&strainconfig.ethservice.configuration.data.as.strain.boardtype.firmware, &thestrain_props.firmware, sizeof(eObrd_firmwareversion_t));
 
     // second check we do is about thestrain_sensor.location
     if(eobrd_place_can != thestrain_sensor.location.any.place)

--- a/src/libraries/icubmod/embObjStrain/embObjStrain.cpp
+++ b/src/libraries/icubmod/embObjStrain/embObjStrain.cpp
@@ -748,21 +748,22 @@ bool embObjStrain::close()
 
 
 void embObjStrain::printServiceConfig(void)
-{
+{    
     char loc[20] = {0};
     char fir[20] = {0};
     char pro[20] = {0};
     const char * boardname = (NULL != res) ? (res->getName()) : ("NOT-ASSIGNED-YET");
     const char * ipv4 = (NULL != res) ? (res->getIPv4string()) : ("NOT-ASSIGNED-YET");
+    const char * boardtype = eoboards_type2string2(static_cast<eObrd_type_t>(serviceConfig.ethservice.configuration.data.as.strain.boardtype.type), eobool_true);
 
     parser->convert(serviceConfig.ethservice.configuration.data.as.strain.canloc, loc, sizeof(loc));
-    parser->convert(serviceConfig.ethservice.configuration.data.as.strain.version.firmware, fir, sizeof(fir));
-    parser->convert(serviceConfig.ethservice.configuration.data.as.strain.version.protocol, pro, sizeof(pro));
+    parser->convert(serviceConfig.ethservice.configuration.data.as.strain.boardtype.firmware, fir, sizeof(fir));
+    parser->convert(serviceConfig.ethservice.configuration.data.as.strain.boardtype.protocol, pro, sizeof(pro));
 
     yInfo() << "The embObjStrain device using BOARD" << boardname << " w/ IP" << ipv4 << "has the following service config:";
     yInfo() << "- acquisitionrate =" << serviceConfig.acquisitionrate;
     yInfo() << "- useCalibration =" << serviceConfig.useCalibration;
-    yInfo() << "- STRAIN named" << serviceConfig.nameOfStrain << "@" << loc << "with required protocol version =" << pro << "and required firmware version =" << fir;
+    yInfo() << "- STRAIN of type" << boardtype << "named" << serviceConfig.nameOfStrain << "@" << loc << "with required protocol version =" << pro << "and required firmware version =" << fir;
 }
 
 


### PR DESCRIPTION
Added support for discovery of strain2 boards. It requires to update icub-firmware-shared and the FW of ETH boards.