### PR TITLE
Wrap optimization library in bindings

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -60,24 +60,43 @@ if(CREATE_PYTHON)
     endif()
     find_package(PythonLibs ${ICUB_USE_PYTHON_VERSION} EXACT)
 
-    get_filename_component(PYTHON_DIR ${PYTHON_LIBRARY} PATH)
-    link_directories(${PYTHON_DIR})
-
-    if(WIN32)
-        get_filename_component(PYTHON_DIR ${PYTHON_LIBRARY} PATH)
-        link_directories(${PYTHON_DIR})
-    endif()
-
-    # message("-->${PYTHON_LIBRARY} ${PYTHON_DIR}")
-
-    include_directories(${PYTHON_INCLUDE_PATH})
+    include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS})
     swig_add_library(icub_python
                      LANGUAGE python
                      SOURCES icub.i)
-    target_include_directories(${SWIG_MODULE_icub_python_REAL_NAME} SYSTEM PRIVATE ${PYTHON_INCLUDE_PATH})
-    set_target_properties(${SWIG_MODULE_icub_python_REAL_NAME} PROPERTIES OUTPUT_NAME "_icub"
-                                                                      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/python")
+    target_include_directories(${SWIG_MODULE_icub_python_REAL_NAME} SYSTEM PRIVATE ${PYTHON_INCLUDE_DIRS})
+    target_link_libraries(${SWIG_MODULE_icub_python_REAL_NAME} ${PYTHON_LIBRARIES})
+    set_target_properties(${SWIG_MODULE_icub_python_REAL_NAME} PROPERTIES OUTPUT_NAME "_icub")
 
+    # installation path is determined reliably on most platforms using distutils
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
+                    OUTPUT_VARIABLE PYTHON_INSTDIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE )
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/icub.py DESTINATION ${PYTHON_INSTDIR})
+
+    set(_CMAKE_INSTALL_PYTHONDIR "${PYTHON_INSTDIR}")
+    set(CMAKE_INSTALL_PYTHONDIR ${_CMAKE_INSTALL_PYTHONDIR} CACHE PATH "python bindings (${_CMAKE_INSTALL_PYTHONDIR})")
+    mark_as_advanced(CMAKE_INSTALL_PYTHONDIR)
+    if(NOT IS_ABSOLUTE ${CMAKE_INSTALL_PYTHONDIR})
+      set(CMAKE_INSTALL_FULL_PYTHONDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_PYTHONDIR}")
+    else()
+      set(CMAKE_INSTALL_FULL_PYTHONDIR "${CMAKE_INSTALL_PYTHONDIR}")
+    endif()
+
+    # Update RPATH
+    if(NOT CMAKE_SKIP_RPATH AND NOT CMAKE_SKIP_INSTALL_RPATH)
+      file(RELATIVE_PATH _rel_path "${CMAKE_INSTALL_FULL_PYTHONDIR}" "${CMAKE_INSTALL_FULL_LIBDIR}")
+      get_target_property(_current_rpath ${SWIG_MODULE_icub_python_REAL_NAME} INSTALL_RPATH)
+      if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        list(APPEND _current_rpath "@loader_path/${_rel_path}")
+      else()
+        list(APPEND _current_rpath "\$ORIGIN/${_rel_path}")
+      endif()
+      set_target_properties("${SWIG_MODULE_icub_python_REAL_NAME}" PROPERTIES INSTALL_RPATH "${_current_rpath}")
+    endif()
+
+    install(TARGETS ${SWIG_MODULE_icub_python_REAL_NAME} DESTINATION ${PYTHON_INSTDIR})
 endif(CREATE_PYTHON)
 
 if(CREATE_RUBY)

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -28,6 +28,7 @@ include_directories(${CMAKE_SOURCE_DIR}/src/libraries/iDyn/include)
 include_directories(${CMAKE_SOURCE_DIR}/src/libraries/iKin/include)
 include_directories(${CMAKE_SOURCE_DIR}/src/libraries/ctrlLib/include)
 include_directories(${CMAKE_SOURCE_DIR}/src/libraries/skinDynLib/include)
+include_directories(${CMAKE_SOURCE_DIR}/src/libraries/optimization/include)
 
 # for yarp.i
 include_directories(${YARP_BINDINGS})

--- a/bindings/icub.i
+++ b/bindings/icub.i
@@ -48,6 +48,12 @@ using namespace yarp::sig;
 #include <iCub/skinDynLib/skinContact.h>
 #include <iCub/skinDynLib/skinContactList.h>
 
