### PR TITLE
Introduced IMU 2.6

### DIFF
--- a/src/libraries/iKin/src/iKinFwd.cpp
+++ b/src/libraries/iKin/src/iKinFwd.cpp
@@ -2430,7 +2430,7 @@ void iCubEye::allocate(const string &_type)
         pushLink(new iKinLink(    0.0,  -0.034, -M_PI/2.0,       0.0, -35.0*CTRL_DEG2RAD, 15.0*CTRL_DEG2RAD));
         pushLink(new iKinLink(    0.0,     0.0,  M_PI/2.0, -M_PI/2.0, -50.0*CTRL_DEG2RAD, 50.0*CTRL_DEG2RAD));
     }
-    else if ((getType()=="right_v2") || (getType()=="right_v2.5"))
+    else if ((getType()=="right_v2") || (getType()=="right_v2.5") || (getType()=="right_v2.6"))
     {
         pushLink(new iKinLink(  0.032,     0.0,  M_PI/2.0,       0.0, -22.0*CTRL_DEG2RAD, 84.0*CTRL_DEG2RAD));
         pushLink(new iKinLink(    0.0, -0.0055,  M_PI/2.0, -M_PI/2.0, -39.0*CTRL_DEG2RAD, 39.0*CTRL_DEG2RAD));
@@ -2468,7 +2468,7 @@ void iCubEye::allocate(const string &_type)
     }
     else
     {
-        if ((type!="left_v2") && (type!="left_v2.5"))
+        if ((type!="left_v2") && (type!="left_v2.5") && (type!="left_v2.6"))
             type="left_v2";
 
         pushLink(new iKinLink(  0.032,     0.0,  M_PI/2.0,       0.0, -22.0*CTRL_DEG2RAD, 84.0*CTRL_DEG2RAD));

--- a/src/libraries/iKin/src/iKinFwd.cpp
+++ b/src/libraries/iKin/src/iKinFwd.cpp
@@ -2612,7 +2612,7 @@ void iCubInertialSensor::allocate(const string &_type)
     H0.zero();
     H0(3,3)=1.0;
 
-    if ((getType()=="v2") || (getType()=="v2.5"))
+    if ((getType()=="v2") || (getType()=="v2.5") || (getType()=="v2.6"))
     {
         H0(0,1)=-1.0;
         H0(1,2)=-1.0;
@@ -2665,12 +2665,25 @@ void iCubInertialSensor::allocate(const string &_type)
     HN(3,3)=1.0;
     setHN(HN);
 
-    if ((getType()=="v2.5") || (getType()=="v3"))
+    if ((getType()=="v2.5") || (getType()=="v2.6") || (getType()=="v3"))
     {
         Matrix HN=eye(4,4);
         HN(0,3)=0.0087;
         HN(1,3)=0.01795;
         HN(2,3)=-0.0105;
+        setHN(getHN()*HN);
+    }
+
+    if (getType()=="v2.6")
+    {
+        Matrix HN=zeros(4,4);
+        HN(0,3)=0.0323779;
+        HN(1,3)=-0.0139537;
+        HN(2,3)=0.072;
+        HN(1,0)=1.0;
+        HN(0,1)=1.0;
+        HN(2,2)=-1.0;
+        HN(3,3)=1.0;
         setHN(getHN()*HN);
     }
 

--- a/src/modules/iKinGazeCtrl/src/main.cpp
+++ b/src/modules/iKinGazeCtrl/src/main.cpp
@@ -209,8 +209,8 @@ Factors</a>.
 
 --head_version \e ver
 - This option specifies the kinematic structure of the head; the value
-  \e ver is a double in the set {1.0, 2.0, 2.5}, being 1.0 the default
-  version.
+  \e ver is a double in the set {1.0, 2.0, 2.5, 2.6, 3.0}, being 1.0
+  the default version.
 
 --verbose
 - Enable some output print-out.
@@ -1068,12 +1068,15 @@ protected:
         d[fabs(1.0-ver_in)]=1.0;
         d[fabs(2.0-ver_in)]=2.0;
         d[fabs(2.5-ver_in)]=2.5;
+        d[fabs(2.6-ver_in)]=2.6;
         d[fabs(3.0-ver_in)]=3.0;
 
         double ver_out=d.begin()->second;
         if (ver_out!=ver_in)
+        {
             yWarning("Unknown \"head_version\" %g requested => used \"head_version\" %g instead",
                      ver_in,ver_out);
+        }
 
         return ver_out;
     }


### PR DESCRIPTION
As per request #570, this PR introduces IMU version **`2.6`**.
Changes are regarded with:
- `iKin` to declare the new kinematics.
  Differently from what I planned, HN matrices are accumulated to adapt to the current code.
- `iKinGazeCtrl` to extend the set of allowed IMU's.