### PR TITLE
Fix memory usage in ParametricCalibratorEth

### DIFF
--- a/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.cpp
+++ b/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.cpp
@@ -297,6 +297,8 @@ bool parametricCalibratorEth::open(yarp::os::Searchable& config)
     startupPosThreshold = new double[n_joints];
     disableHomeAndPark = new int[n_joints];
     disableStartupPosCheck = new int[n_joints];
+    original_max_pwm = new double[n_joints];
+    limited_max_pwm = new double[n_joints];
 
     for (int i = 0; i < n_joints; i++) timeout_goToZero[i] = 10;
     for (int i = 0; i < n_joints; i++) timeout_calibration[i] = 20;
@@ -585,8 +587,6 @@ bool parametricCalibratorEth::calibrate()
         yWarning() << deviceName << " is calibrating only a subset of the robot part. Calibrating " << totJointsToCalibrate << " over a total of " << n_joints;
     }
 
-    original_max_pwm = new double[n_joints];
-    limited_max_pwm = new double[n_joints];
 
     if(skipCalibration)
         yWarning() << deviceName << ": skipCalibration flag is on! Setting safe pid but skipping calibration.";


### PR DESCRIPTION
In this PR I fix a wrong use of memory allocation. 
Every time the calibrate function is called, two new heap allocations are done. (see [here](https://github.com/robotology/icub-main/blob/55154efbb1d94983598f85e270c6ad145a3ba4de/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.cpp#L588) )

I moved such allocations in the `open` function, so they are performed one  time only. The delete is done in `close` function