### PR TITLE
Include used PolyDriver.h YARP header

### DIFF
--- a/src/tools/frameGrabberGui2-qt/dc1394thread.h
+++ b/src/tools/frameGrabberGui2-qt/dc1394thread.h
@@ -2,6 +2,7 @@
 #define DC1394THREAD_H
 
 #include <QThread>
+#include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/RemoteFrameGrabberDC1394.h>
 #include <QMutex>
 #include <QWaitCondition>


### PR DESCRIPTION
Before, it was included transitively from yarp/dev/RemoteFrameGrabberDC1394.h , 
but that include was removed in https://github.com/robotology/yarp/commit/8950b792f2b1d9d75ebbad041d9effa849c92a6f .