### PR TITLE
Fix include order

### DIFF
--- a/src/tools/canLoader/canLoaderLib/downloader.h
+++ b/src/tools/canLoader/canLoaderLib/downloader.h
@@ -10,11 +10,18 @@
 #ifndef DOWNLOADER_H
 #define DOWNLOADER_H
 
+#include "EoBoards.h"
+#include "EoCommon.h"
+
+#include "driver.h"
+
+#include <canProtocolLib/iCubCanProto_types.h>
+
 #include <yarp/os/Searchable.h>
 #include <yarp/dev/CanBusInterface.h>
 
 #include <fstream>
-#include "stdint.h"
+#include <stdint.h>
 
 
 //*****************************************************************/
@@ -71,13 +78,6 @@ void drv_sleep (double time);
 //*****************************************************************/
 
 
-
-#include "driver.h"
-
-#include "EoBoards.h"
-#include "EoCommon.h"
-
-#include <canProtocolLib/iCubCanProto_types.h>
 
 // it forces the use of the new driver2 interface
 #define DOWNLOADER_USE_IDRIVER2


### PR DESCRIPTION
Due to robotology/icub-firmware-shared#22 defining `float32_t`, conflicting with YARP `yarp::conf::float32_t` introduced in robotology/yarp#1677, icub-firmware-shared headers must be included before any include from YARP, since doing the opposite will cause a build error.