### PR TITLE
WIP: Convert MTB inertial measurements to metric units and timestamp to seconds

### DIFF
--- a/src/libraries/icubmod/embObjInertials/embObjInertials.cpp
+++ b/src/libraries/icubmod/embObjInertials/embObjInertials.cpp
@@ -849,11 +849,11 @@ bool embObjInertials::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig:
     mutex.wait();
 
     int firstpos = 2 + inertials_Channels*(gyrSensors[sens_index]);
-    timestamp = analogdata[firstpos+2];
+    timestamp = analogdata[firstpos+2]*1e-6;
     out.resize(3);
-    out[0] = analogdata[firstpos+3];
-    out[1] = analogdata[firstpos+4];
-    out[2] = analogdata[firstpos+5];
+    out[0] = analogdata[firstpos+3]*gyrFactor;
+    out[1] = analogdata[firstpos+4]*gyrFactor;
+    out[2] = analogdata[firstpos+5]*gyrFactor;
 
     mutex.post();
 
@@ -901,11 +901,11 @@ bool embObjInertials::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, 
     mutex.wait();
 
     int firstpos = 2 + inertials_Channels*(accSensors[sens_index]);
-    timestamp = analogdata[firstpos+2];
+    timestamp = analogdata[firstpos+2]*1e-6;
     out.resize(3);
-    out[0] = analogdata[firstpos+3];
-    out[1] = analogdata[firstpos+4];
-    out[2] = analogdata[firstpos+5];
+    out[0] = analogdata[firstpos+3]*accFactor;
+    out[1] = analogdata[firstpos+4]*accFactor;
+    out[2] = analogdata[firstpos+5]*accFactor;
 
     mutex.post();
 

--- a/src/libraries/icubmod/embObjInertials/embObjInertials.h
+++ b/src/libraries/icubmod/embObjInertials/embObjInertials.h
@@ -112,6 +112,8 @@ private:
     unsigned int    counterSat;
     unsigned int    counterError;
     unsigned int    counterTimeout;
+    const double    gyrFactor = 250.0/32768;
+    const double    accFactor = (2*9.81)/32768;
 
     ////////////////////
     // parameters


### PR DESCRIPTION
This change in `embObjInertials` device would convert the gyroscopes and accelerometers measurements from raw values to metric units:
- gyroscope: degrees/second
- accelerometer: meters/second^2

This allows to have homogeneous units among all the available inertial measurements, whether they're coming from a strain2 IMU, whether they come from an MTB board accelerometer, avoiding more conditional processing in a Yarp network client (remapper devices, wrappers, client application). This makes even more sense in the context of the **Multiple Analog Sensors Interface**.

The conversion factors were computed considering the following documentation:
- [Distributed_Inertial_sensing](http://wiki.icub.org/wiki/Distributed_Inertial_sensing)
- [LIS331DLH 3-axis digital accelerometer from STMicroelectronics](http://www.st.com/web/catalog/sense_power/FM89/SC444/PF218132) --> selected fullscale = 2g
- [L3G4200D 3-axis digital gyroscope from STMicroelectronics](http://www.st.com/web/catalog/sense_power/FM89/SC1288/PF250373) --> selected fullscale = 250 degrees/s

As done for strain2 IMUs, the timestamp was converted to seconds.