### PR TITLE
Add missing icub_export_library for ethLoaderLib

### DIFF
--- a/src/tools/ethLoader/ethLoaderLib/CMakeLists.txt
+++ b/src/tools/ethLoader/ethLoaderLib/CMakeLists.txt
@@ -29,3 +29,6 @@ source_group("Header Files" FILES ${folder_header})
 add_library(${PROJECTNAME} ${folder_source} ${folder_header})
 
 target_link_libraries(${PROJECTNAME} ${YARP_LIBRARIES} ${ACE_LIBRARIES})
+
+icub_export_library(ethLoaderLib)
+


### PR DESCRIPTION
There is a missing `icub_export_library` in `ethLoaderLib` which causes e.g. FirmwareUpdater to fail because the library cannot be found (as it is not being installed).