### PR TITLE
Improve doxygen documentation of YARP Devices

### DIFF
--- a/src/doc/groups.dox
+++ b/src/doc/groups.dox
@@ -90,7 +90,7 @@
 * interfaces. Most often they wrap vendor's libraries for hardware
 * devices (dragonfly cameras, or the can bus), and the calibrator classes of the robot.
 *
-* The compilation of this devices is typically optional and regulated by
+* The compilation of these devices is typically optional and regulated by
 * the ENABLE_devicename CMake option.
 * The device can be instantiated from the yarpdev or yarprobotinterface executables
 * or in the code by using yarp::dev::PolyDriver factory class.

--- a/src/doc/groups.dox
+++ b/src/doc/groups.dox
@@ -82,27 +82,27 @@
 */
 
 /**
-* \defgroup icub_mod_library iCub mod library
+* \defgroup icub_mod_library iCub YARP devices library
 * @ingroup icub_modules_all
 *
-* Objects that can be conditionally compiled in the main build. 
-* All these objects are compiled in a single library called 
-* icubmod; they can be instantiated from the icubmoddev
-* executable or in the code by calling the polydriver.
+* [YARP devices](http://www.yarp.it/note_devices.html) contained in icub-main .
+* The YARP devices are classes that implement one or more YARP virtual
+* interfaces. Most often they wrap vendor's libraries for hardware
+* devices (dragonfly cameras, or the can bus), and the calibrator classes of the robot.
 *
-* These objects are classes that implement one or more YARP virtual 
-* interfaces. Most often they wrap vendor's libraries for hardware 
-* devices (dragonfly cameras, or the can bus),
-* and the calibrator classes of the robot. 
-* 
-* Each object is stored in a directory within icub-main/src/modules. 
+* The compilation of this devices is typically optional and regulated by
+* the ENABLE_devicename CMake option.
+* The device can be instantiated from the yarpdev or yarprobotinterface executables
+* or in the code by using yarp::dev::PolyDriver factory class.
+*
+* Each device is stored in a directory within icub-main/src/libraries/icubmod .
 *
 * To add a module to this list please add this in the source code:
 *
 \verbatim
   /**
-   * \defgroup icub_your_mod_library your_mod_library
    * @ingroup icub_mod_library
+   * @brief `yarpdevicename` : device description.
    *
    */
 \endverbatim
@@ -111,17 +111,17 @@
 */
 
 /**
-* \defgroup icub_hardware_modules Hardware modules
+* \defgroup icub_hardware_modules Hardware YARP devices
 * @ingroup icub_mod_library
 *
-* Objects that provide access to the robot hardware. 
+* YARP devices that provide access to the robot hardware.
 *
-* To add a module to this list please add this in the source code:
+* To add a device to this list please add this in the source code:
 *
 \verbatim
   /**
-   * \defgroup icub_your_mod_library your_mod_library
    * @ingroup icub_hardware_modules
+   * @brief `yarpdevicename` : device description.
    *
    */
 \endverbatim
@@ -130,19 +130,19 @@
 */
 
 /**
-* \defgroup icub_calibrators Calibrator classes
+* \defgroup icub_calibrators Calibrator YARP devices
 * @ingroup icub_mod_library
 *
-* Objects that contain the routines
+* YARP devices that contain the routines
 * for calibrating the robot at startup. They are very 
 * iCub specific.
 *
-* To add a module to this group add this in the source code:
+* To add a module to this group add this in the doxygen block of the device class:
 *
 \verbatim
   /**
-   * \defgroup icub_your_calibrator your_calibrator
    * @ingroup icub_calibrators
+   * @brief `yarpdevicename` : device description.
    *
    */
 \endverbatim

--- a/src/doc/main.dox
+++ b/src/doc/main.dox
@@ -17,7 +17,7 @@ completely broken!
 Topics:
 
  - <a href="http://wiki.icub.org/wiki/ICub_Software_Installation">Software installation</a>.
- - \ref icub_modules_all \endref - most of the software (including \ref icub_module \endref)
+ - \ref icub_modules_all \endref - most of the software (including \ref icub_module \endref and \ref icub_mod_library \endref)
  - \ref icub_applications \endref - a list of documented applications 
    (collections of modules)
  - \ref icub_tutorials \endref - a set of tutorials to learn how to use the software

