### PR TITLE
Extend icub bindings with icub libraries and tests

### DIFF
--- a/bindings/icub.i
+++ b/bindings/icub.i
@@ -16,18 +16,116 @@
 using namespace yarp::os;
 using namespace yarp::sig;
 
+// iKin
 #include <iCub/iKin/iKinFwd.h>
 #include <iCub/iKin/iKinHlp.h>
 #include <iCub/iKin/iKinInv.h>
 #include <iCub/iKin/iKinIpOpt.h>
 #include <iCub/iKin/iKinSlv.h>
+
+// ctrlLib
+#include <iCub/ctrl/adaptWinPolyEstimator.h>
+#include <iCub/ctrl/clustering.h>
+#include <iCub/ctrl/filters.h>
+#include <iCub/ctrl/functionEncoder.h>
+#include <iCub/ctrl/kalman.h>
+#include <iCub/ctrl/math.h>
+#include <iCub/ctrl/minJerkCtrl.h>
+#include <iCub/ctrl/neuralNetworks.h>
+#include <iCub/ctrl/optimalControl.h>
+#include <iCub/ctrl/outliersDetection.h>
+#include <iCub/ctrl/pids.h>
+#include <iCub/ctrl/tuning.h>
+
+// skinDynLib
+#include <iCub/skinDynLib/common.h>
+#include <iCub/skinDynLib/Taxel.h>
+#include <iCub/skinDynLib/skinPart.h>
+#include <iCub/skinDynLib/iCubSkin.h>
+#include <iCub/skinDynLib/dynContact.h>
+#include <iCub/skinDynLib/dynContactList.h>
+#include <iCub/skinDynLib/rpcSkinManager.h>
+#include <iCub/skinDynLib/skinContact.h>
+#include <iCub/skinDynLib/skinContactList.h>
+
+
+// iDyn
+//#include <iCub/iDyn/iDynInv.h>
+//#include <iCub/iDyn/iDyn.h>
+//#include <iCub/iDyn/iDynContact.h>
+//#include <iCub/iDyn/iDynTransform.h>
+//#include <iCub/iDyn/iDynBody.h>
+
 %}
 
+%include <std_vector.i>
+
+// iKin
 %include <iCub/iKin/iKinFwd.h>
 %include <iCub/iKin/iKinHlp.h>
 %include <iCub/iKin/iKinInv.h>
 %include <iCub/iKin/iKinIpOpt.h>
 %include <iCub/iKin/iKinSlv.h>
