### PR TITLE
Fix find_package(ICUB) after introduction CMake components in YARP.

### DIFF
--- a/conf/template/icub-config-build-tree.cmake.in
+++ b/conf/template/icub-config-build-tree.cmake.in
@@ -4,21 +4,32 @@
 
 if (NOT ICUB_FOUND)
 
-message(STATUS "Using iCub from build tree")
+  message(STATUS "Using iCub from build tree")
 
-set(ICUB_VERSION @ICUB_VERSION@)
+  set(ICUB_VERSION @ICUB_VERSION@)
+  # If YARP_LIBRARIES has been valorized by a previous call of find_package(YARP)
+  # in user CMakelists.txt save it in temporary variable to restore it later.
+  if(DEFINED YARP_LIBRARIES)
+    set(_temp_yarp_libs ${YARP_LIBRARIES})
+  endif()
 
-include("@CMAKE_BINARY_DIR@/@EXPORT_INCLUDE_FILE@")
-include("@CMAKE_BINARY_DIR@/@EXPORT_CONFIG_FILE@")
+  find_package(YARP 3.0 REQUIRED
+                        COMPONENTS OS conf sig dev math gsl)
 
-set(ICUB_LIBRARIES "@ICUB_TARGETS@" CACHE INTERNAL "List of iCub libraries")
-set(ICUB_MODULE_PATH "@ICUB_MODULE_PATH@" CACHE INTERNAL "iCub cmake scripts directory")
-set(ICUB_LINK_FLAGS "@ICUB_LINK_FLAGS@" CACHE INTERNAL "List of iCub linker options")
-set(ICUB_LINK_DIRECTORIES "@ICUB_LINK_DIRECTORIES@")
+  include("@CMAKE_BINARY_DIR@/@EXPORT_INCLUDE_FILE@")
+  include("@CMAKE_BINARY_DIR@/@EXPORT_CONFIG_FILE@")
 
-# This is not ideal and should be removed. At the moment
-# only needed by OpenCV
-link_directories(${ICUB_LINK_DIRECTORIES})
+  set(ICUB_LIBRARIES "@ICUB_TARGETS@" CACHE INTERNAL "List of iCub libraries")
+  set(ICUB_MODULE_PATH "@ICUB_MODULE_PATH@" CACHE INTERNAL "iCub cmake scripts directory")
+  set(ICUB_LINK_FLAGS "@ICUB_LINK_FLAGS@" CACHE INTERNAL "List of iCub linker options")
+  set(ICUB_LINK_DIRECTORIES "@ICUB_LINK_DIRECTORIES@")
 
-set (ICUB_FOUND TRUE)
+  # This is not ideal and should be removed. At the moment
+  # only needed by OpenCV
+  link_directories(${ICUB_LINK_DIRECTORIES})
+  set (ICUB_FOUND TRUE)
+  if(DEFINED _temp_yarp_libs)
+    list(APPEND YARP_LIBRARIES ${_temp_yarp_libs})
+    list(REMOVE_DUPLICATES YARP_LIBRARIES)
+  endif()
 endif (NOT ICUB_FOUND)

--- a/conf/template/icub-config-install.cmake.in
+++ b/conf/template/icub-config-install.cmake.in
@@ -4,36 +4,49 @@
 
 if (NOT ICUB_FOUND)
 
-message(STATUS "Using iCub from install")
+  message(STATUS "Using iCub from install")
 
-set(ICUB_VERSION @ICUB_VERSION@)
+  set(ICUB_VERSION @ICUB_VERSION@)
+  # If YARP_LIBRARIES has been valorized by a previous call of find_package(YARP)
+  # in user CMakelists.txt save it in temporary variable to restore it later.
+  if(DEFINED YARP_LIBRARIES)
+    set(_temp_yarp_libs ${YARP_LIBRARIES})
+  endif()
 