--- a/src/libraries/icubmod/canBusAnalogSensor/CanBusAnalogSensor.h
+++ b/src/libraries/icubmod/canBusAnalogSensor/CanBusAnalogSensor.h
@@ -19,10 +19,12 @@ using namespace yarp::dev;
 
 /**
 *  @ingroup icub_hardware_modules
-*  \defgroup canbusanalogsensor canbusanalogsensor
 *
+* @brief `canbusanalogsensor` : driver for CAN communication with IIT's analog sensor boards, including the MAIS and STRAIN boards.
 *
-* Driver for CAN communication with analog sensors.
+* | YARP device name |
+* |:-----------------:|
+* | `canbusanalogsensor` |
 *
 * Parameters accepted in the config argument of the open method:
 * | Parameter name | Type   | Units | Default Value | Required | Description | Notes |

--- a/src/libraries/icubmod/canBusDoubleFTSensor/CanBusDoubleFTSensor.h
+++ b/src/libraries/icubmod/canBusDoubleFTSensor/CanBusDoubleFTSensor.h
@@ -19,7 +19,7 @@ using namespace yarp::dev;
 
 /**
 *  @ingroup icub_hardware_modules
-*
+* @brief `canBusDoubleFTSensor` : driver for IIT's double FTSens over CAN.
 *
 * Driver for CAN communication with two six-axis FT sensor, mounted in parallel.
 * This driver acts as a wrapper and it combines the readings of this two FT sensors,
@@ -42,6 +42,10 @@ using namespace yarp::dev;
 * For the double sensor ankle setup this parameters extracted from the CAD are:
 *   firstSecondDistance : 0.046 m
 *   firstSingleDistance : 0.0101175 m
+*
+* | YARP device name |
+* |:-----------------:|
+* | `canBusDoubleFTSensor` |
 *
 * Parameters accepted in the config argument of the open method:
 * | Parameter name | Type   | Units | Default Value | Required | Description | Notes |

--- a/src/libraries/icubmod/canBusInertialMTB/CanBusInertialMTB.h
+++ b/src/libraries/icubmod/canBusInertialMTB/CanBusInertialMTB.h
@@ -20,29 +20,7 @@ using namespace yarp::os;
 using namespace yarp::dev;
 
 
-/**
-*  @ingroup icub_hardware_modules
-*  \defgroup canbusinertialmtb canbusinertialmtb
-*
-*
-* Driver for CAN communication with inertial sensors (accelerometers, gyroscopes)
-*        mounted on MTB boards.
-*
-* The minimum MTB firmware version supported by this device is 2.10.17 .
-*
-* It is possible to read from multiple MTB. This readings will be combined in a single vector.
-*
-* Parameters accepted in the config argument of the open method:
-* | Parameter name | Type   | Units | Default Value | Required | Description | Notes |
-* |:--------------:|:------:|:-----:|:-------------:|:--------:|:-----------:|:-----:|
-* | canbusDevice   | string | -     | - | Yes | Yarp device name of CAN Bus wrapper | - |
-* | physDevice     | string | -     | - | Yes | Yarp device name for the low level CAN device driver | - |
-* | canDeviceNum   | int    | -     | - | Yes | ID of the CAN Bus line | - |
-* | canAddress     | vector of int    | -     | - | Yes | Vector of the CAN Bus Addresses for the sensor boards | - |
-* | period         | int    | milliseconds | 10 | No | Period of the thread reading messages from the CAN bus | - |
-* | sensorType     | int |       | - | Yes | Type of sensor to read from MTBs.  | Possible values: acc for the internal LIS331DLH accelerometer of the MTB, extAccAndGyro for the external LIS331DLH accelerometer and L3G4200D gyroscope. |
-* | sensorPeriod   | int    | milliseconds | 5 | No | Every sensorPeriod milliseconds the MTB publishes the sensor measurements on the CAN Bus | Possible values: from 1 to 255 |
-*/
+
 
 struct MTBInertialBoardInfo
 {
@@ -57,11 +35,28 @@ struct MTBInertialBoardInfo
 };
 
 /**
- * Class implementing the canBusInertialMTB device driver. 
- * 
- * Check \ref canbusinertialmtb for more information about this driver and the required parameters.
- * 
- */
+*  @ingroup icub_hardware_modules
+*  @brief `canbusinertialmtb` : driver for CAN communication with inertial sensors (accelerometers, gyroscopes) mounted on MTB boards.
+*
+* The minimum MTB firmware version supported by this device is 2.10.17 .
+*
+* It is possible to read from multiple MTB. This readings will be combined in a single vector.
+*
+* | YARP device name |
+* |:-----------------:|
+* | `canbusinertialmtb` |
+*
+* Parameters accepted in the config argument of the open method:
+* | Parameter name | Type   | Units | Default Value | Required | Description | Notes |
+* |:--------------:|:------:|:-----:|:-------------:|:--------:|:-----------:|:-----:|
+* | canbusDevice   | string | -     | - | Yes | Yarp device name of CAN Bus wrapper | - |
+* | physDevice     | string | -     | - | Yes | Yarp device name for the low level CAN device driver | - |
+* | canDeviceNum   | int    | -     | - | Yes | ID of the CAN Bus line | - |
+* | canAddress     | vector of int    | -     | - | Yes | Vector of the CAN Bus Addresses for the sensor boards | - |
+* | period         | int    | milliseconds | 10 | No | Period of the thread reading messages from the CAN bus | - |
+* | sensorType     | int |       | - | Yes | Type of sensor to read from MTBs.  | Possible values: acc for the internal LIS331DLH accelerometer of the MTB, extAccAndGyro for the external LIS331DLH accelerometer and L3G4200D gyroscope. |
+* | sensorPeriod   | int    | milliseconds | 5 | No | Every sensorPeriod milliseconds the MTB publishes the sensor measurements on the CAN Bus | Possible values: from 1 to 255 |
+*/
 class CanBusInertialMTB : public RateThread, public yarp::dev::IAnalogSensor, public DeviceDriver
 {
 private:

--- a/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.h
+++ b/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.h
@@ -1,30 +1,13 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-/**
- * @ingroup icub_hardware_modules 
- * \defgroup canbusmotioncontrol canbusmotioncontrol
- *
- * This device contains code which handles communication to 
- * the motor control boards on a CAN bus. It 
- * converts requests from function calls into CAN bus messages for
- * the motor control boards. A thread monitors the bus for incoming
- * messages and dispatches replies to calling threads.
- *
- * Comunication with the CAN bus is done through the standard
- * YARP ICanBus interface.
- *
- * Copyright (C) 2010 RobotCub Consortium.
- *
- * Author: Lorenzo Natale
- *
- * CopyPolicy: Released under the terms of the GNU GPL v2.0.
- *
- */
-
 //
 // $Id: CanBusMotionControl.h,v 1.16 2009/07/29 13:12:29 nat Exp $
 //
 //
+
+// Copyright: (C) 2010-2017 iCub Facility, Istituto Italiano di Tecnologia
+// Authors: Lorenzo Natale <lorenzo.natale@iit.it>
+// CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
 #ifndef __CanBusMotionControlh__
 #define __CanBusMotionControlh__
@@ -651,6 +634,24 @@ class axisTorqueHelper
     }
 };
 
+/**
+ * @ingroup icub_hardware_modules
+ * @brief `canbusmotioncontrol` : driver for motor control boards on a CAN bus.
+ *
+ * This device contains code which handles communication to
+ * the motor control boards on a CAN bus. It
+ * converts requests from function calls into CAN bus messages for
+ * the motor control boards. A thread monitors the bus for incoming
+ * messages and dispatches replies to calling threads.
+ *
+ * Communication with the CAN bus is done through the standard
+ * YARP ICanBus interface.
+ *
+ * | YARP device name |
+ * |:-----------------:|
+ * | `canbusmotioncontrol` |
+ *
+ */
 class yarp::dev::CanBusMotionControl:public DeviceDriver,
             public os::RateThread, 
             public IPidControlRaw, 

--- a/src/libraries/icubmod/cartesianController/ClientCartesianController.h
+++ b/src/libraries/icubmod/cartesianController/ClientCartesianController.h
@@ -16,17 +16,7 @@
  * Public License for more details
 */
 
-/**
- * \defgroup clientcartesiancontroller clientcartesiancontroller
- * @ingroup icub_hardware_modules 
- *  
- * Implements the client part of the <a 
- * href="http://wiki.icub.org/yarpdoc/dd/de6/classyarp_1_1dev_1_1ICartesianControl.html">Cartesian
- * Interface</a>. 
- *  
- * @note Please read carefully the \ref icub_cartesian_interface
- *       "Cartesian Interface" documentation.
- *
+/*
  * Copyright (C) 2010 RobotCub Consortium.
  *
  * Author: Ugo Pattacini
@@ -68,7 +58,19 @@ public:
 };
 
 
-/************************************************************************/
+/**
+*  @ingroup icub_hardware_modules
+*
+* @brief `clientcartesiancontroller` : implements the client part of the
+* [Cartesian Interface](http://www.yarp.it/classyarp_1_1dev_1_1ICartesianControl.html).
+*
+* @note Please read carefully the \ref icub_cartesian_interface "Cartesian Interface" documentation.
+*
+* | YARP device name |
+* |:-----------------:|
+* | `clientcartesiancontroller` |
+*
+*/
 class ClientCartesianController : public    yarp::dev::DeviceDriver,
                                   public    yarp::dev::ICartesianControl,
                                   protected iCub::iKin::CartesianHelper

