### PR TITLE
Introduce the use of std::mutex and std::condition_variable

### DIFF
--- a/src/libraries/actionPrimitives/include/iCub/action/actionPrimitives.h
+++ b/src/libraries/actionPrimitives/include/iCub/action/actionPrimitives.h
@@ -79,6 +79,8 @@
 #ifndef __AFFACTIONPRIMITIVES_H__
 #define __AFFACTIONPRIMITIVES_H__
 
+#include <mutex>
+#include <condition_variable>
 #include <string>
 #include <vector>
 #include <deque>
@@ -205,9 +207,11 @@ protected:
     perception::Model            *graspModel;
                                  
     yarp::os::PeriodicThread     *armWaver;
-    yarp::os::Mutex               mutex;
-    yarp::os::Event               motionStartEvent;
-    yarp::os::Event               motionDoneEvent;
+    std::mutex                    mtx;
+    std::mutex                    mtx_motionStartEvent;
+    std::condition_variable       cv_motionStartEvent;
+    std::mutex                    mtx_motionDoneEvent;
+    std::condition_variable       cv_motionDoneEvent;
 
     bool armMoveDone;
     bool handMoveDone;

--- a/src/libraries/ctrlLib/include/iCub/ctrl/tuning.h
+++ b/src/libraries/ctrlLib/include/iCub/ctrl/tuning.h
@@ -22,6 +22,9 @@
 #ifndef __TUNING_H__
 #define __TUNING_H__
 
+#include <mutex>
+#include <condition_variable>
+
 #include <yarp/os/all.h>
 #include <yarp/dev/all.h>
 #include <yarp/sig/all.h>
@@ -159,12 +162,13 @@ protected:
     yarp::dev::IPWMControl     *ipwm;
     yarp::dev::ICurrentControl *icur;
 
-    yarp::os::Mutex    mutex;
-    yarp::os::Event    doneEvent;
-    yarp::sig::Vector  gamma;
-    yarp::sig::Vector  stiction;
-    yarp::os::Property info;
-    yarp::sig::Vector  done;
+    std::mutex              mtx;
+    std::mutex              mtx_doneEvent;
+    std::condition_variable cv_doneEvent;
+    yarp::sig::Vector       gamma;
+    yarp::sig::Vector       stiction;
+    yarp::os::Property      info;
+    yarp::sig::Vector       done;
 
     AWLinEstimator   velEst;
     AWQuadEstimator  accEst;
@@ -359,8 +363,9 @@ protected:
     yarp::dev::Pid               pidOld;
     yarp::dev::Pid               pidNew;
 
-    yarp::os::Mutex mutex;
-    yarp::os::Event doneEvent;
+    std::mutex mtx;
+    std::mutex mtx_doneEvent;
+    std::condition_variable cv_doneEvent;
     yarp::os::BufferedPort<yarp::sig::Vector> port;
 
     yarp::sig::Vector x0;

--- a/src/libraries/iKin/include/iCub/iKin/iKinSlv.h
+++ b/src/libraries/iKin/include/iCub/iKin/iKinSlv.h
@@ -223,13 +223,13 @@
 #ifndef __IKINSLV_H__
 #define __IKINSLV_H__
 
+#include <mutex>
+#include <condition_variable>
 #include <string>
 #include <deque>
 
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/os/Mutex.h>
-#include <yarp/os/Event.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>
 
@@ -265,7 +265,7 @@ class InputPort : public yarp::os::BufferedPort<yarp::os::Bottle>
 protected:
     CartesianSolver *slv;
 
-    yarp::os::Mutex mutex;
+    std::mutex mtx;
 
     bool   contMode;
     bool   isNew;
@@ -345,7 +345,7 @@ protected:
     yarp::os::Port                           *rpcPort;
     InputPort                                *inPort;
     yarp::os::BufferedPort<yarp::os::Bottle> *outPort;
-    yarp::os::Mutex                           mutex;
+    std::mutex                                mtx;
 
     std::string   slvName;
     std::string   type;
@@ -381,7 +381,8 @@ protected:
     yarp::sig::Vector w_3rdTask;
     yarp::sig::Vector idx_3rdTask;
 