+
+// ctrlLib
+%include <iCub/ctrl/adaptWinPolyEstimator.h>
+%include <iCub/ctrl/clustering.h>
+%include <iCub/ctrl/filters.h>
+%include <iCub/ctrl/functionEncoder.h>
+%include <iCub/ctrl/kalman.h>
+%include <iCub/ctrl/math.h>
+%include <iCub/ctrl/minJerkCtrl.h>
+%include <iCub/ctrl/neuralNetworks.h>
+%include <iCub/ctrl/optimalControl.h>
+%include <iCub/ctrl/outliersDetection.h>
+%include <iCub/ctrl/pids.h>
+%include <iCub/ctrl/tuning.h>
+
+// skinDynLib
+%include <iCub/skinDynLib/common.h>
+%include <iCub/skinDynLib/Taxel.h>
+%include <iCub/skinDynLib/skinPart.h>
+%include <iCub/skinDynLib/iCubSkin.h>
+%include <iCub/skinDynLib/dynContact.h>
+%include <iCub/skinDynLib/dynContactList.h>
+%include <iCub/skinDynLib/rpcSkinManager.h>
+%include <iCub/skinDynLib/skinContact.h>
+%include <iCub/skinDynLib/skinContactList.h>
+
+
+// iDyn
+//%include <iCub/iDyn/iDynInv.h>
+
+//%ignore notImplemented;
+//%include <iCub/iDyn/iDyn.h>
+//%include <iCub/iDyn/iDynContact.h>
+//%include <iCub/iDyn/iDynTransform.h>
+//%include <iCub/iDyn/iDynBody.h>
+
+%{
+typedef yarp::os::TypedReader<iCub::skinDynLib::skinContactList> TypedReaderSkinContactList;
+typedef yarp::os::TypedReaderCallback<iCub::skinDynLib::skinContactList> TypedReaderCallbackSkinContactList;
+typedef yarp::os::BufferedPort<iCub::skinDynLib::skinContactList> BufferedPortSkinContactList;
+%}
+
+%{
+typedef yarp::os::TypedReader<iCub::skinDynLib::dynContactList> TypedReaderDynContactList;
+typedef yarp::os::TypedReaderCallback<iCub::skinDynLib::dynContactList> TypedReaderCallbackDynContactList;
+typedef yarp::os::BufferedPort<iCub::skinDynLib::dynContactList> BufferedPortDynContactList;
+%}
+
+%inline %{
+    typedef size_t size_type;
+%}
+
+%template(TypedReaderSkinContactList) yarp::os::TypedReader<iCub::skinDynLib::skinContactList>;
+%template(TypedReaderCallbackSkinContactList) yarp::os::TypedReaderCallback<iCub::skinDynLib::skinContactList>;
+%template(BufferedPortSkinContactList) yarp::os::BufferedPort<iCub::skinDynLib::skinContactList>;
+
+%template(TypedReaderDynContactList) yarp::os::TypedReader<iCub::skinDynLib::dynContactList>;
+%template(TypedReaderCallbackDynContactList) yarp::os::TypedReaderCallback<iCub::skinDynLib::dynContactList>;
+%template(BufferedPortDynContactList) yarp::os::BufferedPort<iCub::skinDynLib::dynContactList>;
+
 
 bool init();
 

--- a/bindings/tests/CMakeLists.txt
+++ b/bindings/tests/CMakeLists.txt
@@ -14,3 +14,6 @@ endmacro()
 file(GLOB icub_python_test_files "${CMAKE_CURRENT_SOURCE_DIR}/*.py")
 
 add_python_unit_test(test_load.py)
+add_python_unit_test(test_ctrLib.py)
+add_python_unit_test(test_iKin.py)
+add_python_unit_test(test_skinDynLib.py)

