### PR TITLE
Implemented CanBusMotionControl::getTorquesRaw

### DIFF
--- a/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.cpp
+++ b/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.cpp
@@ -4893,7 +4893,13 @@ bool CanBusMotionControl::setRefTorquesRaw (const double *ref_trqs)
 /// cmd is an array of double (LATER: to be optimized).
 bool CanBusMotionControl::getTorquesRaw (double *trqs)
 {
-    return NOT_YET_IMPLEMENTED("getTorquesRaw");
+    CanBusResources& r = RES(system_resources);
+    bool ret = true;
+    for (int j = 0; j < r.getJoints() && ret; j++)
+    {
+        ret &= getTorqueRaw(j, &trqs[j]);
+    }
+    return ret;
 }
 
 bool CanBusMotionControl::getTorqueRangeRaw (int j, double *min, double *max)


### PR DESCRIPTION
Using the controlboardWrapper with changes made in function for all joints (https://github.com/robotology/yarp/pull/1668), @Nicogene and I noticed that getTorquesRaw returns false because it was not implemented.
Therefore I implemented it like a for cicle on all joints.

@randaz81 : is there a reason why it was not implemented?

