### PR TITLE
smooth PID 

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -33,7 +33,7 @@ message(STATUS "CMake modules directory: ${CMAKE_MODULE_PATH}")
 # the requested one.
 find_package(icub_firmware_shared COMPONENTS canProtocolLib QUIET)
 if(icub_firmware_shared_FOUND)
-  find_package(icub_firmware_shared 4.0.1 COMPONENTS canProtocolLib)
+  find_package(icub_firmware_shared 4.0.2 COMPONENTS canProtocolLib)
 endif()
 
 find_package(GSL)

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -234,6 +234,8 @@ private:
     bool    *_enabledAmp;       // Middle step toward a full enabled motor controller. Amp (pwm) plus Pid enable command must be sent in order to get the joint into an active state.
     bool    *_enabledPid;       // Depends on enabledAmp. When both are set, the joint exits the idle mode and goes into position mode. If one of them is disabled, it falls to idle.
     bool    *_calibrated;       // Flag to know if the calibrate function has been called for the joint
+    double  *_PosPidSlope;
+    double  *_TrqPidSlope;
     double  *_ref_command_positions;// used for position control.
     double  *_ref_speeds;       // used for position control.
     double  *_ref_command_speeds;   // used for velocity control.

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -469,6 +469,8 @@ public:
     bool getTorqueControlFilterType(int j, int& type) ;
     bool getRotorLimitsRaw(int j, double *rotorMin, double *rotorMax) ;
     bool getWholeImpedanceRaw(int j, eOmc_impedance_t &imped);
+    bool setPidSlopeTimeRaw(const PidControlTypeEnum& pidtype, int j, const int time_ms);
+    bool getPidSlopeTimeRaw(const PidControlTypeEnum& pidtype, int j, int & time_ms);
 
     ////// Amplifier interface
     virtual bool enableAmpRaw(int j) override;


### PR DESCRIPTION
to be used with: https://github.com/robotology/icub-firmware-shared/pull/21
requires icub-firmware-shared 4.0.2

added `getPidSlopeTimeRaw()`, `setPidSlopeTimeRaw()`. 
methods are handled by new remote variables: `posPidSlopeTime`, `trqPidSlopeTime`.