--- a/src/libraries/icubmod/cartesianController/ServerCartesianController.h
+++ b/src/libraries/icubmod/cartesianController/ServerCartesianController.h
@@ -16,26 +16,7 @@
  * Public License for more details
 */
 
-/**
- * \defgroup servercartesiancontroller servercartesiancontroller
- * @ingroup icub_hardware_modules 
- *  
- * Implements the server part of the <a 
- * href="http://wiki.icub.org/yarpdoc/dd/de6/classyarp_1_1dev_1_1ICartesianControl.html">Cartesian
- * Interface</a>. 
- *  
- * @note Please read carefully the \ref icub_cartesian_interface
- *       "Cartesian Interface" documentation.
- *
- * Copyright (C) 2010 RobotCub Consortium.
- *
- * Author: Ugo Pattacini
- *
- * CopyPolicy: Released under the terms of the GNU GPL v2.0.
- *
- * This file can be edited at 
- * src/modules/cartesianController/ServerCartesianController.h 
- */
+
 
 #ifndef __SERVERCARTESIANCONTROLLER_H__
 #define __SERVERCARTESIANCONTROLLER_H__
@@ -106,7 +87,20 @@ public:
     virtual ~TaskRefVelTargetGenerator();
 };
 
-
+/**
+*  @ingroup icub_hardware_modules
+*
+* @brief `servercartesiancontroller` : implements the server part of the
+* [Cartesian Interface](http://www.yarp.it/classyarp_1_1dev_1_1ICartesianControl.html).
+*
+* @note Please read carefully the \ref icub_cartesian_interface
+*       "Cartesian Interface" documentation.
+*
+* | YARP device name |
+* |:-----------------:|
+* | `servercartesiancontroller` |
+*
+*/
 class ServerCartesianController : public    yarp::dev::DeviceDriver,
                                   public    yarp::dev::IMultipleWrapper,
                                   public    yarp::dev::ICartesianControl,

--- a/src/libraries/icubmod/cfw2Can/Cfw2Can.h
+++ b/src/libraries/icubmod/cfw2Can/Cfw2Can.h
@@ -1,12 +1,6 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-/**
- * @ingroup icub_hardware_modules 
- * \defgroup cfw2can cfw2can
- *
- * Implements <a href="http://wiki.icub.org/yarpdoc/d3/d5b/classyarp_1_1dev_1_1ICanBus.html" ICanBus interface <\a> for a cfw2 can bus device (cfw2 pc104 card). This is the cfw2can module
- * device.
- *
+/*
  * Copyright (C) 2010 RobotCub Consortium.
  *
  * Author: Lorenzo Natale
@@ -90,6 +84,14 @@ class yarp::dev::Cfw2CanMessage:public yarp::dev::CanMessage
     }
 };
 
+/**
+*  @ingroup icub_hardware_modules
+*  @brief `cfw2can` : driver implementing the yarp::dev::ICanBus interface for a cfw2 can bus device (cfw2 pc104 card).
+*
+* | YARP device name |
+* |:-----------------:|
+* | `cfw2can` |
+*/
 class yarp::dev::Cfw2Can: public ImplementCanBufferFactory<Cfw2CanMessage, CFWCAN_MSG>,
             public ICanBus, 
            /* public ICanBusErrors, */

--- a/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.h
+++ b/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.h
@@ -45,10 +45,10 @@ The dragonfly2 framegrabber device driver can acquire RGB color images in 320x24
 The dragonfly2raw framegrabber device driver can acquire raw format images in 640x480 resolution.
 
 \section intro_sec Description
-The dragonfly framegrabber device driver is based on libdc1394-2. 
+The dragonfly framegrabber device driver is based on libdc1394-2.
 
-It can acquire RGB color images in 320x240 or 640x480 resolutions. 
-In 640x480 there are two options: Bayer decoding performed on board by the camera or Bayer pattern decoding performed by the driver. In the second mode the bandwidth required to the Firewire bus is lower, and thus the framerate can be up to 60 fps. In the first mode the framerate is limited to 15 fps with two cameras on the same channel. Moreover, once the resolution is chosen, 
+It can acquire RGB color images in 320x240 or 640x480 resolutions.
+In 640x480 there are two options: Bayer decoding performed on board by the camera or Bayer pattern decoding performed by the driver. In the second mode the bandwidth required to the Firewire bus is lower, and thus the framerate can be up to 60 fps. In the first mode the framerate is limited to 15 fps with two cameras on the same channel. Moreover, once the resolution is chosen,
 the image can be cropped on board by the camera before the transfer on the Firewire bus.
 
 These functionalities are made availabe thought two YARP devices: dragonfly2 (for RGB images) and dragondly2raw (for raw images with Bayer encoding).
@@ -63,7 +63,7 @@ PGRFlyCapture (Windows)
 
 --name             // image output port
 
---video_type       // 1: RGB 320x240, 2: RGB 640x480, 3: RGB 640x480 (default) software Bayer decoding (higher fps) 
+--video_type       // 1: RGB 320x240, 2: RGB 640x480, 3: RGB 640x480 (default) software Bayer decoding (higher fps)
 
 --width|size_x     // width image cropping (limited to image size)
 
@@ -71,11 +71,11 @@ PGRFlyCapture (Windows)
 
 --port_number      // Firewire channel (need to specify only if you have more than one firewire card)
 
---guid             // camera global unique 64 bit identifier <B>WARNING: replaces --d</B> 
+--guid             // camera global unique 64 bit identifier <B>WARNING: replaces --d</B>
 
 --d                // camera unit number <B>DEPRECATED</B>
 
---white_balance    // red and blue balance, values are normalized betwen 0.0 and 1.0 
+--white_balance    // red and blue balance, values are normalized betwen 0.0 and 1.0
 
 --feature          // camera feature setting, normalized between 0.0 and 1.0 (features listed below)
 
@@ -92,14 +92,14 @@ The video_type parameter determines how images are acquired by the dragonfly chi
 
 \subsection port_units Port, Unit number and 64 bit Global Unique Identifier
 
-Many cameras can coexist on the same Firewire bus (port), sharing the available bandwidth. Each camera connected to the same Firewire bus is associated to a unit number. Port numbers, as well as unit numbers, are assigned increasingly starting from 0. 
+Many cameras can coexist on the same Firewire bus (port), sharing the available bandwidth. Each camera connected to the same Firewire bus is associated to a unit number. Port numbers, as well as unit numbers, are assigned increasingly starting from 0.
 The iCub robot has one only Firewire card, and thus its port number is always 0 (can be omitted). The two left and right cameras will be unit 0 and 1, but unfortunately this association is not deterministic, and thus the Global Unique Identifier (guid) must be used in order to univokely identify a camera.
-The icubmoddev device driver supports configuration files, thus the most convenient way to deal with GUIDs is putting them in .ini files that will be passed to icubmoddev together with all the other parameters as follows:
+The yarpdev device driver supports configuration files, thus the most convenient way to deal with GUIDs is putting them in .ini files that will be passed to yarpdev together with all the other parameters as follows:
 
