### PR TITLE
Removed deprecated cmake instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,21 +2,7 @@
 # Authors: Lorenzo Natale
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-# New build system. Exploit new cmake 2.6 features (export).
-
-#reduce warning level with cmake 2.6
 cmake_minimum_required(VERSION 3.5)
-
-#cmake policies
-# CMake Policy CMP0020 (Automatically link Qt executables to qtmain
-# target on Windows). Can be removed with
-# CMAKE_MINIMUM_REQUIRED_VERSION 2.8.11 or later.
-if(NOT ${CMAKE_MINIMUM_REQUIRED_VERSION} VERSION_LESS 2.8.11)
-    message(AUTHOR_WARNING "CMake Policy CMP0020 is now NEW by default. You can remove this.")
-endif()
-if(NOT ${CMAKE_VERSION} VERSION_LESS 2.8.11)
-    cmake_policy(SET CMP0020 NEW)
-endif()
 
 project(iCub)
 


### PR DESCRIPTION
~~Removed 'FindPackage(ACE)' not directly used by iCub~~
Removed legacy cmake instructions

@drdanz can you double check, please? 
~~In my knowledge `ACE` is not directly used by iCub, is it right?~~  It is used