-    yarp::os::Event dofEvent;
+    std::mutex mtx_dofEvent;
+    std::condition_variable cv_dofEvent;
 
     virtual PartDescriptor *getPartDesc(yarp::os::Searchable &options)=0;
     virtual yarp::sig::Vector solve(yarp::sig::Vector &xd);

--- a/src/libraries/icubmod/cartesianController/ServerCartesianController.h
+++ b/src/libraries/icubmod/cartesianController/ServerCartesianController.h
@@ -19,6 +19,8 @@
 #ifndef __SERVERCARTESIANCONTROLLER_H__
 #define __SERVERCARTESIANCONTROLLER_H__
 
+#include <mutex>
+#include <condition_variable>
 #include <string>
 #include <vector>
 #include <set>
@@ -167,8 +169,9 @@ protected:
     bool         skipSlvRes;
     bool         syncEventEnabled;
 
-    yarp::os::Mutex mutex;
-    yarp::os::Event syncEvent;
+    std::mutex mtx;
+    std::mutex mtx_syncEvent;
+    std::condition_variable cv_syncEvent;
     yarp::os::Stamp txInfo;
     yarp::os::Stamp poseInfo;
     yarp::os::Stamp eventInfo;

--- a/src/libraries/perceptiveModels/include/iCub/perception/private/ports.h
+++ b/src/libraries/perceptiveModels/include/iCub/perception/private/ports.h
@@ -18,7 +18,8 @@
 #ifndef __PERCEPTIVEMODELS_PORTS_H__
 #define __PERCEPTIVEMODELS_PORTS_H__
 
-#include <yarp/os/Mutex.h>
+#include <mutex>
+
 #include <yarp/os/Value.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