-icubmoddev --from camera/dragonfly2_config_left.ini
-icubmoddev --from camera/dragonfly2_config_right.ini 
+yarpdev --from camera/dragonfly2_config_left.ini
+yarpdev --from camera/dragonfly2_config_right.ini
 
-In the latest iCub software releases the .ini files are already supplied in <B>app/robots/iCubXXXnn/camera</B> folders. The --d option must be replaced in them by assigning the guid of the corresponding camera to the guid parameter. 
+In the latest iCub software releases the .ini files are already supplied in <B>app/robots/iCubXXXnn/camera</B> folders. The --d option must be replaced in them by assigning the guid of the corresponding camera to the guid parameter.
 The following configuration file dragonfly2_config_left.ini
 
 device grabber \n
@@ -107,7 +107,7 @@ subdevice dragonfly2 \n
 width 320 \n
 height 240 \n
 video_type 1 \n
-white_balance 0.506 0.494 \n 
+white_balance 0.506 0.494 \n
 gain 0.312 \n
 shutter 0.913 \n
 name /icub/cam/left \n
@@ -129,7 +129,7 @@ subdevice dragonfly2 \n
 width 320 \n
 height 240 \n
 video_type 1 \n
-white_balance 0.506 0.494 \n 
+white_balance 0.506 0.494 \n
 gain 0.312 \n
 shutter 0.913 \n
 name /icub/cam/left \n
@@ -156,7 +156,7 @@ dragonfly_config_right_bayer_640_480.ini \n
 
 Execute from terminal:
 
-icubmoddev --device grabber --subdevice dragonfly 2 --name /foocam0 --d 0 
+yarpdev --device grabber --subdevice dragonfly 2 --name /foocam0 --d 0
 
 The driver will answer something like:
 
@@ -187,11 +187,11 @@ yarp connect /foocam0 /fooview0 \n
 and check in the viewer if the camera is the left or right iCub eye. Supposing that it is the left one, write the guid parameter in the dragonfly2_config_left*.ini files as shown in the former section.
 Do the same for the other camera, using unit number 1:
 
-icubmoddev --device grabber --subdevice dragonfly 2 --name /foocam1 --d 1 \n 
+yarpdev --device grabber --subdevice dragonfly 2 --name /foocam1 --d 1 \n
 yarpview --name /fooview1 \n
 yarp connect /foocam1 /fooview1 \n
 
-and set the corresponding guid in the other camera's .ini files, <B>without leading 0x</B>. 
+and set the corresponding guid in the other camera's .ini files, <B>without leading 0x</B>.
 
 
 \subsection features Features
@@ -213,7 +213,7 @@ None.
 
 \section portsc_sec Ports Created
 
-The dragonfly device driver is usually executed combined with a network wrapper grabber (called \a grabber, see examples below) which reads images from the driver and streams them on the network. The grabber opens the followig ports: 
+The dragonfly device driver is usually executed combined with a network wrapper grabber (called \a grabber, see examples below) which reads images from the driver and streams them on the network. The grabber opens the followig ports:
 
 Output ports:
 - <as specified by --name> streams out a yarp::sig::ImageOf<yarp::sig::PixelRgb> which contains the image grabbed by the Dragonfly camera.
@@ -236,36 +236,36 @@ Linux and Windows.
 \section example_sec Example Instantiation of the Module
 Usage syntax:
 
-icubmoddev --device grabber --subdevice dragonfly2 --name <yarp port name> 
-[--video_type <type>] [--width|size_x <W> --height|size_y <H>] [--port_number <pn>] 
+yarpdev --device grabber --subdevice dragonfly2 --name <yarp port name>
+[--video_type <type>] [--width|size_x <W> --height|size_y <H>] [--port_number <pn>]
 [--guid <64_bit_camera_unique_identifier>] [--white_balance <red_value> <blue_value>] [--feature <parameter>] [...]
 
-icubmoddev --device grabber --subdevice dragonfly2raw --name <yarp port name> 
-[--width|size_x <W> --height|size_y <H>] [--port_number <pn>] 
+yarpdev --device grabber --subdevice dragonfly2raw --name <yarp port name>
+[--width|size_x <W> --height|size_y <H>] [--port_number <pn>]
 [--guid <64_bit_global_unique_identifier>] [--white_balance <red_value> <blue_value>] [--feature <parameter>] [...]
 
 <B>WARNING: the old --d <unit_number> parameter is still working but deprecated, please use --guid <64_bit_global_unique_identifier> instead,
-because --d <unit_number> camera has become non deterministic in left/right assignment in latest linux releases.</B> 
+because --d <unit_number> camera has become non deterministic in left/right assignment in latest linux releases.</B>
 
 Example:
 
-icubmoddev --device grabber --subdevice dragonfly2 --name /icub/cam/left  --guid AB10980D6656E455 [...]
+yarpdev --device grabber --subdevice dragonfly2 --name /icub/cam/left  --guid AB10980D6656E455 [...]
 
-icubmoddev --device grabber --subdevice dragonfly2 --name /icub/cam/right --guid 98FF0666E478A001 [...]
+yarpdev --device grabber --subdevice dragonfly2 --name /icub/cam/right --guid 98FF0666E478A001 [...]
 
-icubmoddev --device grabber --subdevice dragonfly2raw --name /icub/cam/left  --guid AB10980D6656E455 [...]
+yarpdev --device grabber --subdevice dragonfly2raw --name /icub/cam/left  --guid AB10980D6656E455 [...]
 
-icubmoddev --device grabber --subdevice dragonfly2raw --name /icub/cam/right --guid 98FF0666E478A001 [...]
+yarpdev --device grabber --subdevice dragonfly2raw --name /icub/cam/right --guid 98FF0666E478A001 [...]
 
 <B>DEPRECATED:</B>
 
-icubmoddev --device grabber --subdevice dragonfly2 --name /icub/cam/right --d 1|0 [...]
+yarpdev --device grabber --subdevice dragonfly2 --name /icub/cam/right --d 1|0 [...]
 
-icubmoddev --device grabber --subdevice dragonfly2 --name /icub/cam/left  --d 0|1 [...]
+yarpdev --device grabber --subdevice dragonfly2 --name /icub/cam/left  --d 0|1 [...]
 
-icubmoddev --device grabber --subdevice dragonfly2raw --name /icub/cam/left  --d 0|1 [...]
+yarpdev --device grabber --subdevice dragonfly2raw --name /icub/cam/left  --d 0|1 [...]
 
-icubmoddev --device grabber --subdevice dragonfly2raw --name /icub/cam/right --d 1|0 [...]
+yarpdev --device grabber --subdevice dragonfly2raw --name /icub/cam/right --d 1|0 [...]
 
 
 
