### PR TITLE
Introduced PeriodicThread

### DIFF
--- a/src/libraries/actionPrimitives/include/iCub/action/actionPrimitives.h
+++ b/src/libraries/actionPrimitives/include/iCub/action/actionPrimitives.h
@@ -188,7 +188,7 @@ struct ActionPrimitivesWayPoint
 * (in joint-space) primitive actions and to combine them in the 
 * actions queue. 
 */
-class ActionPrimitives : protected yarp::os::RateThread
+class ActionPrimitives : protected yarp::os::PeriodicThread
 {
 protected:
     std::string robot;
@@ -204,7 +204,7 @@ protected:
 
     perception::Model            *graspModel;
                                  
-    yarp::os::RateThread         *armWaver;
+    yarp::os::PeriodicThread     *armWaver;
     yarp::os::Mutex               mutex;
     yarp::os::Event               motionStartEvent;
     yarp::os::Event               motionDoneEvent;
@@ -279,13 +279,13 @@ protected:
         bool handSeqTerminator;
         // reach way points action
         bool execWayPoints;
-        yarp::os::RateThread *wayPointsThr;
+        yarp::os::PeriodicThread *wayPointsThr;
         // action callback
         ActionPrimitivesCallback *clb;
     };
 
     ActionPrimitivesCallback *actionClb;
