### PR TITLE
Limit use of yarp::sig::VectorOf in favor of std::vector

### DIFF
--- a/src/libraries/actionPrimitives/include/iCub/action/actionPrimitives.h
+++ b/src/libraries/actionPrimitives/include/iCub/action/actionPrimitives.h
@@ -80,6 +80,7 @@
 #define __AFFACTIONPRIMITIVES_H__
 
 #include <string>
+#include <vector>
 #include <deque>
 #include <set>
 #include <map>
@@ -244,10 +245,10 @@ protected:
     double            curHandTmo;
     double            latchTimerHand;
 
-    yarp::sig::VectorOf<int> fingersJnts;
-    std::set<int>            fingersJntsSet;
-    std::set<int>            fingersMovingJntsSet;
-    std::multimap<int,int>   fingers2JntsMap;
+    std::vector<int>       fingersJnts;
+    std::set<int>          fingersJntsSet;
+    std::set<int>          fingersMovingJntsSet;
+    std::multimap<int,int> fingers2JntsMap;
 
     friend class ArmWayPoints;
 

--- a/src/libraries/actionPrimitives/src/actionPrimitives.cpp
+++ b/src/libraries/actionPrimitives/src/actionPrimitives.cpp
@@ -1489,12 +1489,12 @@ bool ActionPrimitives::cmdHand(const Action &action)
         size_t sz=std::min(fingersJnts.size(),std::min(poss.length(),vels.length()));
         for (size_t i=0; i<sz; i++)
         {
-            size_t j=fingersJnts[i];
+            int j=fingersJnts[i];
             modCtrl->setControlMode(j,VOCAB_CM_POSITION);
             posCtrl->setRefSpeed(j,vels[j-jHandMin]);
         }
         
-        posCtrl->positionMove(sz,fingersJnts.getFirst(),poss.data());
+        posCtrl->positionMove((int)sz,fingersJnts.data(),poss.data());
 
         latchHandMoveDone=handMoveDone=false;
         handSeqTerminator=action.handSeqTerminator;
@@ -1862,7 +1862,7 @@ bool ActionPrimitives::stopControl()
         clearActionsQueue();
 
         cartCtrl->stopControl();
-        posCtrl->stop(fingersJnts.size(),fingersJnts.getFirst());
+        posCtrl->stop((int)fingersJnts.size(),fingersJnts.data());
 
         armMoveDone =latchArmMoveDone =true;
         handMoveDone=latchHandMoveDone=true;

--- a/src/libraries/icubmod/cartesianController/ServerCartesianController.cpp
+++ b/src/libraries/icubmod/cartesianController/ServerCartesianController.cpp
@@ -1286,15 +1286,15 @@ bool ServerCartesianController::getNewTarget()
 
 
 /************************************************************************/
