### PR TITLE
Add MSVS CMake folder and json in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@ licenses-authors.txt
 licenses-bad.txt
 licenses-copyright-compact.txt
 licenses-good.txt
-
 .DS_Store
 .Spotlight-V100
 .Trashes
-
+.vs/
+CMakeSettings.json


### PR DESCRIPTION
This PR adds the folder `.vs/` and the json file `CMakeSettings.json` as gitignor entries.
The folder and the file are generated by MS Visual Studio usign CMake projects.