### PR TITLE
Fix dragonfly and framegrabber gui compilation errors

### DIFF
--- a/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.cpp
+++ b/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.cpp
@@ -62,11 +62,9 @@ int DragonflyDeviceDriver2Raw::height () const
 
 ////////////////////////////////////////////////////
 
-DragonflyDeviceDriver2::DragonflyDeviceDriver2(bool raw=false)
+DragonflyDeviceDriver2::DragonflyDeviceDriver2(bool raw) :
+    raw(raw), system_resources(NULL)
 {
-    this->raw=raw;
-    system_resources=NULL;
-	//ACE_ASSERT(system_resources!=NULL);
 }
 
 DragonflyDeviceDriver2::~DragonflyDeviceDriver2()

--- a/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.h
+++ b/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.h
@@ -299,7 +299,7 @@ public:
     /**
     * Constructor.
     */
-    DragonflyDeviceDriver2(bool raw);
+    DragonflyDeviceDriver2(bool raw = false);
 
     /**
     * Destructor.

--- a/src/tools/frameGrabberGui2-qt/mainwindow.cpp
+++ b/src/tools/frameGrabberGui2-qt/mainwindow.cpp
@@ -4,6 +4,7 @@
 #include "log.h"
 #include "dc1394slider.h"
 #include "dc1394sliderwb.h"
+#include <iostream>
 
 static QStringList video_mode_labels;
 static QStringList video_rate_labels;


### PR DESCRIPTION
This PR fixes the following compilation errors:

- `DragonflyDeviceDriver2.cpp`:  error: addition of default argument on redeclaration makes
    this constructor a default constructor.
- `framegrabber-gui`: error: no member named 'cout' in namespace 'std' (cherry-picked @drdanz 's commit made on `devel`)