@@ -903,6 +903,16 @@ protected:
     bool TRANSL_MODE(FeatureMode mode) { return (mode == MODE_AUTO? 1 : 0); }
 };
 
+/**
+* @ingroup icub_hardware_modules
+* @brief `dragonfly2` : framegrabber device driver that can acquire RGB color images in 320x240 or 640x480 resolutions.
+*
+* See \ref dragonfly2 for for more details.
+*
+* | YARP device name |
+* |:-----------------:|
+* | `dragonfly2` |
+*/
 class yarp::dev::DragonflyDeviceDriver2Rgb : 
     public yarp::dev::DragonflyDeviceDriver2,
     public IFrameGrabberImage,
@@ -953,6 +963,16 @@ public:
     virtual int width() const;
 };
 
+/**
+* @ingroup icub_hardware_modules
+* @brief `dragonfly2raw` : framegrabber device driver that can acquire raw format images in 640x480 resolution.
+*
+* See \ref dragonfly2 for for more details.
+*
+* | YARP device name |
+* |:-----------------:|
+* | `dragonfly2raw` |
+*/
 class yarp::dev::DragonflyDeviceDriver2Raw :
     public yarp::dev::DragonflyDeviceDriver2,
     public IFrameGrabberImageRaw

--- a/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.h
+++ b/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.h
@@ -51,7 +51,7 @@ It can acquire RGB color images in 320x240 or 640x480 resolutions.
 In 640x480 there are two options: Bayer decoding performed on board by the camera or Bayer pattern decoding performed by the driver. In the second mode the bandwidth required to the Firewire bus is lower, and thus the framerate can be up to 60 fps. In the first mode the framerate is limited to 15 fps with two cameras on the same channel. Moreover, once the resolution is chosen,
 the image can be cropped on board by the camera before the transfer on the Firewire bus.
 
-These functionalities are made availabe thought two YARP devices: dragonfly2 (for RGB images) and dragondly2raw (for raw images with Bayer encoding).
+These functionalities are made available thought two YARP devices: dragonfly2 (for RGB images) and dragondly2raw (for raw images with Bayer encoding).
 
 Runtime parameters can be changed using the graphical interface: \ref icub_framegrabbergui2.
 
@@ -85,7 +85,7 @@ PGRFlyCapture (Windows)
 The video_type parameter determines how images are acquired by the dragonfly chip.
 
 -video_type 1: the image is acquired by the Dragonfly2 camera in 320x240 resolution as RGB color image, and transferred to the framegrabber driver memory buffer in this format. The Firewire bandwidth allows maximum framerate (60 fps) with two cameras. If specified, the --width and --height parameters will '''crop''' the image to the specified dimension.
-
+e
 -video_type 2: the image is acquired by the Dragonfly2 camera in 640x480 resolution as RGB color image, and transferred to the framegrabber driver memory buffer in this format. The Firewire bandwidth allows 15 fps with two cameras. If specified, the --width and --height parameters will '''crop''' the image to the specified dimension.
 
 -video_type 3: the image is acquired as a raw Bayer pattern 640x480 image, and transferred in this format to the framegrabber driver memory buffer. In this way, the bandwidth required to the Firewire bus is lower than in the previous format, allowing 60 fps. The Bayer decoding to the usual RGB format provided by the DragonflyDeviceDriver2 framegrabber is performed at software level by the driver itself. If specified, the --width and --height parameters will '''crop''' the original 640 x 480 image to the specified dimension.

--- a/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.h
+++ b/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.h
@@ -85,7 +85,7 @@ PGRFlyCapture (Windows)
 The video_type parameter determines how images are acquired by the dragonfly chip.
 
 -video_type 1: the image is acquired by the Dragonfly2 camera in 320x240 resolution as RGB color image, and transferred to the framegrabber driver memory buffer in this format. The Firewire bandwidth allows maximum framerate (60 fps) with two cameras. If specified, the --width and --height parameters will '''crop''' the image to the specified dimension.
-e
+
 -video_type 2: the image is acquired by the Dragonfly2 camera in 640x480 resolution as RGB color image, and transferred to the framegrabber driver memory buffer in this format. The Firewire bandwidth allows 15 fps with two cameras. If specified, the --width and --height parameters will '''crop''' the image to the specified dimension.
 
 -video_type 3: the image is acquired as a raw Bayer pattern 640x480 image, and transferred in this format to the framegrabber driver memory buffer. In this way, the bandwidth required to the Firewire bus is lower than in the previous format, allowing 60 fps. The Bayer decoding to the usual RGB format provided by the DragonflyDeviceDriver2 framegrabber is performed at software level by the driver itself. If specified, the --width and --height parameters will '''crop''' the original 640 x 480 image to the specified dimension.

--- a/src/libraries/icubmod/embObjAnalog/embObjAnalogSensor.h
+++ b/src/libraries/icubmod/embObjAnalog/embObjAnalogSensor.h
@@ -1,13 +1,5 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-/**
- * @ingroup icub_hardware_modules 
- * \defgroup analogSensorEth
- *
- * To Do: add description
- *
- */
-
 #ifndef __analogSensorEth_h__
 #define __analogSensorEth_h__
 

--- a/src/libraries/icubmod/embObjInertials/embObjInertials.h
+++ b/src/libraries/icubmod/embObjInertials/embObjInertials.h
@@ -1,13 +1,5 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-/**
- * @ingroup icub_hardware_modules 
- * \defgroup analogSensorEth
- *
- * To Do: add description
- *
- */
-
 #ifndef __embObjInertials_h__
 #define __embObjInertials_h__
 

--- a/src/libraries/icubmod/embObjLib/IethResource.h
+++ b/src/libraries/icubmod/embObjLib/IethResource.h
@@ -1,10 +1,6 @@
 
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-<<<<<<< 0e0449d15ef4573fd626ce0c1cf2338444a86b0a
-
-=======
->>>>>>> [icubmod] Cleanup doxygen documentation
 /* Copyright (C) 2014  iCub Facility, Istituto Italiano di Tecnologia
  * Author: Marco Accame
  * email: marco.accame@iit.it

--- a/src/libraries/icubmod/embObjLib/IethResource.h
+++ b/src/libraries/icubmod/embObjLib/IethResource.h
@@ -1,7 +1,10 @@
 
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
+<<<<<<< 0e0449d15ef4573fd626ce0c1cf2338444a86b0a
 
+=======
+>>>>>>> [icubmod] Cleanup doxygen documentation
 /* Copyright (C) 2014  iCub Facility, Istituto Italiano di Tecnologia
  * Author: Marco Accame
  * email: marco.accame@iit.it

--- a/src/libraries/icubmod/embObjLib/embObjLibConf.h
+++ b/src/libraries/icubmod/embObjLib/embObjLibConf.h
@@ -1,10 +1,5 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-/**
- * @ingroup icub_hardware_modules 
- * \defgroup embObjLibConfig embObjLibConfig
- *
-*/
 /* Copyright (C) 2013  iCub Facility, Istituto Italiano di Tecnologia
  * Author: Marco Accame
  * email: marco.accame@iit.it

--- a/src/libraries/icubmod/embObjLib/serviceParser.h
+++ b/src/libraries/icubmod/embObjLib/serviceParser.h
@@ -1,13 +1,5 @@
 ﻿// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-/**
- * @ingroup icub_hardware_modules
- * \defgroup ServiceParser ServiceParser
- *
- * To Do: add description
- *
- */
-
 #ifndef __serviceParser_h__
 #define __serviceParser_h__
 

