### PR TITLE
Fix camCalibs after the introduction of move semantic in YARP images

### DIFF
--- a/src/modules/camCalib/src/PinholeCalibTool.cpp
+++ b/src/modules/camCalib/src/PinholeCalibTool.cpp
@@ -196,9 +196,7 @@ void PinholeCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & o
         _needInit)
         init(inSize,_calibImgSize);
 
-    out.resize(inSize.width, inSize.height);
-
-    cv::Mat outMat=toCvMat(out);
+    cv::Mat outMat;
     cv::remap( toCvMat(const_cast<ImageOf<PixelRgb>&>(in)), outMat,
                cv::cvarrToMat(_mapUndistortX), cv::cvarrToMat(_mapUndistortY),
                cv::INTER_LINEAR );

--- a/src/modules/camCalibWithPose/src/PinholeCalibTool.cpp
+++ b/src/modules/camCalibWithPose/src/PinholeCalibTool.cpp
@@ -196,9 +196,7 @@ void PinholeCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & o
         _needInit)
         init(inSize,_calibImgSize);
 
-    out.resize(inSize.width, inSize.height);
-
-    cv::Mat outMat=toCvMat(out);
+    cv::Mat outMat;
     cv::remap( toCvMat(const_cast<ImageOf<PixelRgb>&>(in)), outMat,
                cv::cvarrToMat(_mapUndistortX), cv::cvarrToMat(_mapUndistortY),
                cv::INTER_LINEAR );

--- a/src/modules/dualCamCalib/src/PinholeCalibTool.cpp
+++ b/src/modules/dualCamCalib/src/PinholeCalibTool.cpp
@@ -196,9 +196,7 @@ void PinholeCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & o
         _needInit)
         init(inSize,_calibImgSize);
 
-    out.resize(inSize.width, inSize.height);
-
-    cv::Mat outMat=toCvMat(out);
+    cv::Mat outMat;
     cv::remap( toCvMat(const_cast<ImageOf<PixelRgb>&>(in)), outMat,
              cv::cvarrToMat(_mapUndistortX), cv::cvarrToMat(_mapUndistortY),
              cv::INTER_LINEAR );


### PR DESCRIPTION
It fixes https://github.com/robotology/yarp/issues/1979 .

The first `toCvMat(out)` has been removed since it is not necessary, and it makes the yarp and cv output image memory shared.
I am not sure but it seems that `cv::remap` does some memory changes that made crash the program while trying to write the yarp image.
This crash does not happen without using `cv::remap`.

I tested it on my laptop with `usbCamera` and now it works. 
 
Please review code.