### PR TITLE
Travis: Pull yarp devel when the branch is devel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_script:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo sh -c 'echo "deb http://www.icub.org/ubuntu trusty contrib/science" > /etc/apt/sources.list.d/icub.list'; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get --assume-yes --force-yes install cmake libeigen3-dev icub-common libv4lconvert0 libv4l-dev; fi
-
   # macOS dependencies
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew tap robotology/cask; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install --only-dependencies yarp; fi
@@ -32,7 +31,9 @@ before_script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export PATH="$PATH:/usr/local/opt/qt/bin"; fi
   #use the same set of cmake options used in the dashboard build
   - source ./admin/scripts/generate-cmake-options.sh
-  #install yarp from master
+  # Setup the YARP branch
+  - if [ "$TRAVIS_BRANCH" = "devel" ] ; then export YARP_BRANCH="devel" && echo "Using yarp devel branch" ; fi
+  #install yarp
   - git clone --depth 1 -b $YARP_BRANCH https://github.com/robotology/yarp
   - cd yarp
   - mkdir build
@@ -51,4 +52,3 @@ script:
   - cmake --build .
   - sudo make install
   - sudo make uninstall
-


### PR DESCRIPTION
### What's wrong

For some reason, commit https://github.com/robotology/icub-main/commit/07016c66032031c15bb5741ec88d460ceedc7ec5 forced the use of yarp master both in icub-main master and devel.

Often changes happening in yarp devel are required for new features arriving in icub-main devel, and pulling yarp master would break the tests (https://github.com/robotology/icub-main/pull/488).

### Content of this PR

This PR sets Travis in such a way to read the branch using the [`TRAVIS_BRANCH`](https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables) variable, and sets the correct yarp branch to pull.

### What does it mean

This approach allows testing a PR against both yarp master and devel by changing the base branch (editing the PR title and then selecting the target branch).

Edit: after changing the title, just restarting an already existing build is not enough, since Travis will not the target branch (you can see it from the web interface). Triggering a new build is required, either by adding a  new commit or other dirty hacks (e.g. amending the last local commit and force pushing it to your personal fork).

cc @traversaro @pattacini @randaz81 