--- a/src/libraries/icubmod/embObjLib/tools/statExt.h
+++ b/src/libraries/icubmod/embObjLib/tools/statExt.h
@@ -1,10 +1,5 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-/**
- * @ingroup icub_hardware_modules
- * \defgroup stat stat
- *
-*/
 /* Copyright (C) 2012  iCub Facility, Istituto Italiano di Tecnologia
  * Author: Valentina Gaggero
  * email: valentina.gaggero@iit.it

--- a/src/libraries/icubmod/embObjMais/embObjMais.h
+++ b/src/libraries/icubmod/embObjMais/embObjMais.h
@@ -1,12 +1,5 @@
 ﻿// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-/**
- * @ingroup icub_hardware_modules 
- * \defgroup analogSensorEth
- *
- * To Do: add description
- *
- */
 
 #ifndef __embObjMais_h__
 #define __embObjMais_h__

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -17,24 +17,8 @@
  * Public License for more details
  */
 
-// update comment hereafter
 
-/**
- * @ingroup icub_hardware_modules
- * \defgroup eth2ems eth2ems
- *
- * Implements <a href="http://wiki.icub.org/yarpdoc/d3/d5b/classyarp_1_1dev_1_1ICanBus.html" ICanBus interface <\a> for a ems to can bus device.
- * This is the eth2ems module device.
- *
- * Copyright (C) 2012 Department of Robotics Brain and Cognitive Sciences - Istituto Italiano di Tecnologia
- *
- * Author: Alberto Cardellino
- *
- * CopyPolicy: Released under the terms of the GNU GPL v2.0.
- *
- * This file can be edited at src/modules/....h
- *
- */
+
 
 //
 // $Id: embObjMotionControl.h,v 1.5 2008/06/25 22:33:53 nat Exp $
