### PR TITLE
Dragonfly add missing include

### DIFF
--- a/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.h
+++ b/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.h
@@ -20,6 +20,7 @@
 #include <yarp/os/Bottle.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/os/Stamp.h>
+#include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/PreciselyTimed.h>
 #include <yarp/dev/IVisualParams.h>
 


### PR DESCRIPTION
Dragonfly device was not compiling after include cleanup.
