### PR TITLE
Bug fixed in checkMotionDone for all joints

### DIFF
--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -2141,7 +2141,7 @@ bool embObjMotionControl::checkMotionDoneRaw(bool *flag)
 
     for(int j=0, index=0; j< _njoints; j++, index++)
     {
-        ret &= checkMotionDoneRaw(&val);
+        ret &= checkMotionDoneRaw(j, &val);
         tot_res &= val;
     }
     *flag = tot_res;


### PR DESCRIPTION
The checkMotionDone(bool *flags) was recursive because it called itself instaed of checkMotionDoneRaw(int j, bool *flag);