@@ -33,7 +34,7 @@ namespace perception
 class Port : public yarp::os::BufferedPort<yarp::os::Bottle>
 {
 protected:
-    yarp::os::Mutex  mutex;
+    std::mutex mtx;
     yarp::os::Bottle bottle;
 
     void onRead(yarp::os::Bottle &bottle);

--- a/src/libraries/perceptiveModels/include/iCub/perception/springyFingers.h
+++ b/src/libraries/perceptiveModels/include/iCub/perception/springyFingers.h
@@ -56,6 +56,8 @@
 #ifndef __PERCEPTIVEMODELS_SPRINGYFINGERS_H__
 #define __PERCEPTIVEMODELS_SPRINGYFINGERS_H__
 
+#include <mutex>
+
 #include <yarp/os/all.h>
 #include <yarp/dev/all.h>
 #include <yarp/sig/all.h>
@@ -214,7 +216,7 @@ private:
     yarp::os::BufferedPort<yarp::os::Bottle> *port;
     yarp::dev::PolyDriver                     driver;
 
-    yarp::os::Mutex mutex;
+    std::mutex mtx;
 
     class CalibThread : public yarp::os::Thread
     {

--- a/src/libraries/perceptiveModels/src/ports.cpp
+++ b/src/libraries/perceptiveModels/src/ports.cpp
@@ -15,9 +15,9 @@
  * Public License for more details
 */
 
-#include <yarp/os/LockGuard.h>
 #include <iCub/perception/private/ports.h>
 
+using namespace std;
 using namespace yarp::os;
 using namespace iCub::perception;
 
@@ -32,7 +32,7 @@ iCub::perception::Port::Port()
 /************************************************************************/
 void iCub::perception::Port::onRead(Bottle &bottle)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     this->bottle=bottle;
 }
 
@@ -40,7 +40,7 @@ void iCub::perception::Port::onRead(Bottle &bottle)
 /************************************************************************/
 Value iCub::perception::Port::getValue(const int index)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
 
     Value ret;
     if ((index>=0) && (index<bottle.size()))

--- a/src/libraries/perceptiveModels/src/springyFingers.cpp
+++ b/src/libraries/perceptiveModels/src/springyFingers.cpp
@@ -725,11 +725,11 @@ void SpringyFingersModel::calibrateFinger(SpringyFinger &finger, const int joint
     double *tol=&tol_min;
     double timeout=2.0*(_max-_min)/finger.getCalibVel();
 
-    mutex.lock();
+    mtx.lock();
     IControlMode     *imod; driver.view(imod);
     IEncoders        *ienc; driver.view(ienc);
     IPositionControl *ipos; driver.view(ipos);
-    mutex.unlock();
+    mtx.unlock();
 
     // workaround
     if ((finger.getName()=="ring") || (finger.getName()=="little"))
@@ -746,16 +746,16 @@ void SpringyFingersModel::calibrateFinger(SpringyFinger &finger, const int joint
 
     finger.calibrate(reset);
 
-    mutex.lock();
+    mtx.lock();
     imod->setControlMode(joint,VOCAB_CM_POSITION);
     ipos->setRefSpeed(joint,finger.getCalibVel());
-    mutex.unlock();
+    mtx.unlock();
 
     for (int i=0; i<5; i++)
     {
-        mutex.lock();
+        mtx.lock();
         ipos->positionMove(joint,*val);
-        mutex.unlock();
+        mtx.unlock();
 
         bool done=false;
         double fbOld=std::numeric_limits<double>::max();
@@ -764,9 +764,9 @@ void SpringyFingersModel::calibrateFinger(SpringyFinger &finger, const int joint
         {
             Time::delay(0.01);
 
-            mutex.lock();
+            mtx.lock();
             double fb; ienc->getEncoder(joint,&fb);
-            mutex.unlock();
+            mtx.unlock();
 
             if (fabs(fb-fbOld)>0.5)
             {

--- a/src/modules/actionsRenderingEngine/include/iCub/VisuoThread.h
+++ b/src/modules/actionsRenderingEngine/include/iCub/VisuoThread.h
@@ -24,13 +24,13 @@
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/BufferedPort.h>
-#include <yarp/os/Semaphore.h>
 
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Image.h>
 
 #include <cv.h>
 
+#include <mutex>
 #include <string>
 #include <deque>
 #include <map>
@@ -90,10 +90,10 @@ private:
     Port                                    cmdMSRPort;
     BufferedPort<Bottle>                    recMSRPort;
 
-    Semaphore                   imgMutex;
-    Semaphore                   motMutex;
-    Semaphore                   MILMutex;
-    Semaphore                   trackMutex;
+    mutex                       imgMutex;
+    mutex                       motMutex;
+    mutex                       MILMutex;
+    mutex                       trackMutex;
 
     unsigned int                minMotionBufSize;
     unsigned int                minTrackBufSize;
@@ -154,11 +154,8 @@ public:
 
     bool isTracking()
     {
-        trackMutex.wait();
-        bool track=tracking;
-        trackMutex.post();
-
-        return track;
+        lock_guard<mutex> lck(trackMutex);
+        return tracking;
     }
 
     bool checkTracker(Vector *vec);

--- a/src/modules/actionsRenderingEngine/src/main.cpp
+++ b/src/modules/actionsRenderingEngine/src/main.cpp
@@ -414,8 +414,6 @@ Windows, Linux
 #define EXPLORE_HAND                yarp::os::createVocab('h','a','n','d')
 
 
-
-
 #define PORT_TAG_CMD                0
 #define PORT_TAG_GET                1
 
@@ -439,7 +437,6 @@ protected:
 
     Initializer                 *initializer;
 
-    Mutex                       processMutex;
     bool                        interrupted;
     volatile bool               closing;
     bool                        idle;
@@ -679,8 +676,6 @@ public:
 
     bool process(int &port_tag, Bottle &command, Bottle &reply)
     {
-        LockGuard guard(processMutex);
-
         if(closing)
         {
             reply.addVocab(NACK);

--- a/src/modules/iKinGazeCtrl/include/iCub/controller.h
+++ b/src/modules/iKinGazeCtrl/include/iCub/controller.h
@@ -19,6 +19,8 @@
 #ifndef __CONTROLLER_H__
 #define __CONTROLLER_H__
 
+#include <mutex>
+#include <condition_variable>
 #include <string>
 #include <vector>
 #include <set>
@@ -77,12 +79,13 @@ protected:
     Stamp txInfo_event;
     Stamp txInfo_debug;
 
-    Mutex mutexRun;
-    Mutex mutexChain;
-    Mutex mutexCtrl;
-    Mutex mutexData;
-    Mutex mutexLook;
-    Event eventLook;
+    mutex mutexRun;
+    mutex mutexChain;
+    mutex mutexCtrl;
+    mutex mutexData;
+    mutex mutexLook;
+    mutex mtx_eventLook;
+    condition_variable cv_eventLook;
     unsigned int period;
     bool unplugCtrlEyes;
     bool ctrlInhibited;

--- a/src/modules/iKinGazeCtrl/include/iCub/localizer.h
+++ b/src/modules/iKinGazeCtrl/include/iCub/localizer.h
@@ -19,6 +19,7 @@
 #ifndef __LOCALIZER_H__
 #define __LOCALIZER_H__
 
+#include <mutex>
 #include <string>
 
 #include <yarp/os/all.h>
@@ -43,7 +44,7 @@ using namespace iCub::iKin;
 class Localizer : public GazeComponent, public PeriodicThread
 {
 protected:
-    Mutex                 mutex;
+    mutex                 mtx;
     ExchangeData         *commData;
     BufferedPort<Bottle>  port_mono;
     BufferedPort<Bottle>  port_stereo;

--- a/src/modules/iKinGazeCtrl/include/iCub/solver.h
+++ b/src/modules/iKinGazeCtrl/include/iCub/solver.h
@@ -19,6 +19,7 @@
 #ifndef __SOLVER_H__
 #define __SOLVER_H__
 
+#include <mutex>
 #include <string>
 
 #include <yarp/os/all.h>
@@ -64,7 +65,7 @@ protected:
     ExchangeData         *commData;
     Controller           *ctrl;
     Integrator           *I;
-    Mutex                 mutex;
+    mutex                 mtx;
 
     double                orig_eye_tilt_min;
     double                orig_eye_tilt_max;
@@ -127,7 +128,7 @@ protected:
     EyePinvRefGen      *eyesRefGen;
     Localizer          *loc;
     Controller         *ctrl;    
-    Mutex               mutex;
+    mutex               mtx;
 
     unsigned int period;
     int nJointsTorso;

--- a/src/modules/iKinGazeCtrl/include/iCub/utils.h
+++ b/src/modules/iKinGazeCtrl/include/iCub/utils.h
@@ -19,6 +19,8 @@
 #ifndef __UTILS_H__
 #define __UTILS_H__
 
+#include <mutex>
+#include <condition_variable>
 #include <string>
 #include <algorithm>
 #include <utility>
@@ -55,16 +57,17 @@ class xdPort : public BufferedPort<Bottle>,
 protected:
     void *slv;
 
-    Mutex  mutex_0;
-    Mutex  mutex_1;
-    Event  triggerNeck;
-    Vector xd;
-    Vector xdDelayed;    
-    bool   isNew;
-    bool   isNewDelayed;
-    bool   locked;
-    bool   closing;
-    int    rx;
+    mutex              mutex_0;
+    mutex              mutex_1;
+    mutex              mtx_triggerNeck;
+    condition_variable cv_triggerNeck;
+    Vector             xd;
+    Vector             xdDelayed;    
+    bool               isNew;
+    bool               isNewDelayed;
+    bool               locked;
+    bool               closing;
+    int                rx;
 
     void onRead(Bottle &b) override;
     void run() override;
@@ -90,7 +93,7 @@ public:
 class ExchangeData
 {
 protected:
-    Mutex  mutex[8];
+    mutex  mtx[8];
     Vector xd,qd;
     Vector x,q,torso;
     Vector v,counterv;

--- a/src/modules/iKinGazeCtrl/src/localizer.cpp
+++ b/src/modules/iKinGazeCtrl/src/localizer.cpp
@@ -184,7 +184,7 @@ void Localizer::afterStart(bool s)
 /************************************************************************/
 void Localizer::getPidOptions(Bottle &options)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     pid->getOptions(options);
     Bottle &bDominantEye=options.addList();
     bDominantEye.addString("dominantEye");
@@ -195,7 +195,7 @@ void Localizer::getPidOptions(Bottle &options)
 /************************************************************************/
 void Localizer::setPidOptions(const Bottle &options)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     pid->setOptions(options);
     if (options.check("dominantEye"))
     {
@@ -228,7 +228,7 @@ Vector Localizer::getAbsAngles(const Vector &x)
 /************************************************************************/
 Vector Localizer::get3DPoint(const string &type, const Vector &ang)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     double azi=ang[0];
     double ele=ang[1];
     double ver=ang[2];
@@ -295,7 +295,7 @@ Vector Localizer::get3DPoint(const string &type, const Vector &ang)
 /************************************************************************/
 bool Localizer::projectPoint(const string &type, const Vector &x, Vector &px)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     if (x.length()<3)
     {
         yError("Not enough values given for the point!");
@@ -353,7 +353,7 @@ bool Localizer::projectPoint(const string &type, const Vector &x, Vector &px)
 bool Localizer::projectPoint(const string &type, const double u, const double v,
                              const double z, Vector &x)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     bool isLeft=(type=="left");
 
     Matrix  *invPrj=(isLeft?invPrjL:invPrjR);
@@ -412,7 +412,7 @@ bool Localizer::projectPoint(const string &type, const double u, const double v,
 
     if (projectPoint(type,u,v,1.0,x))
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lck(mtx);
 
         // pick up a point belonging to the plane
         Vector p0(3,0.0);
@@ -449,7 +449,7 @@ bool Localizer::projectPoint(const string &type, const double u, const double v,
 /************************************************************************/
 bool Localizer::triangulatePoint(const Vector &pxl, const Vector &pxr, Vector &x)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     if ((pxl.length()<2) || (pxr.length()<2))
     {
         yError("Not enough values given for the pixels!");
@@ -591,9 +591,9 @@ void Localizer::handleStereoInput()
                     fb=ul-cxl;
                 }
                 
-                mutex.lock();
+                mtx.lock();
                 Vector z=pid->compute(ref,fb);
-                mutex.unlock();
+                mtx.unlock();
 
                 if (projectPoint(dominantEye,u,v,z[0],fp))
                     commData->port_xd->set_xd(fp);

--- a/src/modules/iKinGazeCtrl/src/main.cpp
+++ b/src/modules/iKinGazeCtrl/src/main.cpp
@@ -562,6 +562,7 @@ Windows, Linux
 \author Ugo Pattacini, Alessandro Roncone
 */
 
+#include <mutex>
 #include <cmath>
 #include <algorithm>
 #include <fstream>
@@ -599,8 +600,8 @@ protected:
     ExchangeData    commData;
     bool            interrupting;
     bool            doSaveTweakFile;
-    Mutex           mutexContext;
-    Mutex           mutexTweak;
+    mutex           mutexContext;
+    mutex           mutexTweak;
 
     IThreeAxisGyroscopes* iGyro;
     IThreeAxisLinearAccelerometers* iAccel;
@@ -675,7 +676,7 @@ protected:
     /************************************************************************/
     void storeContext(int *id)
     {
-        LockGuard lg(mutexContext);
+        lock_guard<mutex> lg(mutexContext);
         Context &context=contextMap[contextIdCnt];
 
         // solver part
@@ -705,7 +706,7 @@ protected:
     /************************************************************************/
     bool restoreContext(const int id)
     {
-        LockGuard lg(mutexContext);
+        lock_guard<mutex> lg(mutexContext);
         auto itr=contextMap.find(id);
         if (itr!=contextMap.end())
         {
@@ -742,7 +743,7 @@ protected:
     {
         if (contextIdList!=nullptr)
         {
-            LockGuard lg(mutexContext);
+            lock_guard<mutex> lg(mutexContext);
             for (int i=0; i<contextIdList->size(); i++)
             {
                 int id=contextIdList->get(i).asInt();
@@ -798,7 +799,7 @@ protected:
     /************************************************************************/
     bool tweakSet(const Bottle &options)
     {
-        LockGuard lg(mutexTweak);
+        lock_guard<mutex> lg(mutexTweak);
         if (Bottle *pB=options.find("camera_intrinsics_left").asList())
         {
             Matrix Prj=zeros(3,4); int w,h;
@@ -945,7 +946,7 @@ protected:
     /************************************************************************/
     bool tweakGet(Bottle &options)
     {
-        LockGuard lg(mutexTweak);
+        lock_guard<mutex> lg(mutexTweak);
         Bottle &intrinsicsLeft=options.addList();
         intrinsicsLeft.addString("camera_intrinsics_left");
         Bottle &intrinsicsLeftValues=intrinsicsLeft.addList();
@@ -2142,7 +2143,7 @@ public:
     {
         if (doSaveTweakFile)
         {
-            LockGuard lg(mutexTweak);
+            lock_guard<mutex> lg(mutexTweak);
             saveTweakFile();
             doSaveTweakFile=false;
         }

--- a/src/modules/iKinGazeCtrl/src/solver.cpp
+++ b/src/modules/iKinGazeCtrl/src/solver.cpp
@@ -135,7 +135,7 @@ EyePinvRefGen::~EyePinvRefGen()
 /************************************************************************/
 void EyePinvRefGen::minAllowedVergenceChanged()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     lim(2,0)=commData->minAllowedVergence;
     I->setLim(lim);
     orig_lim=lim;
@@ -145,7 +145,7 @@ void EyePinvRefGen::minAllowedVergenceChanged()
 /************************************************************************/
 bool EyePinvRefGen::bindEyes(const double ver)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     if (ver>=0.0)
     {
         double ver_rad=std::max(CTRL_DEG2RAD*ver,commData->minAllowedVergence);
@@ -181,7 +181,7 @@ bool EyePinvRefGen::bindEyes(const double ver)
 /************************************************************************/
 bool EyePinvRefGen::clearEyes()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     if (commData->eyesBoundVer>=0.0)
     {        
         commData->eyesBoundVer=-1.0;
@@ -217,7 +217,7 @@ void EyePinvRefGen::manageBindEyes(const double ver)
 /************************************************************************/
 Vector EyePinvRefGen::getCounterRotGain()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     return counterRotGain;
 }
 
@@ -225,7 +225,7 @@ Vector EyePinvRefGen::getCounterRotGain()
 /************************************************************************/
 void EyePinvRefGen::setCounterRotGain(const Vector &gain)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     size_t len=std::min(counterRotGain.length(),gain.length());
     for (size_t i=0; i<len; i++)
         counterRotGain[i]=gain[i];
@@ -302,7 +302,7 @@ void EyePinvRefGen::run()
 {
     if (genOn)
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lck(mtx);
         double timeStamp;
 
         // read encoders
@@ -568,7 +568,7 @@ Solver::~Solver()
 /************************************************************************/
 void Solver::bindNeckPitch(const double min_deg, const double max_deg)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     double min_rad=sat(CTRL_DEG2RAD*min_deg,neckPitchMin,neckPitchMax);
     double max_rad=sat(CTRL_DEG2RAD*max_deg,neckPitchMin,neckPitchMax);
 
@@ -582,7 +582,7 @@ void Solver::bindNeckPitch(const double min_deg, const double max_deg)
 /************************************************************************/
 void Solver::bindNeckRoll(const double min_deg, const double max_deg)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     double min_rad=sat(CTRL_DEG2RAD*min_deg,neckRollMin,neckRollMax);
     double max_rad=sat(CTRL_DEG2RAD*max_deg,neckRollMin,neckRollMax);
 
@@ -596,7 +596,7 @@ void Solver::bindNeckRoll(const double min_deg, const double max_deg)
 /************************************************************************/
 void Solver::bindNeckYaw(const double min_deg, const double max_deg)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     double min_rad=sat(CTRL_DEG2RAD*min_deg,neckYawMin,neckYawMax);
     double max_rad=sat(CTRL_DEG2RAD*max_deg,neckYawMin,neckYawMax);
 
@@ -610,7 +610,7 @@ void Solver::bindNeckYaw(const double min_deg, const double max_deg)
 /************************************************************************/
 void Solver::getCurNeckPitchRange(double &min_deg, double &max_deg)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     min_deg=CTRL_RAD2DEG*(*chainNeck)(0).getMin();
     max_deg=CTRL_RAD2DEG*(*chainNeck)(0).getMax();
 }
@@ -619,7 +619,7 @@ void Solver::getCurNeckPitchRange(double &min_deg, double &max_deg)
 /************************************************************************/
 void Solver::getCurNeckRollRange(double &min_deg, double &max_deg)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     min_deg=CTRL_RAD2DEG*(*chainNeck)(1).getMin();
     max_deg=CTRL_RAD2DEG*(*chainNeck)(1).getMax();
 }
@@ -628,7 +628,7 @@ void Solver::getCurNeckRollRange(double &min_deg, double &max_deg)
 /************************************************************************/
 void Solver::getCurNeckYawRange(double &min_deg, double &max_deg)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     min_deg=CTRL_RAD2DEG*(*chainNeck)(2).getMin();
     max_deg=CTRL_RAD2DEG*(*chainNeck)(2).getMax();
 }
@@ -637,7 +637,7 @@ void Solver::getCurNeckYawRange(double &min_deg, double &max_deg)
 /************************************************************************/
 void Solver::clearNeckPitch()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     (*chainNeck)(0).setMin(neckPitchMin);
     (*chainNeck)(0).setMax(neckPitchMax);
 
@@ -648,7 +648,7 @@ void Solver::clearNeckPitch()
 /************************************************************************/
 void Solver::clearNeckRoll()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     (*chainNeck)(1).setMin(neckRollMin);
     (*chainNeck)(1).setMax(neckRollMax);
 
@@ -659,7 +659,7 @@ void Solver::clearNeckRoll()
 /************************************************************************/
 void Solver::clearNeckYaw()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
     (*chainNeck)(2).setMin(neckYawMin);
     (*chainNeck)(2).setMax(neckYawMax);
 
@@ -776,7 +776,7 @@ void Solver::run()
     typedef enum { ctrl_off, ctrl_wait, ctrl_on } cstate;
     static cstate state_=ctrl_off;
 
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
 
     // get the current target
     Vector xd=commData->port_xd->get_xdDelayed();
@@ -880,7 +880,7 @@ void Solver::suspend()
 /************************************************************************/
 void Solver::resume()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lck(mtx);
 
     // read encoders
     getFeedback(fbTorso,fbHead,drvTorso,drvHead,commData);

--- a/src/modules/positionDirectControl/positionDirectThread.cpp
+++ b/src/modules/positionDirectControl/positionDirectThread.cpp
@@ -42,7 +42,7 @@ void positionDirectControlThread::run()
                 1000.0*getEstimatedUsed());
         resetStat();
     }
-    _mutex.wait();
+    std::lock_guard<std::mutex> lck(_mutex);
 
     //read the position targets
     yarp::os::Bottle *bot = command_port.read(false);
@@ -64,7 +64,6 @@ void positionDirectControlThread::run()
     }
     else
     {
-        _mutex.post();
         return;
     }
 
@@ -109,8 +108,6 @@ void positionDirectControlThread::run()
     idir->setPositions(control_joints, control_joints_list, targets.data());
 
     yDebug() << curr_time << targets[0] << targets[1] << targets[2];
-    _mutex.post();
-
 }
 
 bool positionDirectControlThread::threadInit()
@@ -249,16 +246,12 @@ void positionDirectControlThread::go()
 
 void positionDirectControlThread::setVel(int i, double vel)
 {
-    _mutex.wait();
-
-    _mutex.post();
+    std::lock_guard<std::mutex> lck(_mutex);
 }
 
 void positionDirectControlThread::setGain(int i, double gain)
 {
-    _mutex.wait();
-
-    _mutex.post();
+    std::lock_guard<std::mutex> lck(_mutex);
 }
 
 

--- a/src/modules/positionDirectControl/positionDirectThread.h
+++ b/src/modules/positionDirectControl/positionDirectThread.h
@@ -6,10 +6,10 @@
 #ifndef __POSDIRCONTROLTHREAD__
 #define __POSDIRCONTROLTHREAD__
 
+#include <mutex>
 #include <string>
 
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
@@ -40,7 +40,7 @@ private:
     yarp::sig::Vector prev_targets;
 
     yarp::sig::Vector error;
-    yarp::os::Semaphore _mutex;
+    std::mutex _mutex;
 
     bool suspended;
 

--- a/src/modules/templatePFTracker/include/iCub/particleFilter.h
+++ b/src/modules/templatePFTracker/include/iCub/particleFilter.h
@@ -25,7 +25,6 @@
 #include <yarp/os/Thread.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Time.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Image.h>
@@ -35,6 +34,7 @@
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
 
+#include <mutex>
 #include <time.h>
 #include <string>
 #include <iostream>
@@ -147,13 +147,12 @@ private:
     yarp::sig::Vector targetTemp;
     //string containing module name
     std::string moduleName;
-    yarp::os::Semaphore targetMutex, averageMutex;
+    std::mutex targetMutex, averageMutex, templateMutex;
 
     std::deque< TemplateStruct > tempList;
 
     bool                        updateNeeded;
     TemplateStruct              bestTempl;
-    yarp::os::Semaphore         templateMutex;
     yarp::os::Stamp             targetStamp;
 
     typedef struct params 

--- a/src/modules/velocityControl/velControlThread.cpp
+++ b/src/modules/velocityControl/velControlThread.cpp
@@ -44,7 +44,7 @@ void velControlThread::run()
                 1000.0*getEstimatedUsed());
         resetStat();
     }
-    _mutex.wait();
+    std::lock_guard<std::mutex> lck(_mutex);
 
     ////getting new commands from the fast command port
     //this command receives also feedforward velocities
@@ -153,8 +153,6 @@ void velControlThread::run()
             }
         }
     }
-    _mutex.post();
-
 }
 
 bool velControlThread::threadInit()
@@ -297,15 +295,14 @@ void velControlThread::setRef(int i, double pos)
 {
     yInfo("Setting new target %d to %lf\n", i, pos);
 
-    _mutex.wait();
+    std::lock_guard<std::mutex> lck(_mutex);
     targets(i)=pos;
     ffVelocities(i)=0;
-    _mutex.post();
 }
 
 void velControlThread::setVel(int i, double vel)
 {
-    _mutex.wait();
+    std::lock_guard<std::mutex> lck(_mutex);
 
     if((vel > 0.0) && (vel < MAX_SPEED) && (i>=0) && (i<nJoints))
     {
@@ -314,13 +311,11 @@ void velControlThread::setVel(int i, double vel)
     }
     else
         yError("Impossible to set max vel higher than %f\n",MAX_SPEED);
-
-    _mutex.post();
 }
 
 void velControlThread::setGain(int i, double gain)
 {
-    _mutex.wait();
+    std::lock_guard<std::mutex> lck(_mutex);
 
     if (gain>MAX_GAIN)
         gain=MAX_GAIN;
@@ -332,8 +327,6 @@ void velControlThread::setGain(int i, double gain)
     }
     else
         yError("Cannot set gain of joint %d\n",i);
-
-    _mutex.post();
 }
 
 

--- a/src/modules/velocityControl/velControlThread.h
+++ b/src/modules/velocityControl/velControlThread.h
@@ -6,10 +6,10 @@
 #ifndef __VELCONTROLTHREAD__
 #define __VELCONTROLTHREAD__
 
+#include <mutex>
 #include <string>
 
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
@@ -48,7 +48,7 @@ private:
 
     int nb_void_loops;
 
-    yarp::os::Semaphore _mutex;
+    std::mutex _mutex;
 
     int control_rate; //in ms
 

--- a/src/tools/depth2kin/include/module.h
+++ b/src/tools/depth2kin/include/module.h
@@ -18,6 +18,7 @@
 #ifndef __DEPTH2KIN_MODULE_H__
 #define __DEPTH2KIN_MODULE_H__
 
+#include <mutex>
 #include <string>
 #include <deque>
 
@@ -75,7 +76,7 @@ protected:
     ICartesianControl *iarm;
     IGazeControl      *igaze;
         
-    Mutex mutex;
+    mutex mtx;
     iCubFinger finger;
     Vector curExplorationCenter;
 

--- a/src/tools/trajectoryPlayer/utils.cpp
+++ b/src/tools/trajectoryPlayer/utils.cpp
@@ -26,7 +26,6 @@
 
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Thread.h>
 

--- a/src/tools/trajectoryPlayer/utils.h
+++ b/src/tools/trajectoryPlayer/utils.h
@@ -26,7 +26,6 @@
 
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Thread.h>
 


### PR DESCRIPTION
This PR replaces `yarp::os::Semaphore`, `yarp::os::Mutex` and `yarp::os::LockGuard` with the STD counterparts.