-    yarp::os::RateThread     *actionWP;
+    yarp::os::PeriodicThread *actionWP;
     class ActionsQueue : public std::deque<Action>
     {
     public:

--- a/src/libraries/actionPrimitives/src/actionPrimitives.cpp
+++ b/src/libraries/actionPrimitives/src/actionPrimitives.cpp
@@ -68,7 +68,7 @@ namespace action
 
 // This class handles the arm way points
 /************************************************************************/
-class ArmWayPoints : public RateThread
+class ArmWayPoints : public PeriodicThread
 {
     deque<ActionPrimitivesWayPoint> wayPoints;
     ActionPrimitives  *action;
@@ -117,7 +117,7 @@ class ArmWayPoints : public RateThread
 public:
     /************************************************************************/
     ArmWayPoints(ActionPrimitives *_action, const deque<ActionPrimitivesWayPoint> &_wayPoints) :
-                 RateThread(ACTIONPRIM_DEFAULT_PER)
+                 PeriodicThread((double)ACTIONPRIM_DEFAULT_PER/1000.0)
     {
         action=_action;
         action->getCartesianIF(cartCtrl);
@@ -139,7 +139,7 @@ public:
         {
             Vector o;
             cartCtrl->getPose(x0,o);
-            setRate((int)(1000.0*checkTime(wayPoints[0].granularity)));
+            setPeriod(checkTime(wayPoints[0].granularity));
             i=0;
 
             return true;
@@ -177,7 +177,7 @@ public:
                 x0=wayPoints[i].x;
                 i++;
                 printWayPoint();
-                setRate((int)(1000.0*checkTime(wayPoints[i].granularity)));
+                setPeriod(checkTime(wayPoints[i].granularity));
                 t0=Time::now();
             }
             else
@@ -196,7 +196,7 @@ public:
 
 // This class handles the automatic arm-waving
 /************************************************************************/
-class ArmWavingMonitor : public RateThread
+class ArmWavingMonitor : public PeriodicThread
 {
     ICartesianControl *cartCtrl;
     Vector restPos, restOrien;
@@ -205,7 +205,7 @@ class ArmWavingMonitor : public RateThread
 public:
     /************************************************************************/
     ArmWavingMonitor(ICartesianControl *_cartCtrl) :
-                     RateThread((int)(1000.0*ACTIONPRIM_BALANCEARM_PERIOD))
+                     PeriodicThread(ACTIONPRIM_BALANCEARM_PERIOD)
     {
         cartCtrl=_cartCtrl;
         Rand::init();
@@ -294,7 +294,7 @@ ActionPrimitivesWayPoint::ActionPrimitivesWayPoint()
     oEnabled=false;
     duration=ACTIONPRIM_DISABLE_EXECTIME;
     trajTime=ACTIONPRIM_DISABLE_EXECTIME;
-    granularity=ACTIONPRIM_DEFAULT_PER/1000.0;
+    granularity=(double)ACTIONPRIM_DEFAULT_PER/1000.0;
     callback=NULL;
 }
 
@@ -315,7 +315,7 @@ void ActionPrimitives::ActionsQueue::clear()
 
 /************************************************************************/
 ActionPrimitives::ActionPrimitives() :
-                  RateThread(ACTIONPRIM_DEFAULT_PER)
+                  PeriodicThread((double)ACTIONPRIM_DEFAULT_PER/1000.0)
 {
     init();
 }
@@ -323,7 +323,7 @@ ActionPrimitives::ActionPrimitives() :
 
 /************************************************************************/
 ActionPrimitives::ActionPrimitives(Property &opt) :
-                  RateThread(ACTIONPRIM_DEFAULT_PER)
+                  PeriodicThread((double)ACTIONPRIM_DEFAULT_PER/1000.0)
 {
     init();
     open(opt);
@@ -671,7 +671,7 @@ bool ActionPrimitives::open(Property &opt)
     fingers2JntsMap.insert(pair<int,int>(4,15));
 
     // start the thread with the specified period
-    setRate(period);
+    setPeriod((double)period/1000.0);
     start();
 
     // start the balancer thread

--- a/src/libraries/ctrlLib/include/iCub/ctrl/tuning.h
+++ b/src/libraries/ctrlLib/include/iCub/ctrl/tuning.h
@@ -149,7 +149,7 @@ public:
 * track a time varying reference position. The stiction values 
 * are estimated during the rising and falling edge transitions. 
 */
-class OnlineStictionEstimator : public yarp::os::RateThread
+class OnlineStictionEstimator : public yarp::os::PeriodicThread
 {
 protected:
     yarp::dev::IControlMode    *imod;
@@ -271,7 +271,7 @@ public:
      *  
      * @return true iff started successfully.
      */
-    virtual bool startEstimation() { return RateThread::start(); }
+    virtual bool startEstimation() { return PeriodicThread::start(); }
 
     /**
      * Check the current estimation status.
@@ -291,7 +291,7 @@ public:
     /**
      * Stop the estimation procedure.
      */
-    virtual void stopEstimation() { RateThread::stop(); }
+    virtual void stopEstimation() { PeriodicThread::stop(); }
 
     /**
      * Retrieve the estimation. 
@@ -340,7 +340,7 @@ public:
 * estimation, one for the plant validation, one for the stiction
 * estimation and one for validating the controller's design.
 */
-class OnlineCompensatorDesign : public yarp::os::RateThread
+class OnlineCompensatorDesign : public yarp::os::PeriodicThread
 {
 protected:
     OnlineDCMotorEstimator  plant;
@@ -640,7 +640,7 @@ public:
     /**
      * Stop any ongoing operation.
      */
-    virtual void stopOperation() { RateThread::stop(); }
+    virtual void stopOperation() { PeriodicThread::stop(); }
 
     /**
      * Retrieve the results of the current ongoing operation.

--- a/src/libraries/iKin/include/iCub/iKin/iKinSlv.h
+++ b/src/libraries/iKin/include/iCub/iKin/iKinSlv.h
@@ -227,7 +227,7 @@
 #include <deque>
 
 #include <yarp/os/BufferedPort.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Mutex.h>
 #include <yarp/os/Event.h>
 #include <yarp/sig/Vector.h>
@@ -327,7 +327,7 @@ struct PartDescriptor
 *
 * Abstract class defining the core of on-line solvers.
 */
-class CartesianSolver : public    yarp::os::RateThread,
+class CartesianSolver : public    yarp::os::PeriodicThread,
                         protected CartesianHelper
 {
 protected:

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
@@ -40,7 +40,7 @@ bool BcbBattery::open(yarp::os::Searchable& config)
     }
 
     int period=config.find("thread_period").asInt();
-    setRate(period);
+    setPeriod((double)period/1000.0);
 
     Property prop;
     std::string ps = group_serial.toString();
@@ -74,14 +74,14 @@ bool BcbBattery::open(yarp::os::Searchable& config)
     this->debugEnable = group_general.check("debug", Value(0), "enable/disable the debug mode").asBool();
     this->shutdownEnable = group_general.check("shutdown", Value(0), "enable/disable the automatic shutdown").asBool();
 
-    RateThread::start();
+    PeriodicThread::start();
     return true;
 }
 
 bool BcbBattery::close()
 {
     //stop the thread
-    RateThread::stop();
+    PeriodicThread::stop();
 
     //stop the driver
     driver.close();

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.h
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.h
@@ -7,7 +7,7 @@
 #ifndef __BCBBATTERY_H__
 #define __BCBBATTERY_H__
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/IBattery.h>
 #include <yarp/dev/PolyDriver.h>
@@ -18,7 +18,7 @@
 using namespace yarp::os;
 using namespace yarp::dev;
 
-class BcbBattery : public RateThread, public yarp::dev::IBattery, public DeviceDriver
+class BcbBattery : public PeriodicThread, public yarp::dev::IBattery, public DeviceDriver
 {
 protected:
     yarp::os::Semaphore mutex;
@@ -50,9 +50,8 @@ protected:
     std::string         localName;
 
 public:
-    BcbBattery(int period = 20) : RateThread(period), mutex(1)
+    BcbBattery(int period = 20) : PeriodicThread((double)period/1000.0), mutex(1)
     {}
-
 
     ~BcbBattery()
     {

--- a/src/libraries/icubmod/bmsBattery/bmsBattery.cpp
+++ b/src/libraries/icubmod/bmsBattery/bmsBattery.cpp
@@ -40,7 +40,7 @@ bool BmsBattery::open(yarp::os::Searchable& config)
     }
 
     int period=config.find("thread_period").asInt();
-    setRate(period);
+    setPeriod((double)period/1000.0);
 
     Property prop;
     std::string ps = group_serial.toString();
@@ -74,14 +74,14 @@ bool BmsBattery::open(yarp::os::Searchable& config)
     this->debugEnable = group_general.check("debug", Value(0), "enable/disable the debug mode").asBool();
     this->shutdownEnable = group_general.check("shutdown", Value(0), "enable/disable the automatic shutdown").asBool();
 
-    RateThread::start();
+    PeriodicThread::start();
     return true;
 }
 
 bool BmsBattery::close()
 {
     //stop the thread
-    RateThread::stop();
+    PeriodicThread::stop();
 
     //stop the driver
     driver.close();

--- a/src/libraries/icubmod/bmsBattery/bmsBattery.h
+++ b/src/libraries/icubmod/bmsBattery/bmsBattery.h
@@ -7,7 +7,7 @@
 #ifndef __BMSBATTERY_H__
 #define __BMSBATTERY_H__
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/IBattery.h>
 #include <yarp/dev/PolyDriver.h>
@@ -18,7 +18,7 @@
 using namespace yarp::os;
 using namespace yarp::dev;
 
-class BmsBattery : public RateThread, public yarp::dev::IBattery, public DeviceDriver
+class BmsBattery : public PeriodicThread, public yarp::dev::IBattery, public DeviceDriver
 {
 protected:
     yarp::os::Semaphore mutex;
@@ -50,7 +50,7 @@ protected:
     std::string         localName;
 
 public:
-    BmsBattery(int period = 20) : RateThread(period), mutex(1)
+    BmsBattery(int period = 20) : PeriodicThread((double)period/1000.0), mutex(1)
     {}
 
 

--- a/src/libraries/icubmod/canBusAnalogSensor/CanBusAnalogSensor.cpp
+++ b/src/libraries/icubmod/canBusAnalogSensor/CanBusAnalogSensor.cpp
@@ -38,7 +38,7 @@ bool CanBusAnalogSensor::open(yarp::os::Searchable& config)
     }
 
     int period=config.find("period").asInt();
-    setRate(period);
+    setPeriod((double)period/1000.0);
 
     Property prop;
 
@@ -117,7 +117,7 @@ bool CanBusAnalogSensor::open(yarp::os::Searchable& config)
     //start the sensor broadcast
     sensor_start(config);
 
-    RateThread::start();
+    PeriodicThread::start();
     return true;
 }
 
@@ -288,7 +288,7 @@ bool CanBusAnalogSensor::sensor_stop()
 bool CanBusAnalogSensor::close()
 {
     //stop the thread
-    RateThread::stop();
+    PeriodicThread::stop();
 
     //stop the sensor
     sensor_stop();

--- a/src/libraries/icubmod/canBusAnalogSensor/CanBusAnalogSensor.h
+++ b/src/libraries/icubmod/canBusAnalogSensor/CanBusAnalogSensor.h
@@ -7,7 +7,7 @@
 #ifndef __CANBUSANALOGSENSOR_H__
 #define __CANBUSANALOGSENSOR_H__
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/PolyDriver.h>
@@ -39,7 +39,7 @@ using namespace yarp::dev;
 * | useCalibration | int    | -     | - | No  | If useCalibration is present and set to 1 output the calibrated readings, otherwise output the raw values | - |
 * | diagnostic  | int    | -     | - | No  | If diagnostic is present and set to 1 properly return the state of the sensor, otherwise always return IAnalogSensor::AS_OK | - |
 */
-class CanBusAnalogSensor : public RateThread, public yarp::dev::IAnalogSensor, public DeviceDriver
+class CanBusAnalogSensor : public PeriodicThread, public yarp::dev::IAnalogSensor, public DeviceDriver
 {
     enum AnalogDataFormat
     {
@@ -78,7 +78,7 @@ protected:
     bool               diagnostic;
 
 public:
-    CanBusAnalogSensor(int period=20) : RateThread(period),mutex(1)
+    CanBusAnalogSensor(int period=20) : PeriodicThread((double)period/1000.0), mutex(1)
     {}
 
 

--- a/src/libraries/icubmod/canBusDoubleFTSensor/CanBusDoubleFTSensor.cpp
+++ b/src/libraries/icubmod/canBusDoubleFTSensor/CanBusDoubleFTSensor.cpp
@@ -42,7 +42,7 @@ bool CanBusDoubleFTSensor::open(yarp::os::Searchable& config)
     }
 
     int period=config.find("period").asInt();
-    setRate(period);
+    setPeriod((double)period/1000.0);
 
     Property prop;
 
@@ -124,7 +124,7 @@ bool CanBusDoubleFTSensor::open(yarp::os::Searchable& config)
     sensor_start(config,0);
     sensor_start(config,1);
 
-    RateThread::start();
+    PeriodicThread::start();
     return true;
 }
 
@@ -279,7 +279,7 @@ bool CanBusDoubleFTSensor::sensor_stop(int sensor_number)
 bool CanBusDoubleFTSensor::close()
 {
     //stop the thread
-    RateThread::stop();
+    PeriodicThread::stop();
 
     //stop the sensors
     sensor_stop(0);

--- a/src/libraries/icubmod/canBusDoubleFTSensor/CanBusDoubleFTSensor.h
+++ b/src/libraries/icubmod/canBusDoubleFTSensor/CanBusDoubleFTSensor.h
@@ -7,7 +7,7 @@
 #ifndef CANBUSDOUBLEFTSENSOR_H
 #define CANBUSDOUBLEFTSENSOR_H
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/PolyDriver.h>
@@ -60,7 +60,7 @@ using namespace yarp::dev;
 * | backSingleDistance | double | m | - | Yes | Distance between the back and the single emulated sensor, along the x axis of the second sensor. | - |
 *
 */
-class CanBusDoubleFTSensor : public RateThread, public yarp::dev::IAnalogSensor, public DeviceDriver
+class CanBusDoubleFTSensor : public PeriodicThread, public yarp::dev::IAnalogSensor, public DeviceDriver
 {
     enum AnalogDataFormat
     {
@@ -113,7 +113,7 @@ protected:
     double frontSingleDistance;
 
 public:
-    CanBusDoubleFTSensor(int period=20) : RateThread(period),mutex(1),overallStatus(IAnalogSensor::AS_OK)
+    CanBusDoubleFTSensor(int period=20) : PeriodicThread((double)period/1000.0),mutex(1),overallStatus(IAnalogSensor::AS_OK)
     {
         status[0] = IAnalogSensor::AS_OK;
         status[1] = IAnalogSensor::AS_OK;

--- a/src/libraries/icubmod/canBusInertialMTB/CanBusInertialMTB.cpp
+++ b/src/libraries/icubmod/canBusInertialMTB/CanBusInertialMTB.cpp
@@ -192,7 +192,7 @@ bool CanBusInertialMTB::open(yarp::os::Searchable& config)
     {
         int period=10;
         period=config.find("period").asInt();
-        setRate(period);
+        setPeriod((double)period/1000.0);
     }
 
     Property prop;
@@ -248,14 +248,14 @@ bool CanBusInertialMTB::open(yarp::os::Searchable& config)
     sharedStatus.resize(this->nrOfTotalChannels,IAnalogSensor::AS_OK);
     privateStatus.resize(this->nrOfTotalChannels,IAnalogSensor::AS_OK);
 
-    RateThread::start();
+    PeriodicThread::start();
     return true;
 }
 
 bool CanBusInertialMTB::close()
 {
     //stop the thread
-    RateThread::stop();
+    PeriodicThread::stop();
 
     //stop the driver
     if (pCanBufferFactory)

--- a/src/libraries/icubmod/canBusInertialMTB/CanBusInertialMTB.h
+++ b/src/libraries/icubmod/canBusInertialMTB/CanBusInertialMTB.h
@@ -7,7 +7,7 @@
 #ifndef __CANBUSINERTIALMTB_H__
 #define __CANBUSINERTIALMTB_H__
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/PolyDriver.h>
@@ -57,7 +57,7 @@ struct MTBInertialBoardInfo
 * | sensorType     | int |       | - | Yes | Type of sensor to read from MTBs.  | Possible values: acc for the internal LIS331DLH accelerometer of the MTB, extAccAndGyro for the external LIS331DLH accelerometer and L3G4200D gyroscope. |
 * | sensorPeriod   | int    | milliseconds | 5 | No | Every sensorPeriod milliseconds the MTB publishes the sensor measurements on the CAN Bus | Possible values: from 1 to 255 |
 */
-class CanBusInertialMTB : public RateThread, public yarp::dev::IAnalogSensor, public DeviceDriver
+class CanBusInertialMTB : public PeriodicThread, public yarp::dev::IAnalogSensor, public DeviceDriver
 {
 private:
     /**
@@ -94,7 +94,7 @@ protected:
     bool              initted;
     int               count;
 public:
-    CanBusInertialMTB(int period=20) : RateThread(period),
+    CanBusInertialMTB(int period=20) : PeriodicThread((double)period/1000.0),
                                        mutex(1),
                                        initted(false),
                                        count(0)

--- a/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.h
+++ b/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.h
@@ -20,7 +20,7 @@
 #include <yarp/dev/CanBusInterface.h>
 #include <yarp/dev/PreciselyTimed.h>
 #include <yarp/os/Semaphore.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <string>
 #include <list>
 
@@ -658,7 +658,7 @@ class axisTorqueHelper
  *
  */
 class yarp::dev::CanBusMotionControl:public DeviceDriver,
-            public os::RateThread, 
+            public os::PeriodicThread, 
             public IPidControlRaw, 
             public IPositionControl2Raw,
             public IPositionDirectRaw,

--- a/src/libraries/icubmod/canBusSkin/CanBusSkin.cpp
+++ b/src/libraries/icubmod/canBusSkin/CanBusSkin.cpp
@@ -31,7 +31,7 @@ using yarp::os::Value;
 using yarp::dev::CanMessage;
 
 
-CanBusSkin::CanBusSkin() :  RateThread(20),
+CanBusSkin::CanBusSkin() :  PeriodicThread(0.02),
                             mutex(1),
                             _verbose(false),
                             _isDiagnosticPresent(false)
@@ -65,7 +65,7 @@ bool CanBusSkin::open(yarp::os::Searchable& config)
     _cfgReader.setName(name);
 
     int period=config.find("period").asInt();
-    setRate(period);
+    setPeriod((double)period/1000.0);
 
     netID = config.find("canDeviceNum").asInt(); 
 
@@ -195,7 +195,7 @@ bool CanBusSkin::open(yarp::os::Searchable& config)
         }
     }
 
-    RateThread::start();
+    PeriodicThread::start();
     return true;
 }
 
@@ -533,7 +533,7 @@ bool CanBusSkin::close()
         }
     }
 
-    RateThread::stop();
+    PeriodicThread::stop();
     if (pCanBufferFactory) 
     {
         pCanBufferFactory->destroyBuffer(inBuffer);

--- a/src/libraries/icubmod/canBusSkin/CanBusSkin.h
+++ b/src/libraries/icubmod/canBusSkin/CanBusSkin.h
@@ -9,7 +9,7 @@
 
 #include <string>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/IAnalogSensor.h>
@@ -23,7 +23,7 @@
 #include <SkinDiagnostics.h>
 
 
-class CanBusSkin : public yarp::os::RateThread, public yarp::dev::IAnalogSensor, public yarp::dev::DeviceDriver 
+class CanBusSkin : public yarp::os::PeriodicThread, public yarp::dev::IAnalogSensor, public yarp::dev::DeviceDriver 
 {
 private:
 

--- a/src/libraries/icubmod/canBusVirtualAnalogSensor/CanBusVirtualAnalogSensor.cpp
+++ b/src/libraries/icubmod/canBusVirtualAnalogSensor/CanBusVirtualAnalogSensor.cpp
@@ -39,7 +39,7 @@ bool CanBusVirtualAnalogSensor::open(yarp::os::Searchable& config)
     }
 
     int period=config.find("period").asInt();
-    setRate(period);
+    setPeriod((double)period/1000.0);
 
     Property prop;
 
@@ -111,7 +111,7 @@ bool CanBusVirtualAnalogSensor::open(yarp::os::Searchable& config)
     //start the sensor broadcast
     sensor_start(config);
 
-    RateThread::start();
+    PeriodicThread::start();
     return true;
 }
 
@@ -350,7 +350,7 @@ bool CanBusVirtualAnalogSensor::sensor_stop()
 bool CanBusVirtualAnalogSensor::close()
 {
     //stop the thread
-    RateThread::stop();
+    PeriodicThread::stop();
 
     //stop the sensor
     sensor_stop();

--- a/src/libraries/icubmod/canBusVirtualAnalogSensor/CanBusVirtualAnalogSensor.h
+++ b/src/libraries/icubmod/canBusVirtualAnalogSensor/CanBusVirtualAnalogSensor.h
@@ -10,7 +10,7 @@
 //#include <stdio.h>
 #include <string>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/IVirtualAnalogSensor.h>
@@ -22,7 +22,7 @@
 using namespace yarp::os;
 using namespace yarp::dev;
 
-class CanBusVirtualAnalogSensor : public RateThread, public yarp::dev::IVirtualAnalogSensor, public DeviceDriver 
+class CanBusVirtualAnalogSensor : public PeriodicThread, public yarp::dev::IVirtualAnalogSensor, public DeviceDriver 
 {
     enum AnalogDataFormat
     {
@@ -61,7 +61,7 @@ protected:
     bool               useCalibration;
 
 public:
-    CanBusVirtualAnalogSensor(int period=20) : RateThread(period),mutex(1)
+    CanBusVirtualAnalogSensor(int period=20) : PeriodicThread((double)period/1000.0),mutex(1)
     {}
     
 

--- a/src/libraries/icubmod/cartesianController/ServerCartesianController.h
+++ b/src/libraries/icubmod/cartesianController/ServerCartesianController.h
@@ -102,7 +102,7 @@ public:
 class ServerCartesianController : public    yarp::dev::DeviceDriver,
                                   public    yarp::dev::IMultipleWrapper,
                                   public    yarp::dev::ICartesianControl,
-                                  public    yarp::os::RateThread,
+                                  public    yarp::os::PeriodicThread,
                                   protected iCub::iKin::CartesianHelper
 {
 protected:

--- a/src/libraries/icubmod/embObjAnalog/embObjAnalogSensor.h
+++ b/src/libraries/icubmod/embObjAnalog/embObjAnalogSensor.h
@@ -6,7 +6,7 @@
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/os/Semaphore.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <string>
 #include <list>
 

--- a/src/libraries/icubmod/embObjInertials/embObjInertials.h
+++ b/src/libraries/icubmod/embObjInertials/embObjInertials.h
@@ -6,7 +6,7 @@
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/os/Semaphore.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <string>
 #include <list>
 

--- a/src/libraries/icubmod/embObjLib/ethReceiver.cpp
+++ b/src/libraries/icubmod/embObjLib/ethReceiver.cpp
@@ -61,10 +61,10 @@ using namespace eth;
 
 
 
-EthReceiver::EthReceiver(int raterx): RateThread(raterx)
+EthReceiver::EthReceiver(int raterx): PeriodicThread((double)raterx/1000.0)
 {
     rateofthread = raterx;
-    yDebug() << "EthReceiver is a RateThread with rxrate =" << rateofthread << "ms";
+    yDebug() << "EthReceiver is a PeriodicThread with rxrate =" << rateofthread << "ms";
     // ok, and now i get it from xml file ... if i find it.
 
 //    std::string tmp = NetworkBase::getEnvironment("ETHSTAT_PRINT_INTERVAL");

--- a/src/libraries/icubmod/embObjLib/ethReceiver.h
+++ b/src/libraries/icubmod/embObjLib/ethReceiver.h
@@ -31,14 +31,14 @@
 
 #include <ace/SOCK_Dgram.h>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 
 
 namespace eth {
 
     class TheEthManager;
 
-    class EthReceiver : public yarp::os::RateThread
+    class EthReceiver : public yarp::os::PeriodicThread
     {
     private:
         int rateofthread;

--- a/src/libraries/icubmod/embObjLib/ethSender.cpp
+++ b/src/libraries/icubmod/embObjLib/ethSender.cpp
@@ -59,10 +59,10 @@ using yarp::os::Log;
 
 using namespace eth;
 
-EthSender::EthSender(int txrate) : RateThread(txrate)
+EthSender::EthSender(int txrate) : PeriodicThread((double)txrate/1000.0)
 {
     rateofthread = txrate;
-    yDebug() << "EthSender is a RateThread with txrate =" << rateofthread << "ms";
+    yDebug() << "EthSender is a PeriodicThread with txrate =" << rateofthread << "ms";
     yTrace();
 }
 

--- a/src/libraries/icubmod/embObjLib/ethSender.h
+++ b/src/libraries/icubmod/embObjLib/ethSender.h
@@ -31,14 +31,14 @@
 
 #include <ace/SOCK_Dgram.h>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 
 
 namespace eth {
 
     class TheEthManager;
 
-    class EthSender : public yarp::os::RateThread
+    class EthSender : public yarp::os::PeriodicThread
     {
     private:
         int rateofthread;

--- a/src/libraries/icubmod/embObjLib/hostTransceiver.cpp
+++ b/src/libraries/icubmod/embObjLib/hostTransceiver.cpp
@@ -90,7 +90,7 @@ HostTransceiver::HostTransceiver():delayAfterROPloadingFailure(0.001) // 1ms
 {
     yTrace();
 
-//    delayAfterROPloadingFailure = 0.001 * TheEthManager::instance()->getEthSender()->getRate();
+//    delayAfterROPloadingFailure = TheEthManager::instance()->getEthSender()->getPeriod();
 
     ipport              = 0;
     localipaddr         = 0;

--- a/src/libraries/icubmod/embObjMais/embObjMais.h
+++ b/src/libraries/icubmod/embObjMais/embObjMais.h
@@ -7,7 +7,7 @@
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/os/Semaphore.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <string>
 #include <list>
 

--- a/src/libraries/icubmod/embObjMultiEnc/embObjMultiEnc.h
+++ b/src/libraries/icubmod/embObjMultiEnc/embObjMultiEnc.h
@@ -6,7 +6,7 @@
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/os/Semaphore.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <string>
 #include <list>
 

--- a/src/libraries/icubmod/embObjSkin/embObjSkin.h
+++ b/src/libraries/icubmod/embObjSkin/embObjSkin.h
@@ -23,7 +23,7 @@
 
 #include <string>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/IAnalogSensor.h>

--- a/src/libraries/icubmod/embObjStrain/embObjStrain.h
+++ b/src/libraries/icubmod/embObjStrain/embObjStrain.h
@@ -7,7 +7,7 @@
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/os/Semaphore.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <string>
 #include <list>
 

--- a/src/libraries/icubmod/fakeCan/fakeBoard.cpp
+++ b/src/libraries/icubmod/fakeCan/fakeBoard.cpp
@@ -13,7 +13,7 @@
 
 using namespace std;
 
-FakeBoard::FakeBoard(int id, int p):yarp::os::RateThread(p)
+FakeBoard::FakeBoard(int id, int p):yarp::os::PeriodicThread((double)p/1000.0)
 {
     canId=id;
     outMessages=0;

--- a/src/libraries/icubmod/fakeCan/fakeBoard.h
+++ b/src/libraries/icubmod/fakeCan/fakeBoard.h
@@ -8,10 +8,10 @@
 #ifndef __FAKEBOARD__
 #define __FAKEBOARD__
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include "msgList.h"
 
-class FakeBoard: public yarp::os::RateThread
+class FakeBoard: public yarp::os::PeriodicThread
 {
     int canId;
     MsgList inMessages;

--- a/src/libraries/icubmod/imu3DM_GX3/3dm_gx3.cpp
+++ b/src/libraries/icubmod/imu3DM_GX3/3dm_gx3.cpp
@@ -20,7 +20,7 @@ using namespace yarp::dev;
 using namespace yarp::os;
 
 
-imu3DM_GX3::imu3DM_GX3() : RateThread(6)
+imu3DM_GX3::imu3DM_GX3() : PeriodicThread(0.006)
 {
     /* data to be transfered are:
             1  (request Euler) +

--- a/src/libraries/icubmod/imu3DM_GX3/3dm_gx3.h
+++ b/src/libraries/icubmod/imu3DM_GX3/3dm_gx3.h
@@ -24,7 +24,7 @@
 #include <yarp/os/Stamp.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/PreciselyTimed.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <string.h>
 #include <dataTypes.h>
 #include <termios.h> // terminal io (serial port) interface
@@ -47,10 +47,10 @@ struct XSensMTxParameters
  * Driver for 3DM_GX3 IMU unit from MicroStrain
  * @author Alberto Cardellino
  */
-class yarp::dev::imu3DM_GX3 :  public yarp::dev::IGenericSensor,
-                                public yarp::dev::IPreciselyTimed,
-                                public yarp::dev::DeviceDriver,
-                                public yarp::os::RateThread
+class yarp::dev::imu3DM_GX3 : public yarp::dev::IGenericSensor,
+                              public yarp::dev::IPreciselyTimed,
+                              public yarp::dev::DeviceDriver,
+                              public yarp::os::PeriodicThread
 {
 private:
 

--- a/src/libraries/icubmod/imuST_M1/ST_M1.cpp
+++ b/src/libraries/icubmod/imuST_M1/ST_M1.cpp
@@ -19,7 +19,7 @@ using namespace yarp::dev;
 using namespace yarp::os;
 
 
-imuST_M1::imuST_M1() : RateThread(6)
+imuST_M1::imuST_M1() : PeriodicThread(0.006)
 {
     verbose = false;
     nchannels = 12;

--- a/src/libraries/icubmod/imuST_M1/ST_M1.h
+++ b/src/libraries/icubmod/imuST_M1/ST_M1.h
@@ -27,7 +27,7 @@
 #include <yarp/os/Stamp.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/PreciselyTimed.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 
 #include <ST_M1_dataType.h>
 
@@ -54,10 +54,10 @@ namespace yarp{
  * |:-----------------:|
  * | `imuST_M1` |
  */
-class yarp::dev::imuST_M1 :     public yarp::dev::IGenericSensor,
-                                public yarp::dev::IPreciselyTimed,
-                                public yarp::dev::DeviceDriver,
-                                public yarp::os::RateThread
+class yarp::dev::imuST_M1 : public yarp::dev::IGenericSensor,
+                            public yarp::dev::IPreciselyTimed,
+                            public yarp::dev::DeviceDriver,
+                            public yarp::os::PeriodicThread
 {
 private:
 

--- a/src/libraries/icubmod/sharedCan/SharedCanBus.cpp
+++ b/src/libraries/icubmod/sharedCan/SharedCanBus.cpp
@@ -13,7 +13,7 @@
 #include <yarp/os/Time.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/Property.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/PolyDriver.h>
 
 #include "SharedCanBus.h"
@@ -21,10 +21,10 @@
 const int CAN_DRIVER_BUFFER_SIZE = 500;
 const int DEFAULT_THREAD_PERIOD = 10;
 
-class SharedCanBus : public yarp::os::RateThread
+class SharedCanBus : public yarp::os::PeriodicThread
 {
 public:
-    SharedCanBus() : RateThread(DEFAULT_THREAD_PERIOD), writeMutex(1), configMutex(1)
+    SharedCanBus() : PeriodicThread((double)DEFAULT_THREAD_PERIOD/1000.0), writeMutex(1), configMutex(1)
     {
         mBufferSize=0;
         mCanDeviceNum=-1;
@@ -67,7 +67,7 @@ public:
         if (config.findGroup("CAN").check("sharedCanPeriod"))
         {
             int sharedCanPeriod = config.findGroup("CAN").find("sharedCanPeriod").asInt();
-            int currentCanPeriod = this->getRate();
+            int currentCanPeriod = (int)(1000.0 * this->getPeriod());
             if (currentCanPeriod != sharedCanPeriod && currentCanPeriod != DEFAULT_THREAD_PERIOD)
             {
                 yWarning("SharedCanBus: Requested a different sharedCanPeriod (%d ms) respect to previous instance (%d ms). Using: %d ms\n", sharedCanPeriod, currentCanPeriod, currentCanPeriod);
@@ -379,7 +379,7 @@ public:
         if (config.findGroup("CAN").check("sharedCanPeriod"))
         {
             int sharedCanPeriod = config.findGroup("CAN").find("sharedCanPeriod").asInt();
-            scb->setRate(sharedCanPeriod);
+            scb->setPeriod((double)sharedCanPeriod/1000.0);
             //yDebug("SharedCanBus [%d] using custom thread period = %dms\n", scb->getCanDeviceNum(), sharedCanPeriod);///TOBEREMOVED
         }
         else

--- a/src/libraries/icubmod/skinWrapper/skinWrapper.h
+++ b/src/libraries/icubmod/skinWrapper/skinWrapper.h
@@ -34,7 +34,7 @@
 #include <sstream>
 #include <yarp/sig/Vector.h>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/Wrapper.h>

--- a/src/libraries/icubmod/skinprototype/skinprototype.cpp
+++ b/src/libraries/icubmod/skinprototype/skinprototype.cpp
@@ -35,22 +35,22 @@ bool SkinPrototype::open(yarp::os::Searchable& config)
     }
 
     int period=config.find("Period").asInt();
-    setRate(period);
+    setPeriod((double)period/1000.0);
 
     Bottle ids=config.findGroup("SkinCanIds").tail();
 
     if (ids.size()>1)
     {
-		cerr<<"Warning: SkinPrototype id list contains more than one entry -> devices will be merged. "<<endl;
+        cerr<<"Warning: SkinPrototype id list contains more than one entry -> devices will be merged. "<<endl;
     }
-	for (int i=0; i<ids.size(); i++)
-	{
-		int id = ids.get(i).asInt();
-		cardId.push_back (id);
-		#if SKIN_DEBUG
-			fprintf(stderr, "Id reading from %d\n", id);
-		#endif
-	}
+    for (int i=0; i<ids.size(); i++)
+    {
+        int id = ids.get(i).asInt();
+        cardId.push_back (id);
+        #if SKIN_DEBUG
+            fprintf(stderr, "Id reading from %d\n", id);
+        #endif
+    }
 
     Property prop;
 
@@ -96,13 +96,13 @@ bool SkinPrototype::open(yarp::os::Searchable& config)
     sensorsNum=16*12*cardId.size();
     data.resize(sensorsNum);
 
-    RateThread::start();
+    PeriodicThread::start();
     return true;
 }
 
 bool SkinPrototype::close()
 {
-    RateThread::stop();
+    PeriodicThread::stop();
     if (pCanBufferFactory) 
     {
         pCanBufferFactory->destroyBuffer(inBuffer);
@@ -162,8 +162,8 @@ int SkinPrototype::calibrateSensor()
 
 int SkinPrototype::calibrateChannel(int ch, double v)
 {
-	//NOT YET IMPLEMENTED
-	return calibrateSensor();
+    //NOT YET IMPLEMENTED
+    return calibrateSensor();
 }
 
 int SkinPrototype::calibrateSensor(const yarp::sig::Vector& v)
@@ -206,7 +206,7 @@ bool SkinPrototype::threadInit()
 }
 
 void SkinPrototype::run()
-{	
+{   
     mutex.wait();
 
     unsigned int canMessages=0;
@@ -230,9 +230,9 @@ void SkinPrototype::run()
         unsigned int type=msg.getData()[0]&0x80;
         int len=msg.getLen();
 
-		for (int i=0; i<cardId.size(); i++)
-		{
-			if (id==cardId[i])
+        for (int i=0; i<cardId.size(); i++)
+        {
+            if (id==cardId[i])
             {
                 int index=16*12*i + sensorId*12;
                 
@@ -251,7 +251,7 @@ void SkinPrototype::run()
           //            std::cerr<<"Error: skin received malformed message\n";
           //        }
             }
-		}
+        }
     }
 
     mutex.post();
@@ -260,7 +260,7 @@ void SkinPrototype::run()
 void SkinPrototype::threadRelease()
 {
 #if SKIN_DEBUG
-	printf("SkinPrototype Thread releasing...\n");	
+    printf("SkinPrototype Thread releasing...\n");  
     printf("... done.\n");
 #endif
 }

--- a/src/libraries/icubmod/skinprototype/skinprototype.h
+++ b/src/libraries/icubmod/skinprototype/skinprototype.h
@@ -10,7 +10,7 @@
 //#include <stdio.h>
 #include <string>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/IAnalogSensor.h>
@@ -21,7 +21,7 @@
 using namespace yarp::os;
 using namespace yarp::dev;
 
-class SkinPrototype : public RateThread, public yarp::dev::IAnalogSensor, public DeviceDriver 
+class SkinPrototype : public PeriodicThread, public yarp::dev::IAnalogSensor, public DeviceDriver 
 {
 protected:
 	PolyDriver driver;
@@ -38,7 +38,7 @@ protected:
     yarp::sig::Vector data;
 
 public:
-    SkinPrototype(int period=20) : RateThread(period),mutex(1)
+    SkinPrototype(int period=20) : PeriodicThread((double)period/1000.0),mutex(1)
     {}
     
 

--- a/src/libraries/icubmod/usbCamera/linux/V4L_camera.cpp
+++ b/src/libraries/icubmod/usbCamera/linux/V4L_camera.cpp
@@ -82,7 +82,7 @@ int V4L_camera::convertYARP_to_V4L(int feature)
     return NOT_PRESENT;
 }
 
-V4L_camera::V4L_camera() : RateThread(1000/DEFAULT_FRAMERATE), doCropping(false), toEpochOffset(getEpochTimeShift())
+V4L_camera::V4L_camera() : PeriodicThread(1.0/DEFAULT_FRAMERATE), doCropping(false), toEpochOffset(getEpochTimeShift())
 {
     verbose = false;
     param.fps = DEFAULT_FRAMERATE;

--- a/src/libraries/icubmod/usbCamera/linux/V4L_camera.hpp
+++ b/src/libraries/icubmod/usbCamera/linux/V4L_camera.hpp
@@ -48,7 +48,7 @@
 #include <cv.h>
 
 #include <yarp/os/Semaphore.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/PreciselyTimed.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/IVisualParams.h>
@@ -151,7 +151,7 @@ class yarp::dev::V4L_camera :   public yarp::dev::DeviceDriver,
                                 public yarp::dev::IFrameGrabber,
                                 public yarp::dev::IFrameGrabberControls,
                                 public yarp::dev::IPreciselyTimed,
-                                public yarp::os::RateThread,
+                                public yarp::os::PeriodicThread,
                                 public IRgbVisualParams
 {
 public:

--- a/src/modules/actionsRenderingEngine/include/iCub/MotorThread.h
+++ b/src/modules/actionsRenderingEngine/include/iCub/MotorThread.h
@@ -105,7 +105,7 @@ struct Dragger
 
 
 
-class MotorThread: public RateThread
+class MotorThread: public PeriodicThread
 {
 private:
     ResourceFinder                      &rf;
@@ -249,7 +249,7 @@ private:
 
 public:
     MotorThread(ResourceFinder &_rf, Initializer *initializer)
-        :RateThread(20),rf(_rf),stereo_target(initializer->stereo_target),opcPort(initializer->port_opc),
+        :PeriodicThread(0.02),rf(_rf),stereo_target(initializer->stereo_target),opcPort(initializer->port_opc),
          track_cartesian_target(3,0.0)
     {
         ctrl_gaze=NULL;

--- a/src/modules/actionsRenderingEngine/include/iCub/VisuoThread.h
+++ b/src/modules/actionsRenderingEngine/include/iCub/VisuoThread.h
@@ -21,7 +21,7 @@
 
 
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Semaphore.h>
@@ -59,7 +59,7 @@ struct StereoTracker
 
 
 
-class VisuoThread: public RateThread
+class VisuoThread: public PeriodicThread
 {
 private:
     ResourceFinder                          &rf;

--- a/src/modules/actionsRenderingEngine/src/MotorThread.cpp
+++ b/src/modules/actionsRenderingEngine/src/MotorThread.cpp
@@ -936,7 +936,7 @@ bool MotorThread::threadInit()
     string name=rf.find("name").asString();
     string robot=bMotor.check("robot",Value("icub")).asString();
     string partUsed=bMotor.check("part_used",Value("both_arms")).asString();
-    setRate(bMotor.check("thread_period",Value(100)).asInt());
+    setPeriod((double)bMotor.check("thread_period",Value(100)).asInt()/1000.0);
 
     actions_path=bMotor.check("actions",Value("actions")).asString();
 
@@ -1313,7 +1313,7 @@ bool MotorThread::threadInit()
     setStereoToCartesianMode(starting_modeS2C);
 
     // initializer dragger
-    dragger.init(rf.findGroup("dragger"),this->getRate());
+    dragger.init(rf.findGroup("dragger"),(int)(1000.0*this->getPeriod()));
 
     this->avoidTable(false);
 

--- a/src/modules/actionsRenderingEngine/src/VisuoThread.cpp
+++ b/src/modules/actionsRenderingEngine/src/VisuoThread.cpp
@@ -377,7 +377,7 @@ void VisuoThread::updatePFTracker()
 
 
 VisuoThread::VisuoThread(ResourceFinder &_rf, Initializer *initializer)
-    :RateThread(20),rf(_rf),stereo_target(initializer->stereo_target),opcPort(initializer->port_opc)
+    :PeriodicThread(0.02),rf(_rf),stereo_target(initializer->stereo_target),opcPort(initializer->port_opc)
 {
     buffer[LEFT].clear();
     buffer[RIGHT].clear();
@@ -400,7 +400,7 @@ bool VisuoThread::threadInit()
 
     Bottle bVision=rf.findGroup("vision");
 
-    setRate(bVision.check("period",Value(20)).asInt());
+    setPeriod((double)bVision.check("period",Value(20)).asInt()/1000.0);
 
     minMotionBufSize=bVision.check("minMotionBufSize",Value(10)).asInt();
     minTrackBufSize=bVision.check("minTrackBufSize",Value(1)).asInt();

--- a/src/modules/cartesianInterfaceControl/main.cpp
+++ b/src/modules/cartesianInterfaceControl/main.cpp
@@ -117,7 +117,7 @@ Windows, Linux
 
 #include <yarp/os/Network.h>
 #include <yarp/os/RFModule.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Time.h>
@@ -140,7 +140,7 @@ using namespace yarp::math;
 
 
 /************************************************************************/
-class CtrlThread: public RateThread
+class CtrlThread: public PeriodicThread
 {
 protected:
     ResourceFinder      &rf;
@@ -166,7 +166,7 @@ public:
     /************************************************************************/
     CtrlThread(unsigned int _period, ResourceFinder &_rf,
                string _remote, string _local) :
-               RateThread(_period), rf(_rf),
+               PeriodicThread((double)_period/1000.0), rf(_rf),
                remote(_remote), local(_local) { }
 
     /************************************************************************/

--- a/src/modules/ctpService/main.cpp
+++ b/src/modules/ctpService/main.cpp
@@ -96,7 +96,7 @@ Author: Lorenzo Natale
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/os/Semaphore.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Thread.h>
 #include <yarp/os/Semaphore.h>
 
@@ -371,12 +371,12 @@ public:
     }
 };
 
-class WorkingThread: public RateThread
+class WorkingThread: public PeriodicThread
 {
 private:
     scriptPosPort *posPort;
 public:
-    WorkingThread(int period=100): RateThread(period)
+    WorkingThread(int period=100): PeriodicThread((double)period/1000.0)
     {}
 
     void attachPosPort(scriptPosPort *p)

--- a/src/modules/gravityCompensator/gravityThread.cpp
+++ b/src/modules/gravityCompensator/gravityThread.cpp
@@ -22,7 +22,7 @@
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/dev/PolyDriver.h>
@@ -202,7 +202,7 @@ void  gravityCompensatorThread::setUpperMeasure()
     icub->upperTorso->setInertialMeasure(w0,dw0,d2p0);
 }
 
-gravityCompensatorThread::gravityCompensatorThread(string _wholeBodyName, int _rate, PolyDriver *_ddLA, PolyDriver *_ddRA, PolyDriver *_ddH, PolyDriver *_ddLL, PolyDriver *_ddRL, PolyDriver *_ddT, version_tag icub_type, bool _inertial_enabled) : RateThread(_rate), ddLA(_ddLA), ddRA(_ddRA), ddLL(_ddLL), ddRL(_ddRL), ddH(_ddH), ddT(_ddT)
+gravityCompensatorThread::gravityCompensatorThread(string _wholeBodyName, int _rate, PolyDriver *_ddLA, PolyDriver *_ddRA, PolyDriver *_ddH, PolyDriver *_ddLL, PolyDriver *_ddRL, PolyDriver *_ddT, version_tag icub_type, bool _inertial_enabled) : PeriodicThread((double)_rate/1000.0), ddLA(_ddLA), ddRA(_ddRA), ddLL(_ddLL), ddRL(_ddRL), ddH(_ddH), ddT(_ddT)
 {   
     gravity_mode = GRAVITY_COMPENSATION_ON;
     external_mode = EXTERNAL_TRQ_ON;

--- a/src/modules/gravityCompensator/gravityThread.h
+++ b/src/modules/gravityCompensator/gravityThread.h
@@ -23,7 +23,7 @@
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/dev/PolyDriver.h>
@@ -45,7 +45,7 @@ enum{GRAVITY_COMPENSATION_OFF = 0, GRAVITY_COMPENSATION_ON = 1};
 enum{EXTERNAL_TRQ_OFF = 0, EXTERNAL_TRQ_ON = 1};
 enum{TORQUE_INTERFACE = 0, IMPEDANCE_POSITION = 1, IMPEDANCE_VELOCITY = 2};
 
-class gravityCompensatorThread: public yarp::os::RateThread
+class gravityCompensatorThread: public yarp::os::PeriodicThread
 {
 private:
 

--- a/src/modules/gravityCompensator/main.cpp
+++ b/src/modules/gravityCompensator/main.cpp
@@ -70,7 +70,7 @@ This file can be edited at \in src/gravityCompensator/main.cpp.
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/os/Log.h>

--- a/src/modules/iKinGazeCtrl/include/iCub/controller.h
+++ b/src/modules/iKinGazeCtrl/include/iCub/controller.h
@@ -48,7 +48,7 @@ using namespace iCub::iKin;
 
 // The thread launched by the application which is
 // in charge of computing the control commands.
-class Controller : public GazeComponent, public RateThread
+class Controller : public GazeComponent, public PeriodicThread
 {
 protected:
     iCubHeadCenter     *neck;

--- a/src/modules/iKinGazeCtrl/include/iCub/localizer.h
+++ b/src/modules/iKinGazeCtrl/include/iCub/localizer.h
@@ -40,7 +40,7 @@ using namespace iCub::iKin;
 // The thread launched by the application which is
 // in charge of localizing target 3D position from
 // image coordinates.
-class Localizer : public GazeComponent, public RateThread
+class Localizer : public GazeComponent, public PeriodicThread
 {
 protected:
     Mutex                 mutex;

--- a/src/modules/iKinGazeCtrl/include/iCub/solver.h
+++ b/src/modules/iKinGazeCtrl/include/iCub/solver.h
@@ -54,7 +54,7 @@ using namespace iCub::iKin;
 // The thread launched by the application which computes
 // the eyes target position relying on the pseudoinverse
 // method.
-class EyePinvRefGen : public GazeComponent, public RateThread
+class EyePinvRefGen : public GazeComponent, public PeriodicThread
 {
 protected:
     iCubHeadCenter       *neck;
@@ -115,7 +115,7 @@ public:
 // The thread launched by the application which is
 // in charge of inverting the head kinematic relying
 // on IPOPT computation.
-class Solver : public GazeComponent, public RateThread
+class Solver : public GazeComponent, public PeriodicThread
 {
 protected:    
     iCubHeadCenter     *neck;

--- a/src/modules/iKinGazeCtrl/src/localizer.cpp
+++ b/src/modules/iKinGazeCtrl/src/localizer.cpp
@@ -26,7 +26,8 @@
 
 /************************************************************************/
 Localizer::Localizer(ExchangeData *_commData, const unsigned int _period) :
-                     RateThread(_period), commData(_commData), period(_period)
+                     PeriodicThread((double)_period/1000.0), commData(_commData),
+                     period(_period)
 {
     iCubHeadCenter eyeC("right_"+commData->headVersion2String());
     eyeL=new iCubEye("left_"+commData->headVersion2String());

--- a/src/modules/iKinGazeCtrl/src/solver.cpp
+++ b/src/modules/iKinGazeCtrl/src/solver.cpp
@@ -27,9 +27,9 @@
 EyePinvRefGen::EyePinvRefGen(PolyDriver *_drvTorso, PolyDriver *_drvHead,
                              ExchangeData *_commData, Controller *_ctrl,
                              const Vector &_counterRotGain, const unsigned int _period) :
-                             RateThread(_period), drvTorso(_drvTorso), drvHead(_drvHead),
-                             commData(_commData), ctrl(_ctrl),         period(_period),
-                             Ts(_period/1000.0),  counterRotGain(_counterRotGain)
+                             PeriodicThread((double)_period/1000.0), drvTorso(_drvTorso), drvHead(_drvHead),
+                             commData(_commData),                    ctrl(_ctrl),         period(_period),
+                             Ts(_period/1000.0),                     counterRotGain(_counterRotGain)
 {
     // Instantiate objects
     neck=new iCubHeadCenter("right_"+commData->headVersion2String());
@@ -445,7 +445,7 @@ void EyePinvRefGen::run()
 /************************************************************************/
 void EyePinvRefGen::suspend()
 {    
-    RateThread::suspend();
+    PeriodicThread::suspend();
     yInfo("Pseudoinverse Reference Generator has been suspended!");
 }
 
@@ -453,7 +453,7 @@ void EyePinvRefGen::suspend()
 /************************************************************************/
 void EyePinvRefGen::resume()
 {    
-    RateThread::resume();
+    PeriodicThread::resume();
     yInfo("Pseudoinverse Reference Generator has been resumed!");
 }
 
@@ -462,9 +462,9 @@ void EyePinvRefGen::resume()
 Solver::Solver(PolyDriver *_drvTorso, PolyDriver *_drvHead, ExchangeData *_commData,
                EyePinvRefGen *_eyesRefGen, Localizer *_loc, Controller *_ctrl,
                const unsigned int _period) :
-               RateThread(_period), drvTorso(_drvTorso),     drvHead(_drvHead),
-               commData(_commData), eyesRefGen(_eyesRefGen), loc(_loc),
-               ctrl(_ctrl),         period(_period),         Ts(_period/1000.0)
+               PeriodicThread((double)_period/1000.0), drvTorso(_drvTorso),     drvHead(_drvHead),
+               commData(_commData),                    eyesRefGen(_eyesRefGen), loc(_loc),
+               ctrl(_ctrl),                            period(_period),         Ts(_period/1000.0)
 {
     // Instantiate objects
     neck=new iCubHeadCenter("right_"+commData->headVersion2String());
@@ -874,7 +874,7 @@ void Solver::run()
 void Solver::suspend()
 {
     commData->port_xd->lock();
-    RateThread::suspend();
+    PeriodicThread::suspend();
     yInfo("Solver has been suspended!");
 }
 
@@ -901,7 +901,7 @@ void Solver::resume()
     torsoVel->reset();       
     commData->port_xd->unlock();
 
-    RateThread::resume();
+    PeriodicThread::resume();
     yInfo("Solver has been resumed!");
 }
 

--- a/src/modules/objectsPropertiesCollector/main.cpp
+++ b/src/modules/objectsPropertiesCollector/main.cpp
@@ -395,7 +395,7 @@ bool notEqual(Value &a, Value &b)
 
 
 /************************************************************************/
-class DataBase : public RateThread
+class DataBase : public PeriodicThread
 {
 protected:
     /************************************************************************/
@@ -510,7 +510,7 @@ protected:
 
 public:
     /************************************************************************/
-    DataBase() : RateThread(1000)
+    DataBase() : PeriodicThread(1.0)
     {
         pBroadcastPort=NULL;
         asyncBroadcast=false;
@@ -550,7 +550,7 @@ public:
 
         if (rf.check("sync-bc"))
         {
-            setRate((int)(1000.0*rf.check("sync-bc",Value(1.0)).asDouble()));
+            setPeriod(rf.check("sync-bc",Value(1.0)).asDouble());
             start();
         }
 
@@ -1316,7 +1316,7 @@ public:
                 if (opt==Vocab::encode("start"))
                 {
                     if (command.size()>=3)
-                        setRate((int)(1000.0*command.get(2).asDouble()));
+                        setPeriod(command.get(2).asDouble());
 
                     if (!isRunning())
                         start();

--- a/src/modules/positionDirectControl/positionDirectThread.cpp
+++ b/src/modules/positionDirectControl/positionDirectThread.cpp
@@ -17,7 +17,7 @@ using namespace yarp::os;
 using namespace yarp::sig;
 
 positionDirectControlThread::positionDirectControlThread(int period):
-                yarp::os::RateThread(period)
+                yarp::os::PeriodicThread((double)period/1000.0)
 {
     control_period = period;
     suspended = true;
@@ -36,8 +36,8 @@ void positionDirectControlThread::run()
     {
         yDebug("Thread ran %d times, est period %lf[ms], used %lf[ms]\n",
                 getIterations(),
-                getEstPeriod(),
-                getEstUsed());
+                1000.0*getEstimatedPeriod(),
+                1000.0*getEstimatedUsed());
         resetStat();
     }
     _mutex.wait();

--- a/src/modules/positionDirectControl/positionDirectThread.h
+++ b/src/modules/positionDirectControl/positionDirectThread.h
@@ -8,7 +8,7 @@
 
 #include <string>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
@@ -16,7 +16,7 @@
 #include <yarp/sig/Vector.h>
 #include <yarp/os/Time.h>
 
-class positionDirectControlThread: public yarp::os::RateThread
+class positionDirectControlThread: public yarp::os::PeriodicThread
 {
 private:
     char robotName[255];

--- a/src/modules/skinManager/include/iCub/skinManager/SkinDiagnosticsReadThread.h
+++ b/src/modules/skinManager/include/iCub/skinManager/SkinDiagnosticsReadThread.h
@@ -25,7 +25,7 @@
 #include <vector>
 #include <deque>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Bottle.h>
@@ -33,7 +33,7 @@
 
 namespace iCub {
     namespace skinManager {
-        class SkinDiagnosticsReadThread : public yarp::os::RateThread {
+        class SkinDiagnosticsReadThread : public yarp::os::PeriodicThread {
             private:
                 /* ****** Module attributes                             ****** */
                 /** The thread period. */

--- a/src/modules/skinManager/include/iCub/skinManager/compensationThread.h
+++ b/src/modules/skinManager/include/iCub/skinManager/compensationThread.h
@@ -27,7 +27,7 @@
 
 #include <yarp/sig/Vector.h>
 #include <yarp/os/BufferedPort.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/IAnalogSensor.h>
@@ -46,7 +46,7 @@ namespace iCub{
 
 namespace skinManager{
 
-class CompensationThread : public RateThread
+class CompensationThread : public PeriodicThread
 {
 public:
     typedef enum { calibration, compensation} CompensationThreadState;

--- a/src/modules/skinManager/include/iCub/skinManager/compensator.h
+++ b/src/modules/skinManager/include/iCub/skinManager/compensator.h
@@ -29,7 +29,7 @@
 
 #include <yarp/sig/Vector.h>
 #include <yarp/os/BufferedPort.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/Stamp.h>

--- a/src/modules/skinManager/src/SkinDiagnosticsReadThread.cpp
+++ b/src/modules/skinManager/src/SkinDiagnosticsReadThread.cpp
@@ -30,7 +30,7 @@ using iCub::skinManager::SkinDiagnosticsReadThread;
 using std::cerr;
 using std::cout;
 
-using yarp::os::RateThread;
+using yarp::os::PeriodicThread;
 
 #define SKINMANAGER_TH_DIAGREAD_DEBUG 1
 
@@ -38,7 +38,7 @@ using yarp::os::RateThread;
 /* *********************************************************************************************************************** */
 /* ******* Constructor                                                      ********************************************** */
 SkinDiagnosticsReadThread::SkinDiagnosticsReadThread(const int aPeriod, const yarp::os::ResourceFinder &aRf)
-    : RateThread(aPeriod) {
+    : PeriodicThread((double)aPeriod/1000.0) {
     period = aPeriod;
     rf = aRf;
 

--- a/src/modules/skinManager/src/compensationThread.cpp
+++ b/src/modules/skinManager/src/compensationThread.cpp
@@ -35,10 +35,10 @@ CompensationThread::CompensationThread(string name, ResourceFinder* rf, string r
                                        int addThreshold, float minBaseline, bool zeroUpRawData, 
                                        int period, bool binarization, bool smoothFilter, float smoothFactor)
                                        : 
-                                        RateThread(period), moduleName(name), compensationGain(_compensationGain), 
-                                            contactCompensationGain(_contactCompensationGain), 
-                                            ADD_THRESHOLD(addThreshold), robotName(robotName), 
-                                            binarization(binarization), smoothFilter(smoothFilter), smoothFactor(smoothFactor)
+                                       PeriodicThread((double)period/1000.0), moduleName(name), compensationGain(_compensationGain), 
+                                       contactCompensationGain(_contactCompensationGain), 
+                                       ADD_THRESHOLD(addThreshold), robotName(robotName), 
+                                       binarization(binarization), smoothFilter(smoothFilter), smoothFactor(smoothFactor)
 {
    this->rf                             = rf;
    this->minBaseline                    = minBaseline;
@@ -54,7 +54,7 @@ bool CompensationThread::threadInit()
     readErrorCounter = 0;
     state = calibration;
     calibrationCounter = 0;
-    CAL_SAMPLES = 1000*CAL_TIME/((int)getRate()); // samples needed for calibration (note that getRate() returns the thread period)
+    CAL_SAMPLES = (int)((double)CAL_TIME/getPeriod());          // samples needed for calibration
 
     // open the output ports for communicating with the gui
     string monitorPortName = "/" + moduleName + "/monitor:o";   // output streaming data
@@ -341,7 +341,7 @@ void CompensationThread::sendMonitorData(){
         Vector &b = monitorPort.prepare();
         b.clear();        
         b.resize(1+ 2*originalSkinDim);
-        b[0] = 1000.0/getEstPeriod(); // thread frequency
+        b[0] = 1.0/getEstimatedPeriod(); // thread frequency
         
         stateSem.wait();
         if(state==compensation){    // during calibration don't send this data

--- a/src/modules/skinManager/src/skinManager.cpp
+++ b/src/modules/skinManager/src/skinManager.cpp
@@ -593,10 +593,10 @@ bool skinManager::identifyCommand(Bottle commandBot, SkinManagerCommand &com, Bo
 
 bool skinManager::updateModule() { 
     double avgTime, stdDev, period;
-    period = myThread->getRate();
-    myThread->getEstPeriod(avgTime, stdDev);
+    period = myThread->getPeriod();
+    myThread->getEstimatedPeriod(avgTime, stdDev);
     double avgTimeUsed, stdDevUsed;
-    myThread->getEstUsed(avgTimeUsed, stdDevUsed);     // real duration of run()
+    myThread->getEstimatedUsed(avgTimeUsed, stdDevUsed);     // real duration of run()
     if(avgTime > 1.3 * period){
         yWarning("Thread too slow. Real period: %3.3f+/-%3.3f. Expected period: %3.3f.\n", avgTime, stdDev, period);
         yWarning("Duration of 'run' method: %3.3f+/-%3.3f.\n", avgTimeUsed, stdDevUsed);

--- a/src/modules/templatePFTracker/include/iCub/particleFilter.h
+++ b/src/modules/templatePFTracker/include/iCub/particleFilter.h
@@ -23,7 +23,7 @@
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Thread.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/Stamp.h>
@@ -213,7 +213,7 @@ public:
 };
 
 
-class PARTICLEManager : public yarp::os::RateThread 
+class PARTICLEManager : public yarp::os::PeriodicThread 
 {
 private:
     

--- a/src/modules/templatePFTracker/src/particleFilter.cpp
+++ b/src/modules/templatePFTracker/src/particleFilter.cpp
@@ -748,7 +748,7 @@ TemplateStruct PARTICLEThread::getBestTemplate()
     return best;
 }
 /**********************************************************/
-PARTICLEManager::PARTICLEManager() : RateThread(20) 
+PARTICLEManager::PARTICLEManager() : PeriodicThread(0.02) 
 {
     tpl = NULL;
 }

--- a/src/modules/velocityControl/velControlThread.cpp
+++ b/src/modules/velocityControl/velControlThread.cpp
@@ -23,7 +23,7 @@ const double MAX_GAIN = 10.0;
 const int VELOCITY_INDEX_OFFSET=1000;
 
 velControlThread::velControlThread(int rate):
-                yarp::os::RateThread(rate)
+                yarp::os::PeriodicThread((double)rate/1000.0)
 {
     control_rate = rate;
     suspended = true;
@@ -40,8 +40,8 @@ void velControlThread::run()
     {
         yDebug("Thread ran %d times, est period %lf[ms], used %lf[ms]\n",
                 getIterations(),
-                getEstPeriod(),
-                getEstUsed());
+                1000.0*getEstimatedPeriod(),
+                1000.0*getEstimatedUsed());
         resetStat();
     }
     _mutex.wait();

--- a/src/modules/velocityControl/velControlThread.h
+++ b/src/modules/velocityControl/velControlThread.h
@@ -8,7 +8,7 @@
 
 #include <string>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
@@ -18,7 +18,7 @@
 
 //class yarp::dev::PolyDriver;
 
-class velControlThread: public yarp::os::RateThread
+class velControlThread: public yarp::os::PeriodicThread
 {
 private:
     char robotName[255];

--- a/src/modules/wholeBodyDynamics/main.cpp
+++ b/src/modules/wholeBodyDynamics/main.cpp
@@ -710,8 +710,8 @@ public:
     bool updateModule() 
     {
         double avgTime, stdDev, period;
-        period = inv_dyn->getRate();
-        inv_dyn->getEstPeriod(avgTime, stdDev);
+        period = inv_dyn->getPeriod();
+        inv_dyn->getEstimatedPeriod(avgTime, stdDev);
         if(avgTime > 1.3 * period){
         //   yDebug("(real period: %3.3f +/- %3.3f; expected period %3.3f)\n", avgTime, stdDev, period);
         }

--- a/src/modules/wholeBodyDynamics/observerThread.cpp
+++ b/src/modules/wholeBodyDynamics/observerThread.cpp
@@ -250,7 +250,7 @@ void inverseDynamics::setStiffMode()
      }
 }
 
-inverseDynamics::inverseDynamics(int _rate, PolyDriver *_ddAL, PolyDriver *_ddAR, PolyDriver *_ddH, PolyDriver *_ddLL, PolyDriver *_ddLR, PolyDriver *_ddT, string _robot_name, string _local_name, version_tag _icub_type, bool _autoconnect) : RateThread(_rate), ddAL(_ddAL), ddAR(_ddAR), ddH(_ddH), ddLL(_ddLL), ddLR(_ddLR), ddT(_ddT), robot_name(_robot_name), icub_type(_icub_type), local_name(_local_name), zero_sens_tolerance (1e-12)
+inverseDynamics::inverseDynamics(int _rate, PolyDriver *_ddAL, PolyDriver *_ddAR, PolyDriver *_ddH, PolyDriver *_ddLL, PolyDriver *_ddLR, PolyDriver *_ddT, string _robot_name, string _local_name, version_tag _icub_type, bool _autoconnect) : PeriodicThread((double)_rate/1000.0), ddAL(_ddAL), ddAR(_ddAR), ddH(_ddH), ddLL(_ddLL), ddLR(_ddLR), ddT(_ddT), robot_name(_robot_name), icub_type(_icub_type), local_name(_local_name), zero_sens_tolerance (1e-12)
 {
     status_queue_size = 10;
     autoconnect = _autoconnect;

--- a/src/modules/wholeBodyDynamics/observerThread.h
+++ b/src/modules/wholeBodyDynamics/observerThread.h
@@ -126,7 +126,7 @@ class iCubStatus
 };
 
 // class inverseDynamics: class for reading from Vrow and providing FT on an output port
-class inverseDynamics: public RateThread
+class inverseDynamics: public PeriodicThread
 {
 public:
     bool       com_enabled;

--- a/src/simulators/iCubSimulation/wrapper/iCubSimulationControl.cpp
+++ b/src/simulators/iCubSimulation/wrapper/iCubSimulationControl.cpp
@@ -53,7 +53,7 @@ static inline bool DEPRECATED(const char *txt)
 //////////////////////////////////
 
 iCubSimulationControl::iCubSimulationControl() : 
-    //RateThread(10),
+    //PeriodicThread(0.01),
     ImplementPositionControl2(this),
     ImplementVelocityControl2(this),
     ImplementPidControl(this),
@@ -338,7 +338,7 @@ bool iCubSimulationControl::open(yarp::os::Searchable& config) {
     odeinit.mutex.wait();
     odeinit.setSimulationControl(this, partSelec);
     odeinit.mutex.post();
-    //RateThread::start();
+    //PeriodicThread::start();
     //_done.wait ();
     _mutex.post();
     _opened = true;
@@ -351,11 +351,11 @@ bool iCubSimulationControl::close (void)
 {
     if (_opened) {
 
-        //if (RateThread::isRunning())
+        //if (PeriodicThread::isRunning())
         //    {
         //    }
         
-        //RateThread::stop();/// stops the thread first (joins too).
+        //PeriodicThread::stop();/// stops the thread first (joins too).
         
         ImplementPositionControl2::uninitialize();
         ImplementVelocityControl2::uninitialize();

--- a/src/simulators/iCubSimulation/wrapper/iCubSimulationControl.h
+++ b/src/simulators/iCubSimulation/wrapper/iCubSimulationControl.h
@@ -32,7 +32,7 @@
 
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Semaphore.h>
-//#include <yarp/os/RateThread.h>
+//#include <yarp/os/PeriodicThread.h>
 #include <yarp/sig/Image.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/dev/DeviceDriver.h>
@@ -80,7 +80,7 @@ namespace yarp{
 }
 class yarp::dev::iCubSimulationControl :
     public DeviceDriver,
-    //public yarp::os::RateThread, 
+    //public yarp::os::PeriodicThread, 
     public IPositionControl2Raw,
     public ImplementPositionControl2,
     public IVelocityControl2Raw,

--- a/src/tools/canBusSniffer/canBusSnifferV5/main.cpp
+++ b/src/tools/canBusSniffer/canBusSnifferV5/main.cpp
@@ -21,7 +21,7 @@ This file can be edited at src/canBusSniffer/main.cpp.
 #include <yarp/dev/CanBusInterface.h>
 #include <yarp/os/Time.h>
 #include <yarp/sig/Vector.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include "fft.h"
 #include "hist.h"
 #include <iostream>
@@ -97,14 +97,14 @@ bool done=false;
   freq = new double[NNFT/2];
   for ( i = 0; i < NNFT/2; i++ )
   {
-	  freq[i] = float(i)/(float(NNFT)/2);
-	  
-	  freq[i] = F_SAMPLE/2*freq[i];
+      freq[i] = float(i)/(float(NNFT)/2);
+      
+      freq[i] = F_SAMPLE/2*freq[i];
   }
 
   for ( i = 0; i < 80; i++ )
   {
-	 	printf ( "  %12f %12f \n",  freq[i], fft[i]);
+        printf ( "  %12f %12f \n",  freq[i], fft[i]);
   }
 
 
@@ -118,82 +118,82 @@ bool done=false;
 }
 */
  bool log_start=false;
-class SnifferThread: public RateThread
+class SnifferThread: public PeriodicThread
 {
     PolyDriver driver;
     ICanBus *iCanBus;
     ICanBufferFactory *iBufferFactory;
     CanBuffer messageBuffer;
-	unsigned long int cnt;    
-	FILE *fp;
+    unsigned long int cnt;    
+    FILE *fp;
 
-	/* dimension of local buffer, number of recieved messages */
+    /* dimension of local buffer, number of recieved messages */
     unsigned int messages, readMessages;
 
-	/* variables to be sniffed from the Can Bus */
-	unsigned int position[2];
-	signed short pwm[2];
-	signed short pid[2];
-	signed short kp[2];
-	signed short dutyCycle[2];
-	signed short torque[2];
-	signed short commut[2];
-	unsigned short unsigned_gaugeData[6];
-	signed short signed_gaugeData[6];
-	fft_samples   samples;
-	fft_cyclic_sample_buffer csamples;
-	fft_performer fft;
-	hist_performer hist;
+    /* variables to be sniffed from the Can Bus */
+    unsigned int position[2];
+    signed short pwm[2];
+    signed short pid[2];
+    signed short kp[2];
+    signed short dutyCycle[2];
+    signed short torque[2];
+    signed short commut[2];
+    unsigned short unsigned_gaugeData[6];
+    signed short signed_gaugeData[6];
+    fft_samples   samples;
+    fft_cyclic_sample_buffer csamples;
+    fft_performer fft;
+    hist_performer hist;
 
-	unsigned char cycleIndex;
-	signed short filterCoefficients[6];
-	signed short dataBuffer[6];
+    unsigned char cycleIndex;
+    signed short filterCoefficients[6];
+    signed short dataBuffer[6];
 
-	signed short filterData(signed short datum);
-	
+    signed short filterData(signed short datum);
+    
 
 
 
 
 public:
-    SnifferThread(int r=SNIFFER_THREAD_RATE): RateThread(r)
+    SnifferThread(int r=SNIFFER_THREAD_RATE): PeriodicThread((double)r/1000.0)
     {
-		messages = localBufferSize;
-		cycleIndex = 0;
-		filterCoefficients[0] = 1;
-		filterCoefficients[1] = 1;
-		filterCoefficients[2] = 1;
-		filterCoefficients[3] = 1;
-		filterCoefficients[4] = 1;
-		filterCoefficients[5] = 1;
-		for(int i=0; i<6; i++)
-			dataBuffer[i] = 0;
+        messages = localBufferSize;
+        cycleIndex = 0;
+        filterCoefficients[0] = 1;
+        filterCoefficients[1] = 1;
+        filterCoefficients[2] = 1;
+        filterCoefficients[3] = 1;
+        filterCoefficients[4] = 1;
+        filterCoefficients[5] = 1;
+        for(int i=0; i<6; i++)
+            dataBuffer[i] = 0;
 
-		for(int i=0; i<2; i++)
-		{
-			position[i] = 0;
-			pwm[i] = 0;
-			dutyCycle[i] = 0;
-		}
-		
-	}
+        for(int i=0; i<2; i++)
+        {
+            position[i] = 0;
+            pwm[i] = 0;
+            dutyCycle[i] = 0;
+        }
+        
+    }
 
     bool threadInit()
     {
-		/* load configuration parameters into the options property collector */
+        /* load configuration parameters into the options property collector */
         Property prop;
 
-		/* set driver properties */
-		prop.put("device", "ecan");
+        /* set driver properties */
+        prop.put("device", "ecan");
 
         prop.put("CanTxTimeout", 500);
         prop.put("CanRxTimeout", 500);
         prop.put("CanDeviceNum", 2);
 
-		prop.put("CanTxQueue", CAN_DRIVER_BUFFER_SIZE);
+        prop.put("CanTxQueue", CAN_DRIVER_BUFFER_SIZE);
         prop.put("CanRxQueue", CAN_DRIVER_BUFFER_SIZE);
 
-		/* open driver */
+        /* open driver */
         driver.open(prop);
 
         if (!driver.isValid())
@@ -205,180 +205,180 @@ public:
         driver.view(iCanBus);
         driver.view(iBufferFactory);
 
-		/* set the baud rate (0 is defaul for 1Mb/s) */
-		if (!iCanBus->canSetBaudRate(0))
-			fprintf(stderr, "Error setting baud rate\n");
+        /* set the baud rate (0 is defaul for 1Mb/s) */
+        if (!iCanBus->canSetBaudRate(0))
+            fprintf(stderr, "Error setting baud rate\n");
 
-		/* add the id of can messages to be read */
-		iCanBus->canIdAdd(0x35a);
-	    iCanBus->canIdAdd(0x35b);
-//		iCanBus->canIdAdd(0x171);
-//		iCanBus->canIdAdd(0x172);
-		iCanBus->canIdAdd(0x177);
+        /* add the id of can messages to be read */
+        iCanBus->canIdAdd(0x35a);
+        iCanBus->canIdAdd(0x35b);
+//      iCanBus->canIdAdd(0x171);
+//      iCanBus->canIdAdd(0x172);
+        iCanBus->canIdAdd(0x177);
 
         messageBuffer=iBufferFactory->createBuffer(localBufferSize);
 
-		/* turn force-torque sensor on
-		messageBuffer[0].setId(0x205);
-		messageBuffer[0].setLen(2);
-		messageBuffer[0].getData()[0]=7;
-		messageBuffer[0].getData()[1]=0;
-		bool res=iCanBus->canWrite(messageBuffer,1,&readMessages);
-		
-		if (res)
-			return true;
-		else
-		{
-			fprintf(stderr,"Error starting the force/torque sensor\n");
-			return false;
-		}
-		*/
+        /* turn force-torque sensor on
+        messageBuffer[0].setId(0x205);
+        messageBuffer[0].setLen(2);
+        messageBuffer[0].getData()[0]=7;
+        messageBuffer[0].getData()[1]=0;
+        bool res=iCanBus->canWrite(messageBuffer,1,&readMessages);
+        
+        if (res)
+            return true;
+        else
+        {
+            fprintf(stderr,"Error starting the force/torque sensor\n");
+            return false;
+        }
+        */
 
-		cnt = 0;
-		fp = fopen("output.dat","w");
+        cnt = 0;
+        fp = fopen("output.dat","w");
     }
 
     void run()
     {
-		readMessages = 0; 
-		/* read from the Can Bus messages with the id that has been 
-		   specified */
+        readMessages = 0; 
+        /* read from the Can Bus messages with the id that has been 
+           specified */
         bool res=iCanBus->canRead(messageBuffer, messages, &readMessages);
-		
-		/* cycle from zero to the number of read messages */   
-		for(int i=0; i<readMessages; i++)
-		{
-			if (messageBuffer[i].getId() == 0x35a)
-			{
-				unsigned_gaugeData[0] = (messageBuffer[i].getData()[1]<<8)|messageBuffer[i].getData()[0];
-				unsigned_gaugeData[1] = (messageBuffer[i].getData()[3]<<8)|messageBuffer[i].getData()[2];
-				unsigned_gaugeData[2] = (messageBuffer[i].getData()[5]<<8)|messageBuffer[i].getData()[4];
-				signed_gaugeData[0] = unsigned_gaugeData[0]-0x7fff;
-				signed_gaugeData[1] = unsigned_gaugeData[1]-0x7fff;
-				signed_gaugeData[2] = unsigned_gaugeData[2]-0x7fff;
-				//if (csamples.add_sample(signed_gaugeData[0])) fft.do_fft(csamples);
-				//if (hist.add_sample(unsigned_gaugeData[0])) hist.do_hist();
-			}
-			if (messageBuffer[i].getId() == 0x35b)
-			{
-				unsigned_gaugeData[3] = (messageBuffer[i].getData()[1]<<8)|messageBuffer[i].getData()[0];
-				unsigned_gaugeData[4] = (messageBuffer[i].getData()[3]<<8)|messageBuffer[i].getData()[2];
-				unsigned_gaugeData[5] = (messageBuffer[i].getData()[5]<<8)|messageBuffer[i].getData()[4];
-				signed_gaugeData[3] = unsigned_gaugeData[3]-0x7fff;
-				signed_gaugeData[4] = unsigned_gaugeData[4]-0x7fff;
-				signed_gaugeData[5] = unsigned_gaugeData[5]-0x7fff;
-			}
-			if (messageBuffer[i].getId() == 0x171)
-				/* recompose scalar value from four bytes */
-				position[0] = (messageBuffer[i].getData()[3]<<24)|(messageBuffer[i].getData()[2]<<16)|(messageBuffer[i].getData()[1]<<8)|messageBuffer[i].getData()[0];
+        
+        /* cycle from zero to the number of read messages */   
+        for(int i=0; i<readMessages; i++)
+        {
+            if (messageBuffer[i].getId() == 0x35a)
+            {
+                unsigned_gaugeData[0] = (messageBuffer[i].getData()[1]<<8)|messageBuffer[i].getData()[0];
+                unsigned_gaugeData[1] = (messageBuffer[i].getData()[3]<<8)|messageBuffer[i].getData()[2];
+                unsigned_gaugeData[2] = (messageBuffer[i].getData()[5]<<8)|messageBuffer[i].getData()[4];
+                signed_gaugeData[0] = unsigned_gaugeData[0]-0x7fff;
+                signed_gaugeData[1] = unsigned_gaugeData[1]-0x7fff;
+                signed_gaugeData[2] = unsigned_gaugeData[2]-0x7fff;
+                //if (csamples.add_sample(signed_gaugeData[0])) fft.do_fft(csamples);
+                //if (hist.add_sample(unsigned_gaugeData[0])) hist.do_hist();
+            }
+            if (messageBuffer[i].getId() == 0x35b)
+            {
+                unsigned_gaugeData[3] = (messageBuffer[i].getData()[1]<<8)|messageBuffer[i].getData()[0];
+                unsigned_gaugeData[4] = (messageBuffer[i].getData()[3]<<8)|messageBuffer[i].getData()[2];
+                unsigned_gaugeData[5] = (messageBuffer[i].getData()[5]<<8)|messageBuffer[i].getData()[4];
+                signed_gaugeData[3] = unsigned_gaugeData[3]-0x7fff;
+                signed_gaugeData[4] = unsigned_gaugeData[4]-0x7fff;
+                signed_gaugeData[5] = unsigned_gaugeData[5]-0x7fff;
+            }
+            if (messageBuffer[i].getId() == 0x171)
+                /* recompose scalar value from four bytes */
+                position[0] = (messageBuffer[i].getData()[3]<<24)|(messageBuffer[i].getData()[2]<<16)|(messageBuffer[i].getData()[1]<<8)|messageBuffer[i].getData()[0];
 
-			if (messageBuffer[i].getId() == 0x177) //COMMUT
-			{
-				//commut[0] = (messageBuffer[i].getData()[5]<<8)|messageBuffer[i].getData()[4];
-				torque[0] = (messageBuffer[i].getData()[1]<<8)|messageBuffer[i].getData()[0];
-				dutyCycle[0] = (messageBuffer[i].getData()[3]<<8)|messageBuffer[i].getData()[2];
-				pid[0] = (messageBuffer[i].getData()[5]<<8)|messageBuffer[i].getData()[4];
-				kp[0] = (messageBuffer[i].getData()[7]<<8)|messageBuffer[i].getData()[6];
-			
-			/*	if (kp[0]==1000)
-				{
-					this->stop();
-					fclose(fp);
-					exit(0);
-				};*/
-				
-				//FFT
-				//if (samples.add_sample(torque[0])) fft.do_fft(samples);
-				//if (samples.add_sample(dutyCycle[0])) fft.do_fft(samples);
-				if (csamples.add_sample(torque[0])) fft.do_fft(csamples);
+            if (messageBuffer[i].getId() == 0x177) //COMMUT
+            {
+                //commut[0] = (messageBuffer[i].getData()[5]<<8)|messageBuffer[i].getData()[4];
+                torque[0] = (messageBuffer[i].getData()[1]<<8)|messageBuffer[i].getData()[0];
+                dutyCycle[0] = (messageBuffer[i].getData()[3]<<8)|messageBuffer[i].getData()[2];
+                pid[0] = (messageBuffer[i].getData()[5]<<8)|messageBuffer[i].getData()[4];
+                kp[0] = (messageBuffer[i].getData()[7]<<8)|messageBuffer[i].getData()[6];
+            
+            /*  if (kp[0]==1000)
+                {
+                    this->stop();
+                    fclose(fp);
+                    exit(0);
+                };*/
+                
+                //FFT
+                //if (samples.add_sample(torque[0])) fft.do_fft(samples);
+                //if (samples.add_sample(dutyCycle[0])) fft.do_fft(samples);
+                if (csamples.add_sample(torque[0])) fft.do_fft(csamples);
 
-				if (kp[0]==30 && log_start==false) log_start=true;
+                if (kp[0]==30 && log_start==false) log_start=true;
 
-				log_start=true;
-				
-				if(log_start) fprintf(fp,"%d %d %d %d %d\n",cnt,kp[0],pid[0],dutyCycle[0],torque[0]);
-				cnt++;
-			}
-		}
-			
+                log_start=true;
+                
+                if(log_start) fprintf(fp,"%d %d %d %d %d\n",cnt,kp[0],pid[0],dutyCycle[0],torque[0]);
+                cnt++;
+            }
+        }
+            
 
 /*
-			if (messageBuffer[i].getId() == 0x172)
-			{
-				pwm[0] = (messageBuffer[i].getData()[1]<<8)|messageBuffer[i].getData()[0];
-				dutyCycle[0] = (messageBuffer[i].getData()[5]<<8)|messageBuffer[i].getData()[4];
-			}
+            if (messageBuffer[i].getId() == 0x172)
+            {
+                pwm[0] = (messageBuffer[i].getData()[1]<<8)|messageBuffer[i].getData()[0];
+                dutyCycle[0] = (messageBuffer[i].getData()[5]<<8)|messageBuffer[i].getData()[4];
+            }
 */
 
-//			fprintf(fp,"%d %d %d %d %d %d %d\n",cnt,gaugeData[0],gaugeData[1],gaugeData[2],gaugeData[3],gaugeData[4],gaugeData[5]);
-			//fprintf(fp,"%d %d %d %d %d %d\n",cnt,signed_gaugeData[5],torque[0],dutyCycle[0],pid[0],kp[0]);
+//          fprintf(fp,"%d %d %d %d %d %d %d\n",cnt,gaugeData[0],gaugeData[1],gaugeData[2],gaugeData[3],gaugeData[4],gaugeData[5]);
+            //fprintf(fp,"%d %d %d %d %d %d\n",cnt,signed_gaugeData[5],torque[0],dutyCycle[0],pid[0],kp[0]);
 /*
-			if (cnt==50000) 
-			{
-				this->stop();
-				done =true;
-			}
+            if (cnt==50000) 
+            {
+                this->stop();
+                done =true;
+            }
 */
-		
-	/*	
-		cout<<setiosflags(ios::fixed)
-			<<setw(10)<<"commut:"
-			<<setw(8)<<setprecision(3)<<commut[0]
-			<<" duty cycle:"
-			<<setw(8)<<setprecision(3)<<dutyCycle[0]
-			<<" gauge 5:"
-			<<setw(8)<<setprecision(3)<<signed_gaugeData[5]
-			<<" dsp torque:"
-			<<setw(8)<<setprecision(3)<<torque[0]
-			<<" pid:"
-			<<setw(8)<<setprecision(3)<<pid[0]
-			<<" kp:"
-			<<setw(8)<<setprecision(3)<<kp[0]
-			<<"\r";
-		*/	
-		/*
-		cout<<setiosflags(ios::fixed)
-			<<" "
-			<<setw(8)<<setprecision(3)<<cnt
-			<<" "
-			<<setw(8)<<setprecision(3)<<gaugeData[0]
-			<<" "
-			<<setw(8)<<setprecision(3)<<gaugeData[1]
-			<<" "
-			<<setw(8)<<setprecision(3)<<gaugeData[2]
-			<<" "
-			<<setw(8)<<setprecision(3)<<gaugeData[3]
-			<<" "
-			<<setw(8)<<setprecision(3)<<gaugeData[4]
-			<<" "
-			<<setw(8)<<setprecision(3)<<gaugeData[5]<<"\r";
-		*/
+        
+    /*  
+        cout<<setiosflags(ios::fixed)
+            <<setw(10)<<"commut:"
+            <<setw(8)<<setprecision(3)<<commut[0]
+            <<" duty cycle:"
+            <<setw(8)<<setprecision(3)<<dutyCycle[0]
+            <<" gauge 5:"
+            <<setw(8)<<setprecision(3)<<signed_gaugeData[5]
+            <<" dsp torque:"
+            <<setw(8)<<setprecision(3)<<torque[0]
+            <<" pid:"
+            <<setw(8)<<setprecision(3)<<pid[0]
+            <<" kp:"
+            <<setw(8)<<setprecision(3)<<kp[0]
+            <<"\r";
+        */  
+        /*
+        cout<<setiosflags(ios::fixed)
+            <<" "
+            <<setw(8)<<setprecision(3)<<cnt
+            <<" "
+            <<setw(8)<<setprecision(3)<<gaugeData[0]
+            <<" "
+            <<setw(8)<<setprecision(3)<<gaugeData[1]
+            <<" "
+            <<setw(8)<<setprecision(3)<<gaugeData[2]
+            <<" "
+            <<setw(8)<<setprecision(3)<<gaugeData[3]
+            <<" "
+            <<setw(8)<<setprecision(3)<<gaugeData[4]
+            <<" "
+            <<setw(8)<<setprecision(3)<<gaugeData[5]<<"\r";
+        */
     }
 
     void threadRelease()
     {
-		/* turn force-torque sensor off
-		messageBuffer[0].setId(0x205);
-		messageBuffer[0].setLen(2);
-		messageBuffer[0].getData()[0]=7;
-		messageBuffer[0].getData()[1]=1;
-		bool res=iCanBus->canWrite(messageBuffer,1,&readMessages);
-		*/
+        /* turn force-torque sensor off
+        messageBuffer[0].setId(0x205);
+        messageBuffer[0].setLen(2);
+        messageBuffer[0].getData()[0]=7;
+        messageBuffer[0].getData()[1]=1;
+        bool res=iCanBus->canWrite(messageBuffer,1,&readMessages);
+        */
 
         iBufferFactory->destroyBuffer(messageBuffer);
         driver.close();
-		fclose(fp);
+        fclose(fp);
     }
 };
 
 signed short SnifferThread::filterData(signed short datum)
 {
-	int accumulator = 0;
-	dataBuffer[cycleIndex] = datum;
-	cycleIndex = (cycleIndex==5 ? 0: cycleIndex++);
-	for(int i=0; i<6; i++)
-		accumulator = accumulator + (dataBuffer[i]*filterCoefficients[i]);
-	return accumulator/6;
+    int accumulator = 0;
+    dataBuffer[cycleIndex] = datum;
+    cycleIndex = (cycleIndex==5 ? 0: cycleIndex++);
+    for(int i=0; i<6; i++)
+        accumulator = accumulator + (dataBuffer[i]*filterCoefficients[i]);
+    return accumulator/6;
 }
 
 

--- a/src/tools/canBusSniffer/canBusSnifferV6/main.cpp
+++ b/src/tools/canBusSniffer/canBusSnifferV6/main.cpp
@@ -20,7 +20,7 @@ This file can be edited at src/canBusSniffer/main.cpp.
 #include <yarp/dev/CanBusInterface.h>
 #include <yarp/os/Time.h>
 #include <yarp/sig/Vector.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <iostream>
 #include <iomanip>
 #include <string>
@@ -40,7 +40,7 @@ bool done=false;
 
 
 bool log_start=true;
-class SnifferThread: public RateThread
+class SnifferThread: public PeriodicThread
 {
     PolyDriver driver;
     ICanBus *iCanBus;
@@ -68,7 +68,7 @@ class SnifferThread: public RateThread
     signed short dataBuffer[6];
 
 public:
-    SnifferThread(int r=SNIFFER_THREAD_RATE): RateThread(r)
+    SnifferThread(int r=SNIFFER_THREAD_RATE): PeriodicThread((double)r/1000.0)
     {
         messages = localBufferSize;
 

--- a/src/tools/canBusSniffer/main.cpp
+++ b/src/tools/canBusSniffer/main.cpp
@@ -39,7 +39,7 @@ This file can be edited at src/canBusSniffer/main.cpp.
 #include <yarp/os/Time.h>
 #include <yarp/sig/Vector.h>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 
 #include <iostream>
 #include <string>
@@ -53,7 +53,7 @@ const int SNIFFER_THREAD_RATE=50;
 const int CAN_DRIVER_BUFFER_SIZE=2047;
 const int localBufferSize=512;
 
-class SnifferThread: public RateThread
+class SnifferThread: public PeriodicThread
 {
     PolyDriver driver;
     ICanBus *iCanBus;
@@ -62,7 +62,7 @@ class SnifferThread: public RateThread
     std::string devname;
     int port;
 public:
-    SnifferThread(std::string dname, int p, int r=SNIFFER_THREAD_RATE): RateThread(r)
+    SnifferThread(std::string dname, int p, int r=SNIFFER_THREAD_RATE): PeriodicThread((double)r/1000.0)
     {
         port=p;
         devname=dname;   

--- a/src/tools/controlBoardDumper/dumperThread.cpp
+++ b/src/tools/controlBoardDumper/dumperThread.cpp
@@ -66,7 +66,7 @@ void boardDumperThread::setDevice(PolyDriver *board_d, PolyDriver *debug_d, int 
     port->open(portName);
 
     logToFile = logOnDisk;
-    this->setRate(rate);
+    this->setPeriod((double)rate/1000.0);
 }
 
 boardDumperThread::~boardDumperThread()
@@ -115,7 +115,7 @@ bool boardDumperThread::threadInit()
     return 1;
 }
 
-boardDumperThread::boardDumperThread():RateThread(500)
+boardDumperThread::boardDumperThread():PeriodicThread(0.5)
 {
     getter   = 0;
     board_dd = 0;

--- a/src/tools/controlBoardDumper/dumperThread.h
+++ b/src/tools/controlBoardDumper/dumperThread.h
@@ -26,11 +26,11 @@
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Time.h>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 
 #include "genericControlBoardDumper.h"
 
-class boardDumperThread: public RateThread
+class boardDumperThread: public PeriodicThread
 {
 public:
   void setDevice(PolyDriver *board_d, PolyDriver *debug_d, int rate, std::string portPrefix, std::string dataToDump, bool logOnDisk);

--- a/src/tools/emsBackDoorManager/main.cpp
+++ b/src/tools/emsBackDoorManager/main.cpp
@@ -47,7 +47,7 @@ using namespace std;
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/CanBusInterface.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 */
 
 

--- a/src/tools/iCubSkinGui-gtk/src/include/SkinMeshThreadCan.h
+++ b/src/tools/iCubSkinGui-gtk/src/include/SkinMeshThreadCan.h
@@ -13,7 +13,7 @@
 //#include <stdio.h>
 #include <string>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
@@ -30,15 +30,15 @@
 using namespace yarp::os;
 using namespace yarp::dev;
 
-class SkinMeshThreadCan : public RateThread 
+class SkinMeshThreadCan : public PeriodicThread 
 {
 protected:
-	PolyDriver driver;
+    PolyDriver driver;
     ICanBus *pCanBus;
     ICanBufferFactory *pCanBufferFactory;
     CanBuffer canBuffer;
-	std::string deviceName;
-	int netId;
+    std::string deviceName;
+    int netId;
     
     TouchSensor *sensor[16];
 
@@ -49,7 +49,7 @@ protected:
     bool mbSimpleDraw;
 
 public:
-	SkinMeshThreadCan(Searchable& config,int period) : RateThread(period),mutex(1)
+    SkinMeshThreadCan(Searchable& config,int period) : PeriodicThread((double)period/1000.0),mutex(1)
     {
         mbSimpleDraw=config.check("light");
 
@@ -59,26 +59,26 @@ public:
         {
             sensor[t]=NULL;
         }
-		netId=7;
-		deviceName="cfw2can";
+        netId=7;
+        deviceName="cfw2can";
         cardId=0x300 | (config.find("cardid").asInt() << 4);
-		netId=config.find("CanDeviceNum").asInt();
-		deviceName=config.find("CanDeviceName").asString();
-		std::string part="/skinGui/";
-		part.append(config.find("robotPart").asString());
-		part.append(":i");
+        netId=config.find("CanDeviceNum").asInt();
+        deviceName=config.find("CanDeviceName").asString();
+        std::string part="/skinGui/";
+        part.append(config.find("robotPart").asString());
+        part.append(":i");
         int width =config.find("width" ).asInt();
         int height=config.find("height").asInt();
-		bool useCalibration = config.check("useCalibration");
-		if (useCalibration==true) 
-		{
-			printf("Reading datadirectly from CAN! Calibration unsupported\n");
-			useCalibration = false;
-		}
-		else
-		{
-			printf("Using raw skin values (255-0)\n");
-		}
+        bool useCalibration = config.check("useCalibration");
+        if (useCalibration==true) 
+        {
+            printf("Reading datadirectly from CAN! Calibration unsupported\n");
+            useCalibration = false;
+        }
+        else
+        {
+            printf("Using raw skin values (255-0)\n");
+        }
 
         yarp::os::Bottle sensorSetConfig=config.findGroup("SENSORS").tail();
 
@@ -94,8 +94,8 @@ public:
                 double yc=sensorConfig.get(3).asDouble();
                 double th=sensorConfig.get(4).asDouble();
                 double gain=sensorConfig.get(5).asDouble();
-				int    lrMirror=sensorConfig.get(6).asInt();
-				int    layoutNum=sensorConfig.get(7).asInt();
+                int    lrMirror=sensorConfig.get(6).asInt();
+                int    layoutNum=sensorConfig.get(7).asInt();
 
                 printf("%d %f\n",id,gain);
 
@@ -119,11 +119,11 @@ public:
                         {
                             sensor[id]=new Fingertip(xc,yc,th,gain,layoutNum,lrMirror);
                         }
-						if (type=="fingertip2L")
+                        if (type=="fingertip2L")
                         {
                             sensor[id]=new Fingertip2L(xc,yc,th,gain,layoutNum,lrMirror);
                         }
-						if (type=="fingertip2R")
+                        if (type=="fingertip2R")
                         {
                             sensor[id]=new Fingertip2R(xc,yc,th,gain,layoutNum,lrMirror);
                         }
@@ -164,7 +164,7 @@ public:
         }
     }
 
-	virtual bool threadInit();
+    virtual bool threadInit();
     virtual void threadRelease();
     virtual void run();
 

--- a/src/tools/iCubSkinGui-gtk/src/include/SkinMeshThreadPort.h
+++ b/src/tools/iCubSkinGui-gtk/src/include/SkinMeshThreadPort.h
@@ -13,7 +13,7 @@
 //#include <stdio.h>
 #include <string>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
@@ -32,13 +32,13 @@
 using namespace yarp::os;
 using namespace yarp::dev;
 
-class SkinMeshThreadPort : public RateThread 
+class SkinMeshThreadPort : public PeriodicThread 
 {
 protected:
-	static const int MAX_SENSOR_NUM = 128;
+    static const int MAX_SENSOR_NUM = 128;
 
-	BufferedPort<Bottle> skin_port;							
-	TouchSensor *sensor[MAX_SENSOR_NUM];
+    BufferedPort<Bottle> skin_port;                         
+    TouchSensor *sensor[MAX_SENSOR_NUM];
 
     yarp::os::Semaphore mutex;
 
@@ -46,7 +46,7 @@ protected:
     bool mbSimpleDraw;
 
 public:
-	SkinMeshThreadPort(Searchable& config,int period) : RateThread(period),mutex(1)
+    SkinMeshThreadPort(Searchable& config,int period) : PeriodicThread((double)period/1000.0),mutex(1)
     {
         mbSimpleDraw=config.check("light");
 
@@ -56,8 +56,8 @@ public:
         {
             sensor[t]=NULL;
         }
-	
-		std::string part="/skinGui/";
+    
+        std::string part="/skinGui/";
         
         if (config.check("name"))
         {
@@ -65,20 +65,20 @@ public:
             part+="/";
         }
 
-		part.append(config.find("robotPart").asString());
-		part.append(":i");
-		skin_port.open(part.c_str());
+        part.append(config.find("robotPart").asString());
+        part.append(":i");
+        skin_port.open(part.c_str());
         int width =config.find("width" ).asInt();
         int height=config.find("height").asInt();
-		bool useCalibration = config.check("useCalibration");
-		if (useCalibration==true) 
-		{
-			printf("Using calibrated skin values (0-255)\n");
-		}
-		else
-		{
-			printf("Using raw skin values (255-0)\n");
-		}
+        bool useCalibration = config.check("useCalibration");
+        if (useCalibration==true) 
+        {
+            printf("Using calibrated skin values (0-255)\n");
+        }
+        else
+        {
+            printf("Using raw skin values (255-0)\n");
+        }
         
         Bottle *color = config.find("color").asList();
         unsigned char r=255, g=0, b=0;
@@ -115,8 +115,8 @@ public:
                 double yc=sensorConfig.get(3).asDouble();
                 double th=sensorConfig.get(4).asDouble();
                 double gain=sensorConfig.get(5).asDouble();
-				int    lrMirror=sensorConfig.get(6).asInt();
-				int    layoutNum=sensorConfig.get(7).asInt();
+                int    lrMirror=sensorConfig.get(6).asInt();
+                int    layoutNum=sensorConfig.get(7).asInt();
 
                 printf("%s %d %f\n",type.c_str(),id,gain);
 
@@ -143,16 +143,16 @@ public:
                             sensor[id]=new Fingertip(xc,yc,th,gain,layoutNum,lrMirror);
                             sensor[id]->setCalibrationFlag(useCalibration);
                         }
-						if (type=="fingertip2L")
+                        if (type=="fingertip2L")
                         {
                             sensor[id]=new Fingertip2L(xc,yc,th,gain,layoutNum,lrMirror);
-							sensor[id]->setCalibrationFlag(useCalibration);
+                            sensor[id]->setCalibrationFlag(useCalibration);
                         }
-						if (type=="fingertip2R")
+                        if (type=="fingertip2R")
                         {
                             sensor[id]=new Fingertip2R(xc,yc,th,gain,layoutNum,lrMirror);
-                        	sensor[id]->setCalibrationFlag(useCalibration);
-						}
+                            sensor[id]->setCalibrationFlag(useCalibration);
+                        }
                         if (type=="quad16")
                         {
                             printf("Quad16");
@@ -214,7 +214,7 @@ public:
         }
     }
 
-	virtual bool threadInit();
+    virtual bool threadInit();
     virtual void threadRelease();
     virtual void run();
 

--- a/src/tools/iCubSkinGui-qt/plugin/SkinMeshThreadPort.cpp
+++ b/src/tools/iCubSkinGui-qt/plugin/SkinMeshThreadPort.cpp
@@ -13,9 +13,9 @@
 
 #define SKIN_THRESHOLD 15.0
 
-SkinMeshThreadPort::SkinMeshThreadPort(Searchable& config,int period) : RateThread(period),mutex(1)
+SkinMeshThreadPort::SkinMeshThreadPort(Searchable& config,int period) : PeriodicThread((double)period/1000.0),mutex(1)
 {
-    yDebug("SkinMeshThreadPort running at %g ms.",getRate());
+    yDebug("SkinMeshThreadPort running at %d ms.",(int)(1000.0*getPeriod()));
     mbSimpleDraw=config.check("light");
 
     sensorsNum=0;

--- a/src/tools/iCubSkinGui-qt/plugin/include/SkinMeshThreadCan.h
+++ b/src/tools/iCubSkinGui-qt/plugin/include/SkinMeshThreadCan.h
@@ -13,7 +13,7 @@
 //#include <stdio.h>
 #include <string>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
@@ -32,15 +32,15 @@
 using namespace yarp::os;
 using namespace yarp::dev;
 
-class SkinMeshThreadCan : public RateThread 
+class SkinMeshThreadCan : public PeriodicThread 
 {
 protected:
-	PolyDriver driver;
+    PolyDriver driver;
     ICanBus *pCanBus;
     ICanBufferFactory *pCanBufferFactory;
     CanBuffer canBuffer;
-	std::string deviceName;
-	int netId;
+    std::string deviceName;
+    int netId;
     
     TouchSensor *sensor[16];
 
@@ -51,7 +51,7 @@ protected:
     bool mbSimpleDraw;
 
 public:
-	SkinMeshThreadCan(Searchable& config,int period) : RateThread(period),mutex(1)
+    SkinMeshThreadCan(Searchable& config,int period) : PeriodicThread((double)period/1000.0),mutex(1)
     {
         mbSimpleDraw=config.check("light");
 
@@ -61,26 +61,26 @@ public:
         {
             sensor[t]=NULL;
         }
-		netId=7;
-		deviceName="cfw2can";
+        netId=7;
+        deviceName="cfw2can";
         cardId=0x300 | (config.find("cardid").asInt() << 4);
-		netId=config.find("CanDeviceNum").asInt();
-		deviceName=config.find("CanDeviceName").asString();
-		std::string part="/skinGui/";
-		part.append(config.find("robotPart").asString());
-		part.append(":i");
+        netId=config.find("CanDeviceNum").asInt();
+        deviceName=config.find("CanDeviceName").asString();
+        std::string part="/skinGui/";
+        part.append(config.find("robotPart").asString());
+        part.append(":i");
         int width =config.find("width" ).asInt();
         int height=config.find("height").asInt();
-		bool useCalibration = config.check("useCalibration");
-		if (useCalibration==true) 
-		{
-			printf("Reading datadirectly from CAN! Calibration unsupported\n");
-			useCalibration = false;
-		}
-		else
-		{
-			printf("Using raw skin values (255-0)\n");
-		}
+        bool useCalibration = config.check("useCalibration");
+        if (useCalibration==true) 
+        {
+            printf("Reading datadirectly from CAN! Calibration unsupported\n");
+            useCalibration = false;
+        }
+        else
+        {
+            printf("Using raw skin values (255-0)\n");
+        }
 
         yarp::os::Bottle sensorSetConfig=config.findGroup("SENSORS").tail();
 
@@ -96,8 +96,8 @@ public:
                 double yc=sensorConfig.get(3).asDouble();
                 double th=sensorConfig.get(4).asDouble();
                 double gain=sensorConfig.get(5).asDouble();
-				int    lrMirror=sensorConfig.get(6).asInt();
-				int    layoutNum=sensorConfig.get(7).asInt();
+                int    lrMirror=sensorConfig.get(6).asInt();
+                int    layoutNum=sensorConfig.get(7).asInt();
 
                 printf("%d %f\n",id,gain);
 
@@ -121,7 +121,7 @@ public:
                         {
                             sensor[id]=new Fingertip(xc,yc,th,gain,layoutNum,lrMirror);
                         }
-						if (type=="fingertip2L")
+                        if (type=="fingertip2L")
                         {
                             sensor[id]=new Fingertip2L(xc,yc,th,gain,layoutNum,lrMirror);
                         }
@@ -129,7 +129,7 @@ public:
                         {
                             sensor[id] = new CER_SH_PDL(xc, yc, th, gain, layoutNum, lrMirror);
                         }
-						if (type=="fingertip2R")
+                        if (type=="fingertip2R")
                         {
                             sensor[id]=new Fingertip2R(xc,yc,th,gain,layoutNum,lrMirror);
                         }
@@ -170,7 +170,7 @@ public:
         }
     }
 
-	virtual bool threadInit();
+    virtual bool threadInit();
     virtual void threadRelease();
     virtual void run();
 

--- a/src/tools/iCubSkinGui-qt/plugin/include/SkinMeshThreadPort.h
+++ b/src/tools/iCubSkinGui-qt/plugin/include/SkinMeshThreadPort.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/Log.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
@@ -35,7 +35,7 @@
 using namespace yarp::os;
 using namespace yarp::dev;
 
-class SkinMeshThreadPort : public RateThread 
+class SkinMeshThreadPort : public PeriodicThread 
 {
 protected:
     static const int MAX_SENSOR_NUM = 128;

--- a/src/tools/joystickCtrl/main.cpp
+++ b/src/tools/joystickCtrl/main.cpp
@@ -71,7 +71,7 @@ Windows, Linux
 
 #include <yarp/os/Network.h>
 #include <yarp/os/RFModule.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Time.h>
@@ -103,7 +103,7 @@ using namespace yarp::math;
 
 enum { JTYPE_UNDEF=-1, JTYPE_POLAR=0, JTYPE_CARTESIAN=1, JTYPE_CONSTANT=2, JTYPE_STRING=3 };
 
-class CtrlThread: public RateThread
+class CtrlThread: public PeriodicThread
 {
     struct struct_jointProperties
     {
@@ -155,7 +155,7 @@ protected:
 
 public:
     CtrlThread(unsigned int _period, ResourceFinder &_rf) :
-               RateThread(_period),     rf(_rf)
+               PeriodicThread((double)_period/1000.0), rf(_rf)
     {
         joy_id=0;
         rawButtons=0;

--- a/src/tools/strainCalib/strainCalibGUI/main.cpp
+++ b/src/tools/strainCalib/strainCalibGUI/main.cpp
@@ -24,7 +24,7 @@ This file can be edited at src/canBusSniffer/main.cpp.
 #include <yarp/os/Network.h>
 #include <yarp/os/Os.h>
 #include <yarp/os/Time.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/CanBusInterface.h>

--- a/src/tools/strainCalibrationDataAcquisition/strainCalibrationDataAcquisitionGUI/main.cpp
+++ b/src/tools/strainCalibrationDataAcquisition/strainCalibrationDataAcquisitionGUI/main.cpp
@@ -24,7 +24,7 @@ This file can be edited at src/canBusSniffer/main.cpp.
 #include <yarp/os/Network.h>
 #include <yarp/os/Os.h>
 #include <yarp/os/Time.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/CanBusInterface.h>
@@ -285,7 +285,7 @@ gboolean timer_graphic_updater (gpointer data)
         return true;
 };
 
- class SnifferThread: public RateThread
+ class SnifferThread: public PeriodicThread
 {
     PolyDriver driver;
     ICanBus *iCanBus;
@@ -302,7 +302,7 @@ gboolean timer_graphic_updater (gpointer data)
     signed short signed_gaugeData[6];
 
 public:
-    SnifferThread(int r=SNIFFER_THREAD_RATE): RateThread(r)
+    SnifferThread(int r=SNIFFER_THREAD_RATE): PeriodicThread((double)r/1000.0)
     {
         messages = localBufferSize;
         // create data directory if it does not exist

--- a/src/tools/trajectoryPlayer/main.cpp
+++ b/src/tools/trajectoryPlayer/main.cpp
@@ -36,7 +36,7 @@
 #include "utils.h"
 
 // ******************** THE THREAD
-class BroadcastingThread: public RateThread
+class BroadcastingThread: public PeriodicThread
 {
 private:
     action_class          *actions;
@@ -44,7 +44,7 @@ private:
     BufferedPort<Bottle>  port_data_out;
 
 public:
-    BroadcastingThread(int period=1): RateThread(period)
+    BroadcastingThread(int period=1): PeriodicThread((double)period/1000.0)
     {
         port_data_out.open("/trajectoryPlayer/data_out:o");
     }
@@ -159,7 +159,7 @@ public:
     }
 };
 
-class WorkingThread: public RateThread
+class WorkingThread: public PeriodicThread
 {
 private:
 
@@ -172,7 +172,7 @@ public:
     bool                  enable_execute_joint_command;
     double                start_time;
 
-    WorkingThread(int period=5): RateThread(period)
+    WorkingThread(int period=5): PeriodicThread((double)period/1000.0)
     {
         enable_execute_joint_command = true;
         //*** open the output port
@@ -491,7 +491,7 @@ public:
         {
             int period = rf.find("period").asInt();
             yInfo() << "Thread period set to " << period << "ms";
-            w_thread.setRate(period);
+            w_thread.setPeriod((double)period/1000.0);
         }
         yInfo() << "Using parameters:"  << rf.toString();
 

--- a/src/tools/trajectoryPlayer/utils.cpp
+++ b/src/tools/trajectoryPlayer/utils.cpp
@@ -27,7 +27,7 @@
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/os/Semaphore.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Thread.h>
 
 #include <fstream>

--- a/src/tools/trajectoryPlayer/utils.h
+++ b/src/tools/trajectoryPlayer/utils.h
@@ -27,7 +27,7 @@
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/os/Semaphore.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Thread.h>
 
 #include <fstream>


### PR DESCRIPTION
Upon https://github.com/robotology/yarp/pull/1718 we replace `yarp::os::RateThread` with `yarp::os::PeriodicThread`.

Command-line parameters are left unchanged. This is somewhat the best strategy we can come up with to mitigate the cleanup effort as well as the impact on users.

⚠️ It's been a sort of monkey work 🐒 hence the probability of having made a mistake might be quite high. Therefore, please review it carefully 😏 