--- a/bindings/tests/CMakeLists.txt
+++ b/bindings/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+macro(add_python_unit_test pythonscript)
+  if(PYTHON_EXECUTABLE)
+    add_test(NAME ${pythonscript} COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${pythonscript})
+    set_tests_properties(${pythonscript} PROPERTIES ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:${SWIG_MODULE_icub_python_REAL_NAME}>")
+  endif()
+endmacro()
+
+file(GLOB icub_python_test_files "${CMAKE_CURRENT_SOURCE_DIR}/*.py")
+
+add_python_unit_test(test_load.py)

--- a/bindings/tests/test_ctrlLib.py
+++ b/bindings/tests/test_ctrlLib.py
@@ -13,36 +13,42 @@
 # Measurement: z = [0.39,	0.50,	0.48,	0.29,	0.25,	0.32,	0.34,	0.48,	0.41,	0.45]
 # A=1, B=0, H=1, Q=0, R=0.1
 
+from __future__ import (absolute_import, division,
+                        print_function)
+from future import standard_library
+
+standard_library.install_aliases()
+
 import yarp
 
 import icub
 
 log = yarp.Log()
 
-A = yarp.Matrix(1,1)
-A[0,0] = 1.
-H = yarp.Matrix(1,1)
-H[0,0] = 1.
-Q = yarp.Matrix(1,1)
-Q[0,0] = 0.
-R = yarp.Matrix(1,1)
-R[0,0] = 0.1
+A = yarp.Matrix(1, 1)
+A[0, 0] = 1.
+H = yarp.Matrix(1, 1)
+H[0, 0] = 1.
+Q = yarp.Matrix(1, 1)
+Q[0, 0] = 0.
+R = yarp.Matrix(1, 1)
+R[0, 0] = 0.1
 
-x0 = yarp.Vector(1,0.)
+x0 = yarp.Vector(1, 0.)
 P0 = H
 kal = icub.Kalman(A, H, Q, R)
-kal.init(x0,P0)
+kal.init(x0, P0)
 
-z = [0.39,	0.50,	0.48,	0.29,	0.25,	0.32,	0.34,	0.48,	0.41,	0.45]
+z = [0.39, 0.50, 0.48, 0.29, 0.25, 0.32, 0.34, 0.48, 0.41, 0.45]
 
 z_vec = yarp.Vector(len(z))
 x = yarp.Vector(len(z))
 
 for i in range(len(z)):
     z_vec[i] = z[i]
-    Z = yarp.Vector(1,z[i])
+    Z = yarp.Vector(1, z[i])
     X = kal.filt(Z)
     x[i] = X[0]
 
-log.info('Measured value                        : {:s}'.format(z_vec.toString(3,3)))
-log.debug('Corrected value with 1D Kalman filter: {:s}'.format(x.toString(3,3)))
+log.info('Measured value                       : {:s}'.format(z_vec.toString(3, 3)))
+log.info('Corrected value with 1D Kalman filter: {:s}'.format(x.toString(3, 3)))

--- a/bindings/tests/test_ctrlLib.py
+++ b/bindings/tests/test_ctrlLib.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+
+# Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+# Author: Phuong D.H. Nguyen (phuong.nguyen@iit.it)
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+
+# Example: Using Kalman filter to estimate a scalar random constant, such as a "voltage reading" from a source.
+# So let's assume that it has a constant value of aV (volts), but of course we some noisy readings above and below a volts.
+# And we assume that the standard deviation of the measurement noise is 0.1 V.
+# Measurement: z = [0.39,	0.50,	0.48,	0.29,	0.25,	0.32,	0.34,	0.48,	0.41,	0.45]
+# A=1, B=0, H=1, Q=0, R=0.1
+
+import yarp
+
+import icub
+
+log = yarp.Log()
+
+A = yarp.Matrix(1,1)
+A[0,0] = 1.
+H = yarp.Matrix(1,1)
+H[0,0] = 1.
+Q = yarp.Matrix(1,1)
+Q[0,0] = 0.
+R = yarp.Matrix(1,1)
+R[0,0] = 0.1
+
+x0 = yarp.Vector(1,0.)
+P0 = H
+kal = icub.Kalman(A, H, Q, R)
+kal.init(x0,P0)
+
+z = [0.39,	0.50,	0.48,	0.29,	0.25,	0.32,	0.34,	0.48,	0.41,	0.45]
+
+z_vec = yarp.Vector(len(z))
+x = yarp.Vector(len(z))
+
+for i in range(len(z)):
+    z_vec[i] = z[i]
+    Z = yarp.Vector(1,z[i])
+    X = kal.filt(Z)
+    x[i] = X[0]
+
+log.info('Measured value                        : {:s}'.format(z_vec.toString(3,3)))
+log.debug('Corrected value with 1D Kalman filter: {:s}'.format(x.toString(3,3)))

--- a/bindings/tests/test_iKin.py
+++ b/bindings/tests/test_iKin.py
@@ -5,7 +5,12 @@
 # Author: Phuong D.H. Nguyen (phuong.nguyen@iit.it)
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license. See the accompanying LICENSE file for details.
-from math import pi
+
+from __future__ import (absolute_import, division,
+                        print_function)
+from future import standard_library
+
+standard_library.install_aliases()
 
 import yarp
 
@@ -15,7 +20,7 @@ import icub
 def rad_to_deg(V):
     V_deg = yarp.Vector(V.size(), 0.0)
     for i in range(V.size()):
-        V_deg[i] = V[i]*icub.CTRL_RAD2DEG
+        V_deg[i] = V[i] * icub.CTRL_RAD2DEG
 
     return V_deg
 
@@ -23,7 +28,7 @@ def rad_to_deg(V):
 def deg_to_rad(V):
     V_rad = yarp.Vector(V.size(), 0.0)
     for i in range(V.size()):
-        V_rad[i] = V[i]*icub.CTRL_DEG2RAD
+        V_rad[i] = V[i] * icub.CTRL_DEG2RAD
 
     return V_rad
 
@@ -64,13 +69,14 @@ _iCartCtrl = _iCartDev.viewICartesianControl()
 
 encs = yarp.Vector(_jnts_arm)
 _iEnc_arm.getEncoders(encs.data())
-log.debug('[{:s}] Encoder values with direct motor control interface  : {:s}'.format(name, encs.subVector(0,6).toString(3,3)))
+log.debug('[{:s}] Encoder values with direct motor control interface  : {:s}'.format(name,
+                                                                                     encs.subVector(0, 6).toString(3, 3)))
 
 # End-effector: measured value
 arm_cart_pos = yarp.Vector(3, 0.0)
 arm_cart_rot = yarp.Vector(4, 0.0)
 _iCartCtrl.getPose(arm_cart_pos, arm_cart_rot)
-log.debug('[{:s}] End-effector pose obtained with Cartesian Controller: {:s}'.format(name, arm_cart_pos.toString(3,3)))
+log.debug('[{:s}] End-effector pose obtained with Cartesian Controller: {:s}'.format(name, arm_cart_pos.toString(3, 3)))
 
 # iKinChain to obtain virtual End-effector pose
 if arm_name == 'right_arm':
@@ -87,6 +93,5 @@ joint_angles = yarp.Vector(_iArm.getAng())
 log.debug('[{:s}] joint angles (rad) obtained with iKin: {:s}'.format(name, rad_to_deg(joint_angles).toString(3, 3)))
 
 # End-effector: estimated with iKin
-arm_real = _iArm.EndEffPose(deg_to_rad(encs),False)
-log.debug('[{:s}] End-effector pose obtained with iKin : {:s}'.format(name, arm_real.toString(3,3)))
-
+arm_real = _iArm.EndEffPose(deg_to_rad(encs), False)
+log.debug('[{:s}] End-effector pose obtained with iKin : {:s}'.format(name, arm_real.toString(3, 3)))

--- a/bindings/tests/test_iKin.py
+++ b/bindings/tests/test_iKin.py
@@ -15,9 +15,17 @@ import icub
 def rad_to_deg(V):
     V_deg = yarp.Vector(V.size(), 0.0)
     for i in range(V.size()):
-        V_deg[i] = V[i]*180./pi
+        V_deg[i] = V[i]*icub.CTRL_RAD2DEG
 
     return V_deg
+
+
+def deg_to_rad(V):
+    V_rad = yarp.Vector(V.size(), 0.0)
+    for i in range(V.size()):
+        V_rad[i] = V[i]*icub.CTRL_DEG2RAD
+
+    return V_rad
 
 
 yarp.Network.init()
@@ -25,7 +33,7 @@ icub.init()
 
 name = 'test'
 robot = 'icubSim'
-arm_name = 'right_arm'
+arm_name = 'left_arm'
 
 # To use yarp log function
 log = yarp.Log()
@@ -80,6 +88,6 @@ joint_angles = yarp.Vector(_iArm.getAng())
 log.debug('[{:s}] joint angles (rad) obtained with iKin: {:s}'.format(name, rad_to_deg(joint_angles).toString(3, 3)))
 
 # End-effector: estimated with iKin
-arm_real = _iArm.EndEffPose(False)
+arm_real = _iArm.EndEffPose(deg_to_rad(encs),False)
 log.debug('[{:s}] End-effector pose obtained with iKin : {:s}'.format(name, arm_real.toString(3,3)))
 

--- a/bindings/tests/test_iKin.py
+++ b/bindings/tests/test_iKin.py
@@ -48,7 +48,6 @@ _armDriver = yarp.PolyDriver(props)
 
 # query motor control interfaces
 _iPos = _armDriver.viewIPositionControl()
-iVel = _armDriver.viewIVelocityControl()
 _iEnc_arm = _armDriver.viewIEncoders()
 
 # retrieve number of joints

--- a/bindings/tests/test_iKin.py
+++ b/bindings/tests/test_iKin.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+
+# Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+# Author: Phuong D.H. Nguyen (phuong.nguyen@iit.it)
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+from math import pi
+
+import yarp
+
+import icub
+
+
+def rad_to_deg(V):
+    V_deg = yarp.Vector(V.size(), 0.0)
+    for i in range(V.size()):
+        V_deg[i] = V[i]*180./pi
+
+    return V_deg
+
+
+yarp.Network.init()
+icub.init()
+
+name = 'test'
+robot = 'icubSim'
+arm_name = 'right_arm'
+
+# To use yarp log function
+log = yarp.Log()
+
+props = yarp.Property()
+props.put("device", "remote_controlboard")
+props.put("local", "/" + name + "/" + arm_name)
+props.put("remote", "/" + robot + "/" + arm_name)
+
+# create remote driver
+_armDriver = yarp.PolyDriver(props)
+
+# query motor control interfaces
+_iPos = _armDriver.viewIPositionControl()
+iVel = _armDriver.viewIVelocityControl()
+_iEnc_arm = _armDriver.viewIEncoders()
+
+# retrieve number of joints
+_jnts_arm = _iPos.getAxes()
+log.info('[{:s}] Controlling {:d} joints'.format(name, _jnts_arm))
+
+# Cartesian Controller
+props_cart = yarp.Property("(device cartesiancontrollerclient)")
+props_cart.put("remote", ("/" + robot + "/cartesianController/" + arm_name))
+props_cart.put("local", ("/" + name + "/cart_ctrl/" + arm_name))
+
+_iCartDev = yarp.PolyDriver(props_cart)
+_iCartCtrl = _iCartDev.viewICartesianControl()
+
+encs = yarp.Vector(_jnts_arm)
+_iEnc_arm.getEncoders(encs.data())
+log.debug('[{:s}] Encoder values with direct motor control interface  : {:s}'.format(name, encs.subVector(0,6).toString(3,3)))
+
+# End-effector: measured value
+arm_cart_pos = yarp.Vector(3, 0.0)
+arm_cart_rot = yarp.Vector(4, 0.0)
+_iCartCtrl.getPose(arm_cart_pos, arm_cart_rot)
+log.debug('[{:s}] End-effector pose obtained with Cartesian Controller: {:s}'.format(name, arm_cart_pos.toString(3,3)))
+
+# iKinChain to obtain virtual End-effector pose
+if arm_name == 'right_arm':
+    _iArm = icub.iCubArm('right')
+elif arm_name == 'left_arm':
+    _iArm = icub.iCubArm('left')
+else:
+    raise Exception('arm_name should be right_arm or left_arm!!!')
+
+_iArm.setAllConstraints(False)
+
+joint_angles = yarp.Vector(_iArm.getAng())
+
+log.debug('[{:s}] joint angles (rad) obtained with iKin: {:s}'.format(name, rad_to_deg(joint_angles).toString(3, 3)))
+
+# End-effector: estimated with iKin
+arm_real = _iArm.EndEffPose(False)
+log.debug('[{:s}] End-effector pose obtained with iKin : {:s}'.format(name, arm_real.toString(3,3)))
+

--- a/bindings/tests/test_load.py
+++ b/bindings/tests/test_load.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python
+
+# Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+# Author: Phuong D.H. Nguyen (phuong.nguyen@iit.it)
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+import yarp
+  
+import icub
+
+yarp.Network.init()
+icub.init()

--- a/bindings/tests/test_skinDynLib.py
+++ b/bindings/tests/test_skinDynLib.py
@@ -25,10 +25,13 @@ if connected:
 
     scl = icub.skinContactList()
 
-    scl = skinEventsPortIn.read( True)
+    scl = skinEventsPortIn.read(True)
 
     if scl is not None:
-        print scl.toString(3)
+        print scl.toString()
+
+    dcl = scl.toDynContactList()
+    print dcl.toString()
 
 else:
     log.error('no connection')

--- a/bindings/tests/test_skinDynLib.py
+++ b/bindings/tests/test_skinDynLib.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+
+# Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+# Author: Phuong D.H. Nguyen (phuong.nguyen@iit.it)
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+# Requirement: icubsim with whole_body_skin_emul on in iCub_parts_activation.ini
+# Working condition: there are physical contacts between skin parts with objects, otherwise, skinContactList is empty
+
+import yarp
+
+import icub
+
+log = yarp.Log()
+yarp.Network.init()
+icub.init()
+
+skinEventsPortIn = icub.BufferedPortSkinContactList()
+skinEventsPortIn.open("/test/skin_events:i")
+connected = yarp.Network.connect("/icubSim/skinManager/skin_events:o","/test/skin_events:i")
+
+if connected:
+
+    scl = icub.skinContactList()
+
+    scl = skinEventsPortIn.read( True)
+
+    if scl is not None:
+        print scl.toString(3)
+
+else:
+    log.error('no connection')
+
+
+skinEventsPortIn.close()
+

--- a/bindings/tests/test_skinDynLib.py
+++ b/bindings/tests/test_skinDynLib.py
@@ -6,11 +6,23 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license. See the accompanying LICENSE file for details.
 
-# Requirement: icubsim with whole_body_skin_emul on in iCub_parts_activation.ini
+# Requirement: icubsim with following setting iCub_parts_activation.ini
+# [COLLISIONS]
+# self_collisions on
+# covers_collisions on
+# [SENSORS]
+# pressure off
+# whole_body_skin_emul on
+
 # Working condition: there are physical contacts between skin parts with objects, otherwise, skinContactList is empty
 
-import yarp
+from __future__ import (absolute_import, division,
+                        print_function)
+from future import standard_library
 
+standard_library.install_aliases()
+
+import yarp
 import icub
 
 log = yarp.Log()
@@ -19,7 +31,7 @@ icub.init()
 
 skinEventsPortIn = icub.BufferedPortSkinContactList()
 skinEventsPortIn.open("/test/skin_events:i")
-connected = yarp.Network.connect("/icubSim/skinManager/skin_events:o","/test/skin_events:i")
+connected = yarp.Network.connect("/icubSim/skinManager/skin_events:o", "/test/skin_events:i")
 
 if connected:
 
@@ -28,14 +40,12 @@ if connected:
     scl = skinEventsPortIn.read(True)
 
     if scl is not None:
-        print scl.toString()
+        print(scl.toString())
 
     dcl = scl.toDynContactList()
-    print dcl.toString()
+    print(dcl.toString())
 
 else:
     log.error('no connection')
 
-
 skinEventsPortIn.close()
-


### PR DESCRIPTION
As title, the `PR` aims to extend the current icub bindings with more icub libraries: skinDynLib, ctrlLib, and provides some test files for `python`: test_load, test_iKin, test_ctrlLib, test_skinDynLib.

I comment out the `iDyn` libraries since nobody really use that libraries :) and I personally don't know how to test if the binding works or not :)

This should work after fixing the binding compilation with @Nicogene 's `PR` https://github.com/robotology/icub-main/pull/541

This is partly to solve the https://github.com/robotology/icub-main/issues/484 issue.

Cheers,
P

@Tobias-Fischer @nunoguedelha @traversaro @drdanz @Nicogene 