@@ -125,7 +109,25 @@ namespace yarp {
 using namespace yarp::dev;
 
 
-
+/**
+ * @ingroup icub_hardware_modules
+ * @brief `embObjMotionControl` : driver for iCub motor control boards EMS on a ETH bus.
+ *
+ * This device contains code which handles communication to
+ * the motor control boards (EMS) on the internal ethernet network of the ETH iCub.
+ * It converts requests from function calls into ETH bus messages for
+ * the motor control boards. A thread monitors the bus for incoming
+ * messages and dispatches replies to calling threads.
+ *
+ * For the description of the parameters supported by this device, please check the
+ * template configuration file available in robotology/robots-configuration,
+ * i.e.  https://github.com/robotology/robots-configuration/blob/master/iCubTemplates/iCubTemplateV4_0/hardware/motorControl/body_part--ebX-jA_B-mc.xml .
+ *
+ * | YARP device name |
+ * |:-----------------:|
+ * | `embObjMotionControl` |
+ *
+ */
 class yarp::dev::embObjMotionControl:   public DeviceDriver,
     public IPidControlRaw,
     public IControlCalibration2Raw,

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.h
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.h
@@ -17,27 +17,6 @@
  * Public License for more details
  */
 
-// update comment hereafter
-
-/**
- * @ingroup icub_hardware_modules
- * \defgroup eth2ems eth2ems
- *
- * Implements <a href="http://wiki.icub.org/yarpdoc/d3/d5b/classyarp_1_1dev_1_1ICanBus.html" ICanBus interface <\a> for a ems to can bus device.
- * This is the eth2ems module device.
- *
- * Copyright (C) 2012 Department of Robotics Brain and Cognitive Sciences - Istituto Italiano di Tecnologia
- *
- * Author: Valentina Gaggero
- *
- * CopyPolicy: Released under the terms of the GNU GPL v2.0.
- *
- * This file can be edited at src/modules/....h
- *
- */
-
-
-
 #ifndef __mcParserh__
 #define __mcParserh__
 

--- a/src/libraries/icubmod/embObjMultiEnc/embObjMultiEnc.h
+++ b/src/libraries/icubmod/embObjMultiEnc/embObjMultiEnc.h
@@ -1,13 +1,5 @@
 ﻿// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-/**
- * @ingroup icub_hardware_modules 
- * \defgroup analogSensorEth
- *
- * To Do: add description
- *
- */
-
 #ifndef __embObjMultiEnc_h__
 #define __embObjMultiEnc_h__
 

--- a/src/libraries/icubmod/embObjStrain/embObjStrain.h
+++ b/src/libraries/icubmod/embObjStrain/embObjStrain.h
@@ -35,6 +35,20 @@ namespace yarp {
 
 // -- class embObjStrain
 
+/**
+*  @ingroup icub_hardware_modules
+*
+* @brief `embObjStrain` : driver for communication with IIT's STRAIN board over EMS boards.
+*
+* For the description of the parameters supported by this device, please check the
+* template configuration file available in robotology/robots-configuration,
+* i.e.  https://github.com/robotology/robots-configuration/blob/master/iCubTemplates/iCubTemplateV4_0/hardware/FT/body_part-ebX-strain.xml .
+*
+* | YARP device name |
+* |:-----------------:|
+* | `embObjStrain` |
+*
+*/
 class yarp::dev::embObjStrain:      public yarp::dev::IAnalogSensor,
                                     public yarp::dev::DeviceDriver,
                                     public eth::IethResource

--- a/src/libraries/icubmod/embObjStrain/embObjStrain.h
+++ b/src/libraries/icubmod/embObjStrain/embObjStrain.h
@@ -1,12 +1,5 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-/**
- * @ingroup icub_hardware_modules 
- * \defgroup analogSensorEth
- *
- * To Do: add description
- *
- */
 
 #ifndef __embObjStrain_h__
 #define __embObjStrain_h__

--- a/src/libraries/icubmod/embObjVirtualAnalogSensor/embObjVirtualAnalogSensor.h
+++ b/src/libraries/icubmod/embObjVirtualAnalogSensor/embObjVirtualAnalogSensor.h
@@ -1,13 +1,5 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-/**
- * @ingroup icub_hardware_modules 
- * \defgroup analogSensorEth
- *
- * To Do: add description
- *
- */
-
 #ifndef __analogVirtualSensorEth_h__
 #define __analogVirtualSensorEth_h__
 

--- a/src/libraries/icubmod/esdCan/EsdCan.h
+++ b/src/libraries/icubmod/esdCan/EsdCan.h
@@ -1,12 +1,6 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-/**
- * @ingroup icub_hardware_modules 
- * \defgroup ecan ecan
- *
- * Implements <a href="http://wiki.icub.org/yarpdoc/d3/d5b/classyarp_1_1dev_1_1ICanBus.html" ICanBus interface <\a> for a esd can bus board.
- * This is the ecan device.
- *
+/*
  * Copyright (C) 2008 RobotCub Consortium.
  *
  * Author: Lorenzo Natale
@@ -97,6 +91,14 @@ public:
     }
 };
 
+/**
+ * @ingroup icub_hardware_modules
+ * @brief `ecan` : implements yarp::dev::ICanBus for a esd can bus board.
+ *
+ * | YARP device name |
+ * |:-----------------:|
+ * | `ecan` |
+ */
 class yarp::dev::EsdCan: public ImplementCanBufferFactory<EsdCanMessage, CMSG>,
     public ICanBus, 
     public DeviceDriver

--- a/src/libraries/icubmod/fakeCan/fakeCan.h
+++ b/src/libraries/icubmod/fakeCan/fakeCan.h
@@ -5,27 +5,6 @@
  *
  */
 
-/**
- * @ingroup icub_hardware_modules 
- * \defgroup fakecan fakecan
- *
- * Implements <a href="http://wiki.icub.org/yarpdoc/d3/d5b/classyarp_1_1dev_1_1ICanBus.html" ICanBus <\a> interface for a software (fake) can bus board.
- * It accepts the same parameter file that can be passed to the real hw 
- * (you just need to replace ecan or pcan with fakecan). Useful for debugging 
- * robot code in absence of real hw.
- * 
- * The behavior of the fake boards is very simplified, this module 
- * is not simulating a real robot. 
- *
- * Copyright (C) 2008 RobotCub Consortium.
- *
- * Author: Lorenzo Natale
- *
- * CopyPolicy: Released under the terms of the GNU GPL v2.0.
- *
- * This file can be edited at src/modules/fakeCan/fakeCan.h
- */
-
 #ifndef __FAKECAN__
 #define __FAKECAN__
 
@@ -107,6 +86,22 @@ class Boards: public std::list<FakeBoard *>
 typedef std::list<FakeBoard *>::iterator BoardsIt;
 typedef std::list<FakeBoard *>::const_iterator BoardsConstIt;
 
+
+/**
+ * @ingroup icub_hardware_modules
+ * @brief `fakecan` : implements yarp::dev::ICanBus for a software (fake) can bus board.
+ *
+  * It accepts the same parameter file that can be passed to the real hw
+ * (you just need to replace ecan or pcan with fakecan). Useful for debugging
+ * robot code in absence of real hw.
+ *
+ * The behavior of the fake boards is very simplified, this module
+ * is not simulating a real robot.
+ *
+ * | YARP device name |
+ * |:-----------------:|
+ * | `fakecan` |
+ */
 class yarp::dev::FakeCan: public ImplementCanBufferFactory<FakeCanMessage, FCMSG>,
     public ICanBus, 
     public DeviceDriver

--- a/src/libraries/icubmod/gazeController/ClientGazeController.h
+++ b/src/libraries/icubmod/gazeController/ClientGazeController.h
@@ -16,27 +16,6 @@
  * Public License for more details
 */
 
-/**
- * \defgroup clientgazecontroller clientgazecontroller
- * @ingroup icub_hardware_modules 
- *  
- * Implements the client part of the <a 
- * href="http://wiki.icub.org/yarpdoc/d2/df5/classyarp_1_1dev_1_1IGazeControl.html">Gaze
- * Control Interface</a>. 
- *  
- * @note Please read carefully the \ref icub_gaze_interface
- *       "Gaze Interface" documentation.
- *  
- * Copyright (C) 2010 RobotCub Consortium.
- *
- * Author: Ugo Pattacini
- *
- * CopyPolicy: Released under the terms of the GNU GPL v2.0.
- *
- * This file can be edited at 
- * src/modules/gazeController/ClientGazeController.h 
- */
-
 #ifndef __CLIENTGAZECONTROLLER_H__
 #define __CLIENTGAZECONTROLLER_H__
 
@@ -66,7 +45,20 @@ public:
 };
 
 
-/************************************************************************/
+/**
+*  @ingroup icub_hardware_modules
+*
+* @brief `clientgazecontroller` : implements the client part of the the <a
+* href="http://www.yarp.it/classyarp_1_1dev_1_1IGazeControl.html">Gaze
+* Control Interface</a>. .
+*
+* @note Please read carefully the  \ref icub_gaze_interface
+*       "Gaze Interface" documentation.
+*
+* | YARP device name |
+* |:-----------------:|
+* | `clientgazecontroller` |
+*/
 class ClientGazeController : public yarp::dev::DeviceDriver,
                              public yarp::dev::IGazeControl
 {

--- a/src/libraries/icubmod/imu3DM_GX3/3dm_gx3.h
+++ b/src/libraries/icubmod/imu3DM_GX3/3dm_gx3.h
@@ -44,8 +44,6 @@ struct XSensMTxParameters
 
 /**
  *
- * @ingroup dev_impl
- *
  * Driver for 3DM_GX3 IMU unit from MicroStrain
  * @author Alberto Cardellino
  */

--- a/src/libraries/icubmod/imuST_M1/ST_M1.h
+++ b/src/libraries/icubmod/imuST_M1/ST_M1.h
@@ -46,11 +46,13 @@ namespace yarp{
 // };
 
 /**
- *
- * @ingroup dev_impl
- *
- * Driver for 3DM_GX3 IMU unit from MicroStrain
+ * @ingroup icub_hardware_modules
+ * @brief `imuST_M1` : driver for 3DM_GX3 IMU unit from MicroStrain
  * @author Alberto Cardellino
+ *
+ * | YARP device name |
+ * |:-----------------:|
+ * | `imuST_M1` |
  */
 class yarp::dev::imuST_M1 :     public yarp::dev::IGenericSensor,
                                 public yarp::dev::IPreciselyTimed,

--- a/src/libraries/icubmod/parametricCalibrator/parametricCalibrator.h
+++ b/src/libraries/icubmod/parametricCalibrator/parametricCalibrator.h
@@ -1,10 +1,6 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-/**
- * @ingroup icub_calibrators
- * \defgroup parametricCalibrator
- *
- * Implement calibration routines for the iCub arm(s) (version 1.2).
+/*
  *
  * Copyright (C) 20014 iCub Facility, Istituto Italiano di Tecnologia
  *
@@ -37,8 +33,9 @@ namespace yarp {
  */
 
 /**
- * @ingroup dev_impl
- * 
+ * @ingroup icub_calibrators
+ * @brief `parametricCalibrator`: implement calibration routines for the iCub arm(s) (version 1.2).
+ *
  * A calibrator interface implementation for the Arm of the robot iCub.
  */
 class yarp::dev::parametricCalibrator : public ICalibrator, public DeviceDriver, public IRemoteCalibrator

--- a/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.h
+++ b/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.h
@@ -1,11 +1,6 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
-/**
- * @ingroup icub_calibrators 
- * \defgroup parametricCalibratorEth
- *
- * Implement calibration routines for the iCub arm(s) (version 1.2).
- *
+/*
  * Copyright (C) 20014 iCub Facility, Istituto Italiano di Tecnologia
  *
  * Authors: Alberto Cardellino, Marco Randazzo, Valentina Gaggero
@@ -38,7 +33,8 @@ namespace yarp {
  */
 
 /**
- * @ingroup dev_impl
+ * @ingroup icub_calibrators
+ * @brief `parametricCalibrator`: implement calibration routines for the iCub arm(s) (version 1.2).
  * 
  * A calibrator interface implementation for the Arm of the robot iCub.
  */

--- a/src/libraries/icubmod/plxCan/PlxCan.h
+++ b/src/libraries/icubmod/plxCan/PlxCan.h
@@ -1,13 +1,6 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
 /**
- * @ingroup icub_hardware_modules 
- * \defgroup pcan pcan
- *
- * Implements <a href="http://wiki.icub.org/yarpdoc/d3/d5b/classyarp_1_1dev_1_1ICanBus.html" ICanBus interface <\a> for a "plx based"
- * can bus device (cfw pc104 card). This is the pcan
- * device.
- *
  * Copyright (C) 2008 RobotCub Consortium.
  *
  * Author: Lorenzo Natale
@@ -93,6 +86,14 @@ class yarp::dev::PlxCanMessage:public yarp::dev::CanMessage
     }
 };
 
+/**
+ * @ingroup icub_hardware_modules
+ * @brief `pcan` : implements yarp::dev::ICanBus for a "plx based" can bus device (cfw pc104 card).
+ *
+ * | YARP device name |
+ * |:-----------------:|
+ * | `pcan` |
+ */
 class yarp::dev::PlxCan: public ImplementCanBufferFactory<PlxCanMessage, PLXCAN_MSG>,
             public ICanBus, 
             public ICanBusErrors,

--- a/src/libraries/icubmod/sharedCan/SharedCanBus.cpp
+++ b/src/libraries/icubmod/sharedCan/SharedCanBus.cpp
@@ -19,6 +19,7 @@
 
 const int CAN_DRIVER_BUFFER_SIZE = 500;
 const int DEFAULT_THREAD_PERIOD = 10;
+
 class SharedCanBus : public yarp::os::RateThread
 {
 public:

--- a/src/libraries/icubmod/sharedCan/SharedCanBus.h
+++ b/src/libraries/icubmod/sharedCan/SharedCanBus.h
@@ -1,12 +1,6 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
 /**
- * @ingroup icub_hardware_modules 
- * \defgroup shcan shcan
- *
- * Implements ICanBus interface for multiple access from a single access can driver (for example cfw2can).
- * It wraps the low level device driver (physdevice in the configuration file) in a higher level, multiple
- * access virtual device driver.
  *
  * Copyright (C) 2012 RobotCub Consortium.
  *
@@ -40,6 +34,17 @@ namespace yarp{
 
 class SharedCanBus;
 
+/**
+ * @ingroup icub_hardware_modules
+ * @brief `sharedcan` : implements ICanBus interface for multiple access from a single access can driver (for example cfw2can).
+ *
+ * It wraps the low level device driver (physdevice in the configuration file) in a higher level, multiple
+ * access virtual device driver.
+ *
+ * | YARP device name |
+ * |:-----------------:|
+ * | `sharedcan` |
+ */
 class yarp::dev::CanBusAccessPoint : 
     public ICanBus, 
     public ICanBufferFactory,

--- a/src/libraries/icubmod/socketCan/SocketCan.h
+++ b/src/libraries/icubmod/socketCan/SocketCan.h
@@ -1,10 +1,6 @@
 // -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
 /**
- * @ingroup icub_hardware_modules 
- * \defgroup socketcan socketcan
- *
- * Implements <a href="http://wiki.icub.org/yarpdoc/d3/d5b/classyarp_1_1dev_1_1ICanBus.html" ICanBus interface <\a> for a linux socketcan.
  *
  * Copyright (C) 2010 RobotCub Consortium, European Commission FP6 Project IST-004370
  * Author: Marco Randazzo
@@ -99,6 +95,14 @@ public:
     }
 };
 
+/**
+ * @ingroup icub_hardware_modules
+ * @brief `socketcan` : implements yarp::dev::ICanBus for a linux socketcan.
+ *
+ * | YARP device name |
+ * |:-----------------:|
+ * | `socketcan` |
+ */
 class yarp::dev::SocketCan: public ImplementCanBufferFactory<SocketCanMessage, can_frame>,
     public ICanBus, 
     public DeviceDriver

--- a/src/libraries/icubmod/xsensmtx/XSensMTx.h
+++ b/src/libraries/icubmod/xsensmtx/XSensMTx.h
@@ -6,19 +6,6 @@
  *
  */
 
-/**
- * @ingroup icub_hardware_modules 
- * \defgroup xsensemtx xsensemtx
- *
- * Provide Linux interface for the xsensemtx gyroscope.
- *
- * Copyright (C) 2006 Radu Bogdan Rasu, Alexis Maldonado
- *
- * CopyPolicy: Released under the terms of the GNU GPL v2.0.
- *
- * This file can be edited at src/modules/xsensmtx/XSensMTx.h
- */
-
 #ifndef __XSENSMTX__
 #define __XSENSMTX__
 
@@ -42,11 +29,13 @@ struct XSensMTxParameters
 };
 
 /**
- *
- * @ingroup dev_impl
- *
- * Driver for XSens's MTx IMU unit.
+ * @ingroup icub_hardware_modules
+ * @brief `xsensmtx` : driver for XSens's MTx IMU unit.
  * @author Radu Bogdan Rusu, Alexis Maldonado
+ *
+ * | YARP device name |
+ * |:-----------------:|
+ * | `xsensmtx` |
  */
 class yarp::dev::XSensMTx : public IGenericSensor, public yarp::dev::IPreciselyTimed, public DeviceDriver
 {


### PR DESCRIPTION
Cleanup doxygen documentation regarding the iCub YARP devices contained in the `icubmod` directories. 
In particular, I removed the duplicate group/device class structure, and I moved all the device documentation in each device class documentation. 
Furthermore, I highlighted more the important information of the yarp device name (i.e. the string necessary to spawn the device using the `PolyDriver`, `yarpdev` or `yarprobotinterface`. 

Before: 
![screen shot 2018-01-10 at 17 52 00](https://user-images.githubusercontent.com/1857049/34784619-0f7e62ce-f62f-11e7-829a-caa791f3e75b.png)

After:
![screen shot 2018-01-10 at 17 47 16](https://user-images.githubusercontent.com/1857049/34784607-01898392-f62f-11e7-92a9-3a2035ba8a6f.png)