### PR TITLE
Fix a compilation error with `ROBOTOLOGY_ENABLE_ICUB_HEAD` enabled

### DIFF
--- a/src/libraries/icubmod/xsensmtx/MTComm.h
+++ b/src/libraries/icubmod/xsensmtx/MTComm.h
@@ -90,6 +90,7 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <time.h>
 #ifdef WIN32
 #include <windows.h>
 #include <conio.h>
@@ -99,7 +100,6 @@
 #include <unistd.h>		/* Read function */
 #include <sys/time.h>	/* gettimeofday function */
 #include <sys/stat.h>   /* fstat function */
-#include <time.h>
 #endif
 
 #ifndef	INVALID_SET_FILE_POINTER

--- a/src/libraries/icubmod/xsensmtx/MTComm.h
+++ b/src/libraries/icubmod/xsensmtx/MTComm.h
@@ -93,13 +93,13 @@
 #ifdef WIN32
 #include <windows.h>
 #include <conio.h>
-#include <time.h>
 #else
 #include <fcntl.h>     	/* POSIX Standard: 6.5 File Control Operations     */
 #include <termios.h>   	/* terminal i/o system, talks to /dev/tty* ports  */
 #include <unistd.h>		/* Read function */
 #include <sys/time.h>	/* gettimeofday function */
 #include <sys/stat.h>   /* fstat function */
+#include <time.h>
 #endif
 
 #ifndef	INVALID_SET_FILE_POINTER


### PR DESCRIPTION
Fix a compilation error while trying to compile `robotology-superbuild` with CMake option `ROBOTOLOGY_ENABLE_ICUB_HEAD` enabled.

The [clock_t](http://www.cplusplus.com/reference/ctime/clock_t/) function is not declared in `sys/time.h`, instead it's declared in time.h.