-#set(ICUB_INCLUDE_DIRS "@ICUB_INCLUDE_DIRS@" CACHE INTERNAL "Include directories needed for iCub")
-set(ICUB_MODULE_PATH "@ICUB_MODULE_PATH@" CACHE INTERNAL "iCub cmake scripts directory")
-set(ICUB_LIBRARIES "@ICUB_TARGETS@" CACHE INTERNAL "List of iCub libraries")
-set(ICUB_LINK_FLAGS "@ICUB_LINK_FLAGS@" CACHE INTERNAL "List of iCub linker options")
-set(ICUB_LINK_DIRECTORIES "@ICUB_LINK_DIRECTORIES@")
-set(ICUB_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@")
+  find_package(YARP 3.0 REQUIRED
+                        COMPONENTS OS conf sig dev math gsl)
 
-set(ICUB_PLUGIN_MANIFESTS_INSTALL_DIR "@ICUB_PLUGIN_MANIFESTS_INSTALL_DIR@")
-set(ICUB_MODULES_INSTALL_DIR "@ICUB_MODULES_INSTALL_DIR@")
-set(ICUB_APPLICATIONS_INSTALL_DIR "@ICUB_APPLICATIONS_INSTALL_DIR@")
-set(ICUB_TEMPLATES_INSTALL_DIR "@ICUB_TEMPLATES_INSTALL_DIR@")
-set(ICUB_APPLICATIONS_TEMPLATES_INSTALL_DIR "@ICUB_APPLICATIONS_TEMPLATES_INSTALL_DIR@")
-set(ICUB_MODULES_TEMPLATES_INSTALL_DIR "@ICUB_MODULES_TEMPLATES_INSTALL_DIR@")
-set(ICUB_CONTEXTS_INSTALL_DIR "@ICUB_CONTEXTS_INSTALL_DIR@")
 
-# Remove the old file if it exists. This is a temporary fix 
-if(EXISTS "@CMAKE_INSTALL_PREFIX@/lib/ICUB/icub-export-install-includes.cmake")
-  file(REMOVE "@CMAKE_INSTALL_PREFIX@/lib/ICUB/icub-export-install-includes.cmake")
-endif()
+  #set(ICUB_INCLUDE_DIRS "@ICUB_INCLUDE_DIRS@" CACHE INTERNAL "Include directories needed for iCub")
+  set(ICUB_MODULE_PATH "@ICUB_MODULE_PATH@" CACHE INTERNAL "iCub cmake scripts directory")
+  set(ICUB_LIBRARIES "@ICUB_TARGETS@" CACHE INTERNAL "List of iCub libraries")
+  set(ICUB_LINK_FLAGS "@ICUB_LINK_FLAGS@" CACHE INTERNAL "List of iCub linker options")
+  set(ICUB_LINK_DIRECTORIES "@ICUB_LINK_DIRECTORIES@")
+  set(ICUB_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@")
 
-include("@CMAKE_INSTALL_PREFIX@/lib/ICUB/icub-export-install.cmake")
-include("@CMAKE_INSTALL_PREFIX@/lib/ICUB/icub-export-inst-includes.cmake")
+  set(ICUB_PLUGIN_MANIFESTS_INSTALL_DIR "@ICUB_PLUGIN_MANIFESTS_INSTALL_DIR@")
+  set(ICUB_MODULES_INSTALL_DIR "@ICUB_MODULES_INSTALL_DIR@")
+  set(ICUB_APPLICATIONS_INSTALL_DIR "@ICUB_APPLICATIONS_INSTALL_DIR@")
+  set(ICUB_TEMPLATES_INSTALL_DIR "@ICUB_TEMPLATES_INSTALL_DIR@")
+  set(ICUB_APPLICATIONS_TEMPLATES_INSTALL_DIR "@ICUB_APPLICATIONS_TEMPLATES_INSTALL_DIR@")
+  set(ICUB_MODULES_TEMPLATES_INSTALL_DIR "@ICUB_MODULES_TEMPLATES_INSTALL_DIR@")
+  set(ICUB_CONTEXTS_INSTALL_DIR "@ICUB_CONTEXTS_INSTALL_DIR@")
 
-# This is not ideal and should be removed. At the moment
-# only needed by OpenCV
-link_directories(${ICUB_LINK_DIRECTORIES})
+  # Remove the old file if it exists. This is a temporary fix
+  if(EXISTS "@CMAKE_INSTALL_PREFIX@/lib/ICUB/icub-export-install-includes.cmake")
+    file(REMOVE "@CMAKE_INSTALL_PREFIX@/lib/ICUB/icub-export-install-includes.cmake")
+  endif()
 
-set (ICUB_FOUND TRUE)
+  include("@CMAKE_INSTALL_PREFIX@/lib/ICUB/icub-export-install.cmake")
+  include("@CMAKE_INSTALL_PREFIX@/lib/ICUB/icub-export-inst-includes.cmake")
+
+  # This is not ideal and should be removed. At the moment
+  # only needed by OpenCV
+  link_directories(${ICUB_LINK_DIRECTORIES})
+
+  set (ICUB_FOUND TRUE)
+  if(DEFINED _temp_yarp_libs)
+    list(APPEND YARP_LIBRARIES ${_temp_yarp_libs})
+    list(REMOVE_DUPLICATES YARP_LIBRARIES)
+  endif()
 endif (NOT ICUB_FOUND)


### PR DESCRIPTION
It was impossible create a cmake project with only `find_package(ICUB)`
since icub-main has yarp libs as public dependencies but the `ICUBConfing.cmake/FindICUB.cmake` was not calling `find_package(YARP)` causing linking problems.
Example:
```cmake
cmake_minimum_required(VERSION 3.5)
project(yarpy)

# Find YARP.  Point the YARP_DIR environment variable at your build.
find_package(ICUB REQUIRED)
# Search for source code.
file(GLOB folder_source *.cpp *.cc *.c)
file(GLOB folder_header *.h)

# Automatically add include directories if needed.
foreach(header_file ${folder_header})
  get_filename_component(p ${header_file} PATH)
  include_directories(${p})
endforeach(header_file ${folder_header})

# Set up our main executable.
if(folder_source)
  add_executable(${PROJECT_NAME} ${folder_source} ${folder_header})
  target_link_libraries(${PROJECT_NAME} ${ICUB_LIBRARIES})
else()
  message(FATAL_ERROR "No source code files found. Please add something")
endif()

```
This cmake generates with errors and then compiling there are linking issues against yarp libraries.
Icub has YARP as dependency, but this has not to force to have yarp as dependency also for user code.
Another issue is that if `icub` uses `YARP_gsl`(library `learningMachine`)
``` cmake
find_package(YARP REQUIRED)
find_package(ICUB REQUIRED)
```
is not sufficient, since gsl is not among the default components, you have to add
```cmake
find_package(YARP REQUIRED COMPONENTS OS sig dev math gsl)
```
even if the user code don't need gsl or `YARP_gsl`
This bug was noticed by @arrenglover .
I put this fix in `icub-config-build-tree.cmake.in` and it works but if anyone know a better place to put it please let me know.
cc @drdanz @traversaro 