### PR TITLE
Port the imu of iCub_SIM to the MAS interfaces`

### DIFF
--- a/src/simulators/iCubSimulation/odesdl/OdeInit.cpp
+++ b/src/simulators/iCubSimulation/odesdl/OdeInit.cpp
@@ -130,6 +130,17 @@ void OdeInit::setSimulationControl(iCubSimulationControl *control, int part)
     }
 }
 
+void OdeInit::setSimulationIMU(iCubSimulationIMU *imu) {
+    if (imu)
+    {
+        _imu = imu;
+    }
+}
+
+void OdeInit::removeSimulationIMU() {
+    _imu = nullptr;
+}
+
 void OdeInit::sendHomePos()
 {
     double refs[16] = {0,0,0,0,0,0,0,0,0,0,0,10*M_PI/180,10*M_PI/180,10*M_PI/180,10*M_PI/180,10*M_PI/180};

--- a/src/simulators/iCubSimulation/odesdl/OdeInit.h
+++ b/src/simulators/iCubSimulation/odesdl/OdeInit.h
@@ -35,6 +35,7 @@
 #include <yarp/os/Semaphore.h>
 #include "iCubLogicalJoints.h"
 #include "iCubSimulationControl.h"
+#include "iCubSimulationIMU.h"
 //#include <vector>
 
 #include "RobotConfig.h"
@@ -71,6 +72,7 @@ public:
     int verbosity;
     string name;
     iCubSimulationControl **_controls;
+    iCubSimulationIMU * _imu{nullptr};
     double contactFrictionCoefficient; //unlike the other ODE params fron .ini file that are used to intiialize the properties of the simulation (dWorldSet...),
     //This parameter is employed on the run as contact joints are created (in OdeSdlSimulation::nearCallback() )
     //for whole_body_skin_emul
@@ -95,6 +97,8 @@ public:
 
     void setSimulationControl(iCubSimulationControl *control, int part);
     void removeSimulationControl(int part);
+    void setSimulationIMU(iCubSimulationIMU *imu);
+    void removeSimulationIMU();
     static OdeInit& init(RobotConfig *config);
     void sendHomePos();
 

--- a/src/simulators/iCubSimulation/odesdl/iCub_Sim.cpp
+++ b/src/simulators/iCubSimulation/odesdl/iCub_Sim.cpp
@@ -1087,6 +1087,16 @@ Uint32 OdeSdlSimulation::ODE_process(Uint32 interval, void *param) {
             odeinit._controls[ipart]->jointStep();
         }
     }
+
+    // UPDATE INERTIAL
+
+    if(odeinit._imu) {
+        Bottle inertialBot;
+        retreiveInertialData(inertialBot);
+        odeinit._imu->updateIMUData(inertialBot);
+    }
+
+
     odeinit.sync = true;
     odeinit.mutex.post();
 

--- a/src/simulators/iCubSimulation/wrapper/SimulationRun.cpp
+++ b/src/simulators/iCubSimulation/wrapper/SimulationRun.cpp
@@ -25,6 +25,7 @@
 
 #include "SimulatorModule.h"
 #include "iCubSimulationControl.h"
+#include "iCubSimulationIMU.h"
 #include "SimConfig.h"
 
 using namespace yarp::dev;
@@ -67,6 +68,10 @@ bool SimulationRun::run(SimulationBundle *bundle, int argc, char *argv[]) {
     Drivers::factory().add(new DriverCreatorOf<iCubSimulationControl>("simulationcontrol", 
         "controlboard",
         "iCubSimulationControl"));
+
+    Drivers::factory().add(new DriverCreatorOf<iCubSimulationIMU>("simulationIMU",
+                                                                      "multipleanalogsensorsserver",
+                                                                      "iCubSimulationIMU"));
 
     SimulatorModule module(*world,config,bundle->createSimulation(config));
 

--- a/src/simulators/iCubSimulation/wrapper/SimulatorModule.cpp
+++ b/src/simulators/iCubSimulation/wrapper/SimulatorModule.cpp
@@ -284,6 +284,9 @@ bool SimulatorModule::interruptModule() {
         delete iCubTorso;
         iCubTorso = NULL;
     }
+
+    masserver.close();
+    simImu.close();
     world_manager.clear();
   
     return true;
@@ -477,6 +480,29 @@ bool SimulatorModule::initSimulatorModule()
         if (idesc) idesc->registerDevice(desc);
     }
 
+    Property masServerConf {{"device", Value("multipleanalogsensorsserver")},
+                            {"name",Value(moduleName+"/head/inertials")},
+                            {"period",Value(10)}};
+    Property simImuConf {{"device",Value("simulationIMU")}};
+
+
+    if (!simImu.open(simImuConf)) {
+        return false;
+    }
+
+    polyList.push(&simImu,"simImu");
+
+    if (!masserver.open(masServerConf)){
+        return false;
+    }
+
+    if (!masserver.view(iMWrapper))
+    {
+        yError()<<"Failed to view the IMultipleWrapper";
+        return false;
+    }
+
+    iMWrapper->attachAll(polyList);
     //dd_descClnt will be not used anymore.
     dd_descClnt->close();
     delete dd_descClnt;

--- a/src/simulators/iCubSimulation/wrapper/SimulatorModule.h
+++ b/src/simulators/iCubSimulation/wrapper/SimulatorModule.h
@@ -28,6 +28,7 @@
 #include <yarp/sig/Image.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IRobotDescription.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 #include "RobotStreamer.h"
 #include "RobotConfig.h"
@@ -124,6 +125,9 @@ private:
     yarp::sig::ImageOf<yarp::sig::PixelRgb> buffer;
 
     yarp::dev::PolyDriver *iCubLArm, *iCubRArm, *iCubHead, *iCubLLeg ,*iCubRLeg, *iCubTorso;
+    yarp::dev::PolyDriver masserver, simImu;;
+    yarp::dev::PolyDriverList polyList;
+    yarp::dev::IMultipleWrapper* iMWrapper{nullptr};
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > portLeft, portRight, portWide;
 
 #ifndef OMIT_LOGPOLAR

--- a/src/simulators/iCubSimulation/wrapper/iCubSimulationIMU.cpp
+++ b/src/simulators/iCubSimulation/wrapper/iCubSimulationIMU.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <string>
+#include <yarp/os/Stamp.h>
+#include <yarp/os/LogStream.h>
+
+#include <iCubSimulationIMU.h>
+
+#include "OdeInit.h"
+
+using namespace yarp::os;
+using namespace yarp::dev;
+using namespace yarp::sig;
+
+
+iCubSimulationIMU::iCubSimulationIMU()
+{
+    gyro.resize(3,0.0);
+    rpy.resize(3,0.0);
+    accels.resize(3, 0.0);
+    magn.resize(3,0.0);
+    m_sensorName = "sensorName";
+    m_frameName  = "frameName";
+}
+
+iCubSimulationIMU::~iCubSimulationIMU()
+{
+    OdeInit& odeinit = OdeInit::get();
+    odeinit.mutex.wait();
+    odeinit.removeSimulationIMU();
+    odeinit.mutex.post();
+}
+
+bool iCubSimulationIMU::open(yarp::os::Searchable &config)
+{
+    OdeInit& odeinit = OdeInit::get();
+    odeinit.mutex.wait();
+    odeinit.setSimulationIMU(this);
+    odeinit.mutex.post();
+    return true;
+}
+
+bool iCubSimulationIMU::close()
+{
+    // TODO see what does simulation control
+    return true;
+}
+
+
+
+yarp::dev::MAS_status iCubSimulationIMU::genericGetStatus(size_t sens_index) const
+{
+    if (sens_index!=0) {
+        return yarp::dev::MAS_status::MAS_ERROR;
+    }
+
+    return yarp::dev::MAS_status::MAS_OK;
+}
+
+bool iCubSimulationIMU::genericGetSensorName(size_t sens_index, std::string &name) const
+{
+    if (sens_index!=0) {
+        return false;
+    }
+
+    name = m_sensorName;
+    return true;
+}
+
+bool iCubSimulationIMU::genericGetFrameName(size_t sens_index, std::string &frameName) const
+{
+    if (sens_index!=0) {
+        return false;
+    }
+
+    frameName = m_frameName;
+    return true;
+}
+
+size_t iCubSimulationIMU::getNrOfThreeAxisGyroscopes() const
+{
+    return 1;
+}
+
+yarp::dev::MAS_status iCubSimulationIMU::getThreeAxisGyroscopeStatus(size_t sens_index) const
+{
+    return genericGetStatus(sens_index);
+}
+
+bool iCubSimulationIMU::getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const
+{
+    return genericGetSensorName(sens_index, name);
+}
+
+bool iCubSimulationIMU::getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const
+{
+    return genericGetFrameName(sens_index, frameName);
+}
+
+bool iCubSimulationIMU::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+{
+    if (sens_index!=0) {
+        return false;
+    }
+
+    out.resize(3);
+    m_mutex.lock();
+    out = gyro;
+    m_mutex.unlock();
+
+    // Workaround for https://github.com/robotology/yarp/issues/1610
+    yarp::os::Stamp copyStamp(lastStamp);
+    timestamp = copyStamp.getTime();
+
+    return true;
+}
+
+size_t iCubSimulationIMU::getNrOfThreeAxisLinearAccelerometers() const
+{
+    return 1;
+}
+
+yarp::dev::MAS_status iCubSimulationIMU::getThreeAxisLinearAccelerometerStatus(size_t sens_index) const
+{
+    return genericGetStatus(sens_index);
+}
+
+bool iCubSimulationIMU::getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const
+{
+    return genericGetSensorName(sens_index, name);
+}
+
+bool iCubSimulationIMU::getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const
+{
+    return genericGetFrameName(sens_index, frameName);
+}
+
+bool iCubSimulationIMU::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+{
+    if (sens_index!=0) {
+        return false;
+    }
+
+    out.resize(3);
+    m_mutex.lock();
+    out = accels;
+    m_mutex.unlock();
+
+    // Workaround for https://github.com/robotology/yarp/issues/1610
+    yarp::os::Stamp copyStamp(lastStamp);
+    timestamp = copyStamp.getTime();
+
+    return true;
+}
+
+size_t iCubSimulationIMU::getNrOfThreeAxisMagnetometers() const
+{
+    return 1;
+}
+
+yarp::dev::MAS_status iCubSimulationIMU::getThreeAxisMagnetometerStatus(size_t sens_index) const
+{
+    return genericGetStatus(sens_index);
+}
+
+bool iCubSimulationIMU::getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const
+{
+    return genericGetSensorName(sens_index, name);
+}
+
+bool iCubSimulationIMU::getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const
+{
+    return genericGetFrameName(sens_index, frameName);
+}
+
+bool iCubSimulationIMU::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+{
+    if (sens_index!=0) {
+        return false;
+    }
+
+    out.resize(3);
+    m_mutex.lock();
+    out = magn;
+    m_mutex.unlock();
+
+    // Workaround for https://github.com/robotology/yarp/issues/1610
+    yarp::os::Stamp copyStamp(lastStamp);
+    timestamp = copyStamp.getTime();
+
+    return true;
+}
+
+size_t iCubSimulationIMU::getNrOfOrientationSensors() const
+{
+    return 1;
+}
+
+yarp::dev::MAS_status iCubSimulationIMU::getOrientationSensorStatus(size_t sens_index) const
+{
+    return genericGetStatus(sens_index);
+}
+
+bool iCubSimulationIMU::getOrientationSensorName(size_t sens_index, std::string &name) const
+{
+    return genericGetSensorName(sens_index, name);
+}
+
+bool iCubSimulationIMU::getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const
+{
+    return genericGetFrameName(sens_index, frameName);
+}
+
+bool iCubSimulationIMU::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy_out, double& timestamp) const
+{
+    if (sens_index!=0) {
+        return false;
+    }
+
+    rpy_out.resize(3);
+    m_mutex.lock();
+    rpy_out = rpy;
+    m_mutex.unlock();
+
+    // Workaround for https://github.com/robotology/yarp/issues/1610
+    yarp::os::Stamp copyStamp(lastStamp);
+    timestamp = copyStamp.getTime();
+
+    return true;
+}
+
+
+void iCubSimulationIMU::updateIMUData(const yarp::os::Bottle& imuData) {
+    m_mutex.lock();
+    if (imuData.size() < 12) {
+        return;
+    }
+    rpy[0] = imuData.get(0).asFloat64();
+    rpy[1] = imuData.get(1).asFloat64();
+    rpy[2] = imuData.get(2).asFloat64();
+
+    accels[0] = imuData.get(3).asFloat64();
+    accels[1] = imuData.get(4).asFloat64();
+    accels[2] = imuData.get(5).asFloat64();
+
+    gyro[0] = imuData.get(6).asFloat64();
+    gyro[1] = imuData.get(7).asFloat64();
+    gyro[2] = imuData.get(8).asFloat64();
+
+    magn[0] = imuData.get(9).asFloat64();
+    magn[1] = imuData.get(10).asFloat64();
+    magn[2] = imuData.get(11).asFloat64();
+
+    m_mutex.unlock();
+}

--- a/src/simulators/iCubSimulation/wrapper/iCubSimulationIMU.h
+++ b/src/simulators/iCubSimulation/wrapper/iCubSimulationIMU.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2006-2019 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <string>
+#include <mutex>
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/IGenericSensor.h>
+#include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
+#include <yarp/os/Stamp.h>
+#include <yarp/dev/IPreciselyTimed.h>
+
+
+
+#ifndef __iCubSimulationIMUh__
+#define __iCubSimulationIMUh__
+
+class iCubSimulationIMU :
+        public yarp::dev::DeviceDriver,
+        public yarp::dev::IThreeAxisGyroscopes,
+        public yarp::dev::IThreeAxisLinearAccelerometers,
+        public yarp::dev::IThreeAxisMagnetometers,
+        public yarp::dev::IOrientationSensors
+{
+public:
+    iCubSimulationIMU();
+    virtual ~iCubSimulationIMU();
+
+    // Device Driver interface
+    bool open(yarp::os::Searchable &config) override;
+    bool close() override;
+
+    /* IThreeAxisGyroscopes methods */
+    size_t getNrOfThreeAxisGyroscopes() const override;
+    yarp::dev::MAS_status getThreeAxisGyroscopeStatus(size_t sens_index) const override;
+    bool getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const override;
+    bool getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const override;
+    bool getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+
+    /* IThreeAxisLinearAccelerometers methods */
+    size_t getNrOfThreeAxisLinearAccelerometers() const override;
+    yarp::dev::MAS_status getThreeAxisLinearAccelerometerStatus(size_t sens_index) const override;
+    bool getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const override;
+    bool getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
+    bool getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+
+    /* IThreeAxisMagnetometers methods */
+    size_t getNrOfThreeAxisMagnetometers() const override;
+    yarp::dev::MAS_status getThreeAxisMagnetometerStatus(size_t sens_index) const override;
+    bool getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const override;
+    bool getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const override;
+    bool getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+
+    /* IOrientationSensors methods */
+    size_t getNrOfOrientationSensors() const override;
+    yarp::dev::MAS_status getOrientationSensorStatus(size_t sens_index) const override;
+    bool getOrientationSensorName(size_t sens_index, std::string &name) const override;
+    bool getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const override;
+    bool getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
+
+    void updateIMUData(const yarp::os::Bottle& imuData);
+
+    yarp::sig::Vector gyro, rpy, magn, accels;
+
+private:
+    yarp::dev::MAS_status genericGetStatus(size_t sens_index) const;
+    bool genericGetSensorName(size_t sens_index, std::string &name) const;
+    bool genericGetFrameName(size_t sens_index, std::string &frameName) const;
+
+    yarp::os::Stamp lastStamp;
+    std::string m_sensorName;
+    std::string m_frameName;
+    mutable std::mutex m_mutex;
+
+};
+
+#endif // __iCubSimulationIMUh__


### PR DESCRIPTION
Moreover it instantiates the `multipleanalogsensorsserver` that wraps the new icub sim device that expose the imu.

The port `/icub/inertial` has been maintained for backward compatibilty.

I only checked the number coming from `measures:o`, they seems ok, to be tested with `iCubGui`.