-bool ServerCartesianController::areJointsHealthyAndSet(VectorOf<int> &jointsToSet)
+bool ServerCartesianController::areJointsHealthyAndSet(vector<int> &jointsToSet)
 {    
-    VectorOf<int> modes(maxPartJoints);
+    vector<int> modes(maxPartJoints);
     int chainCnt=0;
 
     jointsToSet.clear();
     for (int i=0; (i<numDrv) && ctrlModeAvailable; i++)
     {
-        lMod[i]->getControlModes(modes.getFirst());
+        lMod[i]->getControlModes(modes.data());
         for (int j=0; j<lJnt[i]; j++)
         {
             if (!(*chainState)[chainCnt].isBlocked())
@@ -1319,7 +1319,7 @@ bool ServerCartesianController::areJointsHealthyAndSet(VectorOf<int> &jointsToSe
 
 
 /************************************************************************/
-void ServerCartesianController::setJointsCtrlMode(const VectorOf<int> &jointsToSet)
+void ServerCartesianController::setJointsCtrlMode(const vector<int> &jointsToSet)
 {
     if (jointsToSet.size()==0)
         return;
@@ -1329,8 +1329,8 @@ void ServerCartesianController::setJointsCtrlMode(const VectorOf<int> &jointsToS
 
     for (int i=0; i<numDrv; i++)
     {
-        VectorOf<int> joints;
-        VectorOf<int> modes;
+        vector<int> joints;
+        vector<int> modes;
         for (int j=0; j<lJnt[i]; j++)
         {
             if (chainCnt==jointsToSet[k])
@@ -1345,8 +1345,7 @@ void ServerCartesianController::setJointsCtrlMode(const VectorOf<int> &jointsToS
         }
 
         if (joints.size()>0)
-            lMod[i]->setControlModes(joints.size(),joints.getFirst(),
-                                     modes.getFirst());
+            lMod[i]->setControlModes((int)joints.size(),joints.data(),modes.data());
     }
 }
 
@@ -1355,7 +1354,7 @@ void ServerCartesianController::setJointsCtrlMode(const VectorOf<int> &jointsToS
 Bottle ServerCartesianController::sendCtrlCmdMultipleJointsPosition()
 {
     Bottle info;
-    VectorOf<int> joints;
+    vector<int> joints;
     Vector refs;
     int cnt=0;
     int j=0;
@@ -1387,7 +1386,7 @@ Bottle ServerCartesianController::sendCtrlCmdMultipleJointsPosition()
         if (++k>=lJnt[j])
         {
             if (joints.size()>0)
-                lPos[j]->setPositions(joints.size(),joints.getFirst(),refs.data());
+                lPos[j]->setPositions((int)joints.size(),joints.data(),refs.data());
 
             joints.clear();
             refs.clear();
@@ -1404,7 +1403,7 @@ Bottle ServerCartesianController::sendCtrlCmdMultipleJointsPosition()
 Bottle ServerCartesianController::sendCtrlCmdMultipleJointsVelocity()
 {
     Bottle info;
-    VectorOf<int> joints;
+    vector<int> joints;
     Vector vels;
     int cnt=0;
     int j=0;
@@ -1441,7 +1440,7 @@ Bottle ServerCartesianController::sendCtrlCmdMultipleJointsVelocity()
         if (++k>=lJnt[j])
         {
             if (joints.size()>0)
-                static_cast<IVelocityControl2*>(lVel[j])->velocityMove(joints.size(),joints.getFirst(),vels.data());
+                static_cast<IVelocityControl2*>(lVel[j])->velocityMove((int)joints.size(),joints.data(),vels.data());
 
             joints.clear();
             vels.clear();
@@ -1627,7 +1626,7 @@ void ServerCartesianController::run()
         else
             txInfo.update();
 
-        VectorOf<int> jointsToSet;
+        vector<int> jointsToSet;
         jointsHealthy=areJointsHealthyAndSet(jointsToSet);
         if (!jointsHealthy)
             stopControlHelper();

--- a/src/libraries/icubmod/cartesianController/ServerCartesianController.h
+++ b/src/libraries/icubmod/cartesianController/ServerCartesianController.h
@@ -41,6 +41,7 @@
 #define __SERVERCARTESIANCONTROLLER_H__
 
 #include <string>
+#include <vector>
 #include <set>
 #include <deque>
 #include <map>
@@ -240,8 +241,8 @@ protected:
     double getFeedback(yarp::sig::Vector &_fb);
     void   createController();
     bool   getNewTarget();
-    bool   areJointsHealthyAndSet(yarp::sig::VectorOf<int> &jointsToSet);
-    void   setJointsCtrlMode(const yarp::sig::VectorOf<int> &jointsToSet);
+    bool   areJointsHealthyAndSet(std::vector<int> &jointsToSet);
+    void   setJointsCtrlMode(const std::vector<int> &jointsToSet);
     void   stopLimb(const bool execStopPosition=true);
     bool   goTo(unsigned int _ctrlPose, const yarp::sig::Vector &xd, const double t, const bool latchToken=false);
     bool   deleteContexts(yarp::os::Bottle *contextIdList);

--- a/src/modules/actionsRenderingEngine/src/MotorThread.cpp
+++ b/src/modules/actionsRenderingEngine/src/MotorThread.cpp
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <sstream>
 #include <cmath>
+#include <vector>
 #include <algorithm>
 #include <iomanip>
 
@@ -2702,9 +2703,8 @@ bool MotorThread::exploreTorso(Bottle &options)
     double step_time=2.0;
     double kp_pos_torso=0.6;
 
-    VectorOf<int> modes(3);
-    modes[0]=modes[1]=modes[2]=VOCAB_CM_VELOCITY;
-    ctrl_mode_torso->setControlModes(modes.getFirst());
+    vector<int> modes(3,VOCAB_CM_VELOCITY);
+    ctrl_mode_torso->setControlModes(modes.data());
 
     double init_walking_time=Time::now();
 
@@ -2762,17 +2762,17 @@ bool MotorThread::exploreTorso(Bottle &options)
                 q_dot=(q_dot_saturation/q_dot_mag)*q_dot;
 
             // account for specific order
-            VectorOf<int> jnts(2);
+            vector<int> jnts(2);
             jnts[0]=2;
             jnts[1]=1;
-            vel_torso->velocityMove(jnts.size(),jnts.getFirst(),q_dot.data());
+            vel_torso->velocityMove((int)jnts.size(),jnts.data(),q_dot.data());
             Time::delay(0.01);
         }
     }
 
     //go back to torso initial position
     modes[0]=modes[1]=modes[2]=VOCAB_CM_POSITION;
-    ctrl_mode_torso->setControlModes(modes.getFirst());
+    ctrl_mode_torso->setControlModes(modes.data());
     pos_torso->positionMove(torso_init_joints.data());
     bool done=false;
     while (isRunning() && !done)
@@ -2838,10 +2838,8 @@ bool MotorThread::exploreHand(Bottle &options)
     int nJnts;
     enc_arm[arm]->getAxes(&nJnts);
 
-    VectorOf<int> modes(nJnts);
-    for (int i=0; i<nJnts; i++)
-        modes[i]=VOCAB_CM_POSITION; 
-    ctrl_mode_arm[arm]->setControlModes(modes.getFirst());
+    vector<int> modes(nJnts,VOCAB_CM_POSITION);
+    ctrl_mode_arm[arm]->setControlModes(modes.data());
 
     //start exploration
     Vector destination(nJnts);

--- a/src/modules/iKinGazeCtrl/include/iCub/controller.h
+++ b/src/modules/iKinGazeCtrl/include/iCub/controller.h
@@ -20,6 +20,7 @@
 #define __CONTROLLER_H__
 
 #include <string>
+#include <vector>
 #include <set>
 
 #include <yarp/os/all.h>
@@ -106,8 +107,8 @@ protected:
     Vector v,vNeck,vEyes;
     Vector q0,qd,qdNeck,qdEyes;
     Vector fbTorso,fbHead,fbNeck,fbEyes;
-    VectorOf<int> neckJoints,eyesJoints;
-    VectorOf<int> jointsToSet;
+    vector<int> neckJoints,eyesJoints;
+    vector<int> jointsToSet;
 
     multiset<double> motionOngoingEvents;
     multiset<double> motionOngoingEventsCurrent;

--- a/src/modules/iKinGazeCtrl/src/controller.cpp
+++ b/src/modules/iKinGazeCtrl/src/controller.cpp
@@ -267,10 +267,10 @@ void Controller::stopLimb(const bool execStopPosition)
     if (commData->neckPosCtrlOn)
     {
         if (execStopPosition)
-            posHead->stop(neckJoints.size(),neckJoints.getFirst());
+            posHead->stop((int)neckJoints.size(),neckJoints.data());
 
         // note: vel==0.0 is always achievable
-        velHead->velocityMove(eyesJoints.size(),eyesJoints.getFirst(),
+        velHead->velocityMove((int)eyesJoints.size(),eyesJoints.data(),
                               Vector(eyesJoints.size(),0.0).data());
     }
     else
@@ -487,8 +487,8 @@ void Controller::doSaccade(const Vector &ang, const Vector &vel)
     ang_[1]=CTRL_RAD2DEG*sat(ang[1],lim(eyesJoints[1],0),lim(eyesJoints[1],1));
     ang_[2]=CTRL_RAD2DEG*sat(ang[2],lim(eyesJoints[2],0),lim(eyesJoints[2],1));
 
-    posHead->setRefSpeeds(eyesJoints.size(),eyesJoints.getFirst(),vel.data());
-    posHead->positionMove(eyesJoints.size(),eyesJoints.getFirst(),ang_.data());
+    posHead->setRefSpeeds((int)eyesJoints.size(),eyesJoints.data(),vel.data());
+    posHead->positionMove((int)eyesJoints.size(),eyesJoints.data(),ang_.data());
 
     if (commData->debugInfoEnabled && (port_debug.getOutputCount()>0))
     {
@@ -545,15 +545,15 @@ void Controller::resetCtrlEyes()
 /************************************************************************/
 bool Controller::areJointsHealthyAndSet()
 {
-    VectorOf<int> modes(nJointsHead);
-    modHead->getControlModes(modes.getFirst());
+    vector<int> modes(nJointsHead);
+    modHead->getControlModes(modes.data());
 
     jointsToSet.clear();
-    for (size_t i=0; i<modes.size(); i++)
+    for (int i=0; i<(int)modes.size(); i++)
     {
         if ((modes[i]==VOCAB_CM_HW_FAULT) || (modes[i]==VOCAB_CM_IDLE))
             return false;
-        else if (i<(size_t)eyesJoints[0])
+        else if (i<eyesJoints[0])
         {
             if (commData->neckPosCtrlOn)
             {
@@ -577,8 +577,8 @@ void Controller::setJointsCtrlMode()
     if (jointsToSet.size()==0)
         return;
 
-    VectorOf<int> modes;
-    for (size_t i=0; i<jointsToSet.size(); i++)
+    vector<int> modes;
+    for (int i=0; i<(int)jointsToSet.size(); i++)
     {
         if (jointsToSet[i]<eyesJoints[0])
         {
@@ -591,8 +591,7 @@ void Controller::setJointsCtrlMode()
             modes.push_back(VOCAB_CM_MIXED);
     }
 
-    modHead->setControlModes(jointsToSet.size(),jointsToSet.getFirst(),
-                             modes.getFirst());
+    modHead->setControlModes((int)jointsToSet.size(),jointsToSet.data(),modes.data());
 }
 
 
@@ -661,7 +660,7 @@ void Controller::run()
     if (commData->saccadeUnderway && (Time::now()-saccadeStartTime>=Ts))
     {
         bool done;
-        posHead->checkMotionDone(eyesJoints.size(),eyesJoints.getFirst(),&done);
+        posHead->checkMotionDone((int)eyesJoints.size(),eyesJoints.data(),&done);
         commData->saccadeUnderway=!done;
 
         if (!commData->saccadeUnderway)
@@ -902,8 +901,8 @@ void Controller::run()
         if (commData->neckPosCtrlOn)
         {
             posdeg=(CTRL_RAD2DEG)*IntPlan->get();
-            posNeck->setPositions(neckJoints.size(),neckJoints.getFirst(),posdeg.data());
-            velHead->velocityMove(eyesJoints.size(),eyesJoints.getFirst(),vdeg.subVector(3,5).data());
+            posNeck->setPositions((int)neckJoints.size(),neckJoints.data(),posdeg.data());
+            velHead->velocityMove((int)eyesJoints.size(),eyesJoints.data(),vdeg.subVector(3,5).data());
         }
         else
             velHead->velocityMove(vdeg.data());

--- a/src/tools/fingersTuner/main.cpp
+++ b/src/tools/fingersTuner/main.cpp
@@ -87,6 +87,7 @@ Windows, Linux
 #include <string>
 #include <sstream>
 #include <fstream>
+#include <vector>
 #include <map>
 
 #include <yarp/os/all.h>
@@ -118,7 +119,7 @@ protected:
         double st_down;
         double encs_ratio;
         pidStatus status;
-        VectorOf<int> idling_joints;
+        vector<int> idling_joints;
         PidData() : Kp(0.0), Ki(0.0), Kd(0.0), scale(0.0),
                     st_up(0.0), st_down(0.0), encs_ratio(1.0),
                     status(download) { }


### PR DESCRIPTION
Smelling https://github.com/robotology/yarp/issues/1598, I guess change is in the air 😄 
Therefore, I've tried to replace `yarp::sig::VectorOf` with `std::vector` whenever it was possible.

Actually, there's still one place where `yarp::sig::VectorOf` seems necessary:
https://github.com/robotology/icub-main/blob/95de4fd9409c2880a70acbc30c17ac384bc2b615/src/tools/iCubGui/src/objectsthread.h#L188
given that `std::vector` is not portable yet. Perhaps, @ale-git might want to consider refactoring this.

Finally, I've been using `std::vector::data()` meaning that I assume we're fully supporting C++11 as in Yarp, although I don't know whether we'd need to enforce this anywhere in cmake by means of `CMAKE_CXX_STANDARD` option.

cc @drdanz @lornat75 @traversaro 