+// optimization
+#include <iCub/optimization/affinity.h>
+#include <iCub/optimization/algorithms.h>
+#include <iCub/optimization/calibReference.h>
+#include <iCub/optimization/matrixTransformation.h>
+#include <iCub/optimization/neuralNetworks.h>
 
 // iDyn
 //#include <iCub/iDyn/iDynInv.h>
@@ -91,6 +97,14 @@ using namespace yarp::sig;
 %include <iCub/skinDynLib/rpcSkinManager.h>
 %include <iCub/skinDynLib/skinContact.h>
 %include <iCub/skinDynLib/skinContactList.h>
+
+
+// optimization
+%include <iCub/optimization/matrixTransformation.h>
+%include <iCub/optimization/affinity.h>
+%include <iCub/optimization/algorithms.h>
+%include <iCub/optimization/calibReference.h>
+%include <iCub/optimization/neuralNetworks.h>
 
 
 // iDyn

--- a/bindings/icub.i
+++ b/bindings/icub.i
@@ -6,6 +6,8 @@
 
 %include "std_string.i"
 %include "std_vector.i"
+%include "std_deque.i"
+%include "typemaps.i"
 
 %import "yarp.i"
 
@@ -97,6 +99,25 @@ using namespace yarp::sig;
 %include <iCub/skinDynLib/rpcSkinManager.h>
 %include <iCub/skinDynLib/skinContact.h>
 %include <iCub/skinDynLib/skinContactList.h>
+
+
+%typemap(in, numinputs=0) (yarp::sig::Matrix &H, yarp::sig::Vector &s, double &error) {
+    yarp::sig::Matrix t1;
+    yarp::sig::Vector t2;
+    double t3;
+    $1= &t1;
+    $2= &t2;
+    $3= &t3;
+}
+
+%typemap(argout) (yarp::sig::Matrix &H, yarp::sig::Vector &s, double &error) {
+    yarp::sig::Matrix* t_out1 = new yarp::sig::Matrix(*$1);
+    yarp::sig::Vector* t_out2 = new yarp::sig::Vector(*$2);
+
+    $result= SWIG_Python_AppendOutput ($result, SWIG_NewPointerObj(t_out1, SWIGTYPE_p_yarp__sig__Matrix, 0 |  0 ));
+    $result= SWIG_Python_AppendOutput ($result, SWIG_NewPointerObj(t_out2, SWIGTYPE_p_yarp__sig__VectorOfT_double_t, 0 |  0 ));
+    $result= SWIG_Python_AppendOutput ($result, PyFloat_FromDouble(*$3));
+}
 
 
 // optimization

--- a/bindings/icub.i
+++ b/bindings/icub.i
@@ -110,6 +110,7 @@ using namespace yarp::sig;
     $3= &t3;
 }
 
+#ifdef SWIGPYTHON
 %typemap(argout) (yarp::sig::Matrix &H, yarp::sig::Vector &s, double &error) {
     yarp::sig::Matrix* t_out1 = new yarp::sig::Matrix(*$1);
     yarp::sig::Vector* t_out2 = new yarp::sig::Vector(*$2);
@@ -118,6 +119,7 @@ using namespace yarp::sig;
     $result= SWIG_Python_AppendOutput ($result, SWIG_NewPointerObj(t_out2, SWIGTYPE_p_yarp__sig__VectorOfT_double_t, 0 |  0 ));
     $result= SWIG_Python_AppendOutput ($result, PyFloat_FromDouble(*$3));
 }
+#endif
 
 
 // optimization

--- a/bindings/tests/CMakeLists.txt
+++ b/bindings/tests/CMakeLists.txt
@@ -17,3 +17,5 @@ add_python_unit_test(test_load.py)
 add_python_unit_test(test_ctrLib.py)
 add_python_unit_test(test_iKin.py)
 add_python_unit_test(test_skinDynLib.py)
+add_python_unit_test(test_optimization.py)
+

