### PR TITLE
 iCubGui: port to the usage of MAS client 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(ICUB_COMPILE_BINDINGS "Compile optional language bindings"  FALSE)
 
-find_package(YARP 3.2.0 REQUIRED)
+find_package(YARP 3.2.101 REQUIRED)
 message(STATUS "YARP is version: ${YARP_VERSION}")
 
 if(YARP_math_FOUND)

--- a/app/iCubGui/scripts/iCubGui.xml.template
+++ b/app/iCubGui/scripts/iCubGui.xml.template
@@ -18,8 +18,8 @@
     <protocol>udp</protocol>
   </connection>
   <connection>
-    <from>/icub/inertial</from>
-    <to>/iCubGui/inertial:i</to>
+    <from>/icub/head/inertials/measures:o</from>
+    <to>/iCubGui/inertials/measures:i</to>
     <protocol>udp</protocol>
   </connection>
   <connection>

--- a/app/iCubGui/scripts/iCubGui_skinContacts.xml.template
+++ b/app/iCubGui/scripts/iCubGui_skinContacts.xml.template
@@ -18,8 +18,8 @@
     <protocol>udp</protocol>
   </connection>
   <connection>
-    <from>/icub/inertial</from>
-    <to>/iCubGui/inertial:i</to>
+    <from>/icub/head/inertials/measures:o</from>
+    <to>/iCubGui/inertials/measures:i</to>
     <protocol>udp</protocol>
   </connection>
   <connection>

--- a/src/tools/iCubGui/src/bvh.cpp
+++ b/src/tools/iCubGui/src/bvh.cpp
@@ -338,7 +338,7 @@ BVHNode* BVH::bvhReadNode(yarp::os::ResourceFinder& config)
             double b=token().toDouble();
             double c=token().toDouble();
             double d=token().toDouble();
-            node=new BVHNodeINERTIAL(sName,a,b,c,d,robot+"/inertial",pMesh);
+            node=new BVHNodeINERTIAL(sName,a,b,c,d,robot+"/head/inertials",pMesh);
         }
         break;
     }


### PR DESCRIPTION
The `iCubGui` has been ported to the usage of the MAS client.
It requires yarp `3.2.101` since it uses a new option of the MAS client(robotology/yarp#2098)
 Successfully tested on `iCubGenova02`.