--- a/bindings/tests/test_optimization.py
+++ b/bindings/tests/test_optimization.py
@@ -1,0 +1,137 @@
+#!/usr/bin/python
+
+# Copyright (C) Tobias Fischer
+# All rights reserved.
+# Author: Tobias Fischer (t.fischer@imperial.ac.uk)
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+from __future__ import (absolute_import, division,
+                        print_function)
+from future import standard_library
+
+standard_library.install_aliases()
+
+import yarp
+import icub
+import math
+import numpy as np
+import time
+
+def np_to_yarp(v):
+    if len(v.shape) == 1: # Vector
+        yarp_vec = yarp.Vector(v.shape[0])
+        for i in range(v.shape[0]):
+            yarp_vec[i] = v[i]
+        return yarp_vec
+    elif len(v.shape) == 2: # Matrix
+        yarp_mat = yarp.Matrix(v.shape[0], v.shape[1])
+        for i in range(v.shape[0]):
+            for j in range(v.shape[1]):
+                yarp_mat[i, j] = v[i, j]
+        return yarp_mat
+    else:
+        raise Exception("Only 1D or 2D numpy arrays are supported")
+
+# no bindings for yarp.math, so let's implement euler2dcm ourselves
+# following http://www.yarp.it/math_8cpp_source.html
+def euler2dcm(v):
+    assert(v.shape[0] >= 3)
+
+    Rza, Ryb, Rzg = np.eye(4), np.eye(4), np.eye(4)
+
+    alpha=v[0]
+    ca=math.cos(alpha)
+    sa=math.sin(alpha)
+
+    beta=v[1]
+    cb=math.cos(beta)
+    sb=math.sin(beta)
+
+    gamma=v[2]
+    cg=math.cos(gamma)
+    sg=math.sin(gamma)
+ 
+    Rza[0,0]=ca
+    Rza[1,1]=ca
+    Rza[1,0]=sa
+    Rza[0,1]=-sa
+    Rzg[0,0]=cg
+    Rzg[1,1]=cg
+    Rzg[1,0]=sg
+    Rzg[0,1]=-sg
+    Ryb[0,0]=cb
+    Ryb[2,2]=cb
+    Ryb[2,0]=-sb
+    Ryb[0,2]=sb;
+ 
+    return np.matmul(np.matmul(Rza,Ryb),Rzg)
+
+yarp.Network.init()
+icub.init()
+
+# define the "unknown" transformation:
+# translation
+p = np.empty(3)
+p[0]=0.3
+p[1]=-2.0
+p[2]=3.1
+# rotation
+euler = np.empty(3)
+euler[0] = math.pi / 4.0
+euler[1] = math.pi / 6.0
+euler[2] = math.pi / 3.0
+
+H=euler2dcm(euler)
+H[0, 3]=p[0]
+H[1, 3]=p[1]
+H[2, 3]=p[2]
+
+# ansisotropic scale
+scale = np.empty(3)
+scale[0]=0.9
+scale[1]=0.8
+scale[2]=1.1
+
+h_scale = np.append(scale, 1.0)
+print('h_scale', h_scale)
+calibrator = icub.CalibReferenceWithMatchedPoints()
+
+#generate randomly the two clouds of matching 3D points
+for i in range(10):
+    p0 = np.random.uniform(-5.0, 5.0, 3)
+    p0 = np.append(p0, 1.0)
+
+    #make data a bit dirty (add up noise in the range (-1,1) [cm])
+    eps = np.random.uniform(-0.01, 0.01, 3)
+    eps = np.append(eps, 0.0)
+
+    p1=h_scale*np.matmul(H,p0).T+eps
+    #feed the calibrator with the matching pair
+    calibrator.addPoints(np_to_yarp(p0),np_to_yarp(p1))
+
+# set the working bounding box where the solution is seeked
+bb_min = yarp.Vector(3, -5.0)
+bb_max = yarp.Vector(3, 5.0)
+
+calibrator.setBounds(bb_min,bb_max)
+
+# carry out the calibration
+t0 = time.time()
+x = calibrator.calibrate()
+dt = time.time()-t0
+
+success, Hcap, scalecap, error=x
+
+# final report
+print("success", success)
+print("H", H)
+print("scale", scale)
+
+print("Hcap", Hcap.toString(3, 3))
+print("scalecap", scalecap.toString(3, 3))
+
+print("residual error", error, "[m]")
+print("calibration performed in ", dt, "[s]")
+
+


### PR DESCRIPTION
Following the discussion in https://github.com/robotology/icub-main/issues/484 this wraps most of the optimization library. To make it usable, we need to apply a typemaps for methods that "return" values by reference (not sure whether this also applies to other libraries). I added one example for the calibrate() method (and a test for it). I won't have time (and patience) to wrap all the other methods which pass by reference.

Some notes:
1) Swig 3.0.12 is required (3.0.8 throws some errors when trying to access the data in Python) for the typemap stuff. A check should be added.
2) The typemap currently only checks the parameter types + names, but not the method name. I can't seem to get it to work if I add the method name.
3) There might be a memory leak in the typemap; I'm not sure whether the pointers are ever freed. This thread might give some insight: https://stackoverflow.com/questions/7223327/what-does-the-last-argument-to-swig-newpointerobj-mean
4) The typemap only works for python (no check in place currently), I'm not sure how to wrap it for other languages.

Maybe @towardthesea can take over from here ;-)?