### PR TITLE
EmbObj uses std::mutex + std::condition_variable

### DIFF
--- a/src/libraries/icubmod/embObjAnalog/embObjAnalogSensor.cpp
+++ b/src/libraries/icubmod/embObjAnalog/embObjAnalogSensor.cpp
@@ -1182,11 +1182,10 @@ int embObjAnalogSensor::read(yarp::sig::Vector &out)
 {
     // This method gives analogdata to the analogServer
 
-      mutex.wait();
+      std::lock_guard<std::mutex> lck(mtx);
 
       if (!analogdata)
       {
-          mutex.post();
           return false;
       }
 
@@ -1212,7 +1211,6 @@ int embObjAnalogSensor::read(yarp::sig::Vector &out)
                   counterError++;
               } break;
           }
-          mutex.post();
           return status;
       }
 
@@ -1221,8 +1219,6 @@ int embObjAnalogSensor::read(yarp::sig::Vector &out)
       {
           out[k]=(*analogdata)[k];
       }
-
-      mutex.post();
     
     return status;
 }
@@ -1354,14 +1350,12 @@ bool embObjAnalogSensor::fillDatOfStrain(void *as_array_raw)
     }
 
     // lock analogdata
-    mutex.wait();
+    std::lock_guard<std::mutex> lck(mtx);
 
     double *_buffer = this->analogdata->getBuffer();
 
     if(NULL == _buffer)
     {
-        // unlock analogdata
-        mutex.post();
         return false;
     }
 
@@ -1386,9 +1380,6 @@ bool embObjAnalogSensor::fillDatOfStrain(void *as_array_raw)
         }
     }
      
-    // unlock analogdata
-    mutex.post();
-
     return true;
 }
 
@@ -1408,13 +1399,12 @@ bool embObjAnalogSensor::fillDatOfMais(void *as_array_raw)
         return false;
     }
 
-    mutex.wait();
+    std::lock_guard<std::mutex> lck(mtx);
 
     double *_buffer = this->analogdata->getBuffer();
 
     if(NULL == _buffer)
     {
-        mutex.post();
         return false;
     }
 
@@ -1426,8 +1416,6 @@ bool embObjAnalogSensor::fillDatOfMais(void *as_array_raw)
         // Get the kth element of the array
         _buffer[k] = (double)val;
     }
-
-    mutex.post();
 
     return true;
 }
@@ -1446,14 +1434,12 @@ bool embObjAnalogSensor::fillDatOfInertial(void *inertialdata)
         return(true);
     }
    
-    mutex.wait();
+    std::lock_guard<std::mutex> lck(mtx);
 
     double *_buffer = this->analogdata->getBuffer();
 
     if(NULL == _buffer)
     {
-        // unlock analogdata
-        mutex.post();
         return false;
     }
 
@@ -1484,8 +1470,6 @@ bool embObjAnalogSensor::fillDatOfInertial(void *inertialdata)
         _buffer[firstpos+4] = (double) status->data.y;
         _buffer[firstpos+5] = (double) status->data.z;
     }
-
-    mutex.post();
 
     return true;
 #endif

--- a/src/libraries/icubmod/embObjAnalog/embObjAnalogSensor.h
+++ b/src/libraries/icubmod/embObjAnalog/embObjAnalogSensor.h
@@ -5,10 +5,10 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/PeriodicThread.h>
 #include <string>
 #include <list>
+#include <mutex>
 
 #include <iCub/FactoryInterface.h>
 #include <iCub/LoggerInterfaces.h>
@@ -136,7 +136,7 @@ private:
 
     double timeStamp;
     double* scaleFactor;
-    yarp::os::Semaphore mutex;
+    std::mutex mtx;
 
 private:
 

--- a/src/libraries/icubmod/embObjFTsensor/eo_ftsens_privData.h
+++ b/src/libraries/icubmod/embObjFTsensor/eo_ftsens_privData.h
@@ -9,8 +9,9 @@
 #ifndef __eo_ftsens_privData_h__
 #define __eo_ftsens_privData_h__
 
-#include "embObjGeneralDevPrivData.h"
+#include <mutex>
 
+#include "embObjGeneralDevPrivData.h"
 
 #include "serviceParser.h"
 
@@ -26,7 +27,7 @@ public:
     
     enum { strain_Channels = 6, strain_FormatData = 16 };
     
-    yarp::os::Semaphore mutex;
+    std::mutex mtx;
     std::string devicename;
     std::vector<double> analogdata;
     std::vector<double> offset;

--- a/src/libraries/icubmod/embObjInertials/embObjInertials.cpp
+++ b/src/libraries/icubmod/embObjInertials/embObjInertials.cpp
@@ -614,8 +614,7 @@ int embObjInertials::read(yarp::sig::Vector &out)
         return false;
     }
 
-    mutex.wait();
-
+    std::lock_guard<std::mutex> lck(mtx);
 
     // errors are not handled for now... it'll always be OK!!
     if (status != IAnalogSensor::AS_OK)
@@ -639,7 +638,6 @@ int embObjInertials::read(yarp::sig::Vector &out)
               counterError++;
             } break;
         }
-        mutex.post();
         return status;
     }
 
@@ -648,9 +646,6 @@ int embObjInertials::read(yarp::sig::Vector &out)
     {
         out[k] = analogdata[k];
     }
-
-
-    mutex.post();
 
     return status;
 
@@ -732,7 +727,7 @@ bool embObjInertials::update(eOprotID32_t id32, double timestamp, void* rxdata)
         return(true);
     }
 
-    mutex.wait();
+    std::lock_guard<std::mutex> lck(mtx);
 
 #if defined(EMBOBJINERTIALS_PUBLISH_OLDSTYLE)
 
@@ -756,8 +751,6 @@ bool embObjInertials::update(eOprotID32_t id32, double timestamp, void* rxdata)
     analogdata[firstpos+3] = (double) status->data.z;
 
 #endif
-
-    mutex.post();
 
     return true;
 }
@@ -846,7 +839,7 @@ bool embObjInertials::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig:
         return false;
     }
 
-    mutex.wait();
+    std::lock_guard<std::mutex> lck(mtx);
 
     int firstpos = 2 + inertials_Channels*(gyrSensors[sens_index]);
     timestamp = analogdata[firstpos+2];
@@ -854,8 +847,6 @@ bool embObjInertials::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig:
     out[0] = analogdata[firstpos+3];
     out[1] = analogdata[firstpos+4];
     out[2] = analogdata[firstpos+5];
-
-    mutex.post();
 
     return true;
 }
@@ -898,7 +889,7 @@ bool embObjInertials::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, 
         return false;
     }
 
-    mutex.wait();
+    std::lock_guard<std::mutex> lck(mtx);
 
     int firstpos = 2 + inertials_Channels*(accSensors[sens_index]);
     timestamp = analogdata[firstpos+2];
@@ -907,13 +898,8 @@ bool embObjInertials::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, 
     out[1] = analogdata[firstpos+4];
     out[2] = analogdata[firstpos+5];
 
-    mutex.post();
-
     return true;
-
 }
-
-
 
 
 // eof

--- a/src/libraries/icubmod/embObjInertials/embObjInertials.h
+++ b/src/libraries/icubmod/embObjInertials/embObjInertials.h
@@ -5,10 +5,10 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/PeriodicThread.h>
 #include <string>
 #include <list>
+#include <mutex>
 
 #include <iCub/FactoryInterface.h>
 #include <iCub/LoggerInterfaces.h>
@@ -117,7 +117,7 @@ private:
     // parameters
     servConfigInertials_t serviceConfig;
 
-    mutable yarp::os::Semaphore mutex;
+    mutable std::mutex mtx;
 
     vector<double> analogdata;
     vector<uint16_t> gyrSensors;

--- a/src/libraries/icubmod/embObjLib/FeatureInterface.cpp
+++ b/src/libraries/icubmod/embObjLib/FeatureInterface.cpp
@@ -18,7 +18,6 @@
 
 
 #include <yarp/os/Time.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/LogStream.h>
 
 

--- a/src/libraries/icubmod/embObjLib/ethManager.cpp
+++ b/src/libraries/icubmod/embObjLib/ethManager.cpp
@@ -78,12 +78,6 @@ using namespace eth;
 
 
 TheEthManager* TheEthManager::handle = NULL;
-yarp::os::Semaphore TheEthManager::managerSem = 1;
-
-yarp::os::Semaphore TheEthManager::rxSem = 1;
-yarp::os::Semaphore TheEthManager::txSem = 1;
-
-
 
 TheEthManager::TheEthManager()
 {
@@ -160,7 +154,7 @@ TheEthManager *TheEthManager::instance()
     yTrace();
     // marco.accame: in here we dont use this->lock() because if object does not already exists, the function does (?) not exist.
     // much better using the static semaphore instead
-    managerSem.wait();
+    std::lock_guard<std::mutex> lck(managerSem);
     if (NULL == handle)
     {
         yTrace() << "Calling EthManager Constructor";
@@ -170,8 +164,6 @@ TheEthManager *TheEthManager::instance()
         else
             feat_Initialise(static_cast<void*>(handle)); // we give the pointer to the feature-interface c module
     }
-    managerSem.post();
-
     return handle;
 }
 
@@ -715,11 +707,11 @@ bool TheEthManager::lock(bool on)
 {
     if(on)
     {
-        managerSem.wait();
+        managerSem.lock();
     }
     else
     {
-        managerSem.post();
+        managerSem.unlock();
     }
 
     return true;
@@ -730,11 +722,11 @@ bool TheEthManager::lockTX(bool on)
 {
     if(on)
     {
-        txSem.wait();
+        txSem.lock();
     }
     else
     {
-        txSem.post();
+        txSem.unlock();
     }
 
     return true;
@@ -745,11 +737,11 @@ bool TheEthManager::lockRX(bool on)
 {
     if(on)
     {
-        rxSem.wait();
+        rxSem.lock();
     }
     else
     {
-        rxSem.post();
+        rxSem.unlock();
     }
 
     return true;
@@ -759,13 +751,13 @@ bool TheEthManager::lockTXRX(bool on)
 {
     if(on)
     {
-        txSem.wait();
-        rxSem.wait();
+        txSem.lock();
+        rxSem.lock();
     }
     else
     {
-        rxSem.post();
-        txSem.post();
+        rxSem.unlock();
+        txSem.unlock();
     }
 
     return true;

--- a/src/libraries/icubmod/embObjLib/ethManager.cpp
+++ b/src/libraries/icubmod/embObjLib/ethManager.cpp
@@ -76,8 +76,15 @@ using namespace eth;
 
 // - class eth::TheEthManager
 
+// explicit definition of static member variables: don't remove
 
-TheEthManager* TheEthManager::handle = NULL;
+// marco.accame: std::mutex is in unlocked state after the constructor completes
+//               that is the same behaviour of the former yarp::os::Semaphore initted w/ value 1
+std::mutex TheEthManager::managerSem {}; 
+std::mutex TheEthManager::txSem {};
+std::mutex TheEthManager::rxSem {};
+
+TheEthManager* TheEthManager::handle {nullptr};
 
 TheEthManager::TheEthManager()
 {

--- a/src/libraries/icubmod/embObjLib/ethManager.h
+++ b/src/libraries/icubmod/embObjLib/ethManager.h
@@ -29,6 +29,7 @@
 #include <list>
 #include <string>
 #include <stdio.h>
+#include <mutex>
 //#include <map>
 
 
@@ -43,7 +44,6 @@
 
 // YARP includes
 #include <yarp/os/Bottle.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Port.h>
 
@@ -162,10 +162,10 @@ namespace eth {
         void initEOYsystem(void);
 
         // this semaphore is used to ....
-        static yarp::os::Semaphore managerSem;
+        static std::mutex managerSem;
         // the following two semaphore are used separately or together to stop tx and rx if a change is done on ethboards (in startup and shutdown phases)
-        static yarp::os::Semaphore txSem;
-        static yarp::os::Semaphore rxSem;
+        static std::mutex txSem;
+        static std::mutex rxSem;
 
         static eth::TheEthManager* handle;
 

--- a/src/libraries/icubmod/embObjLib/ethResource.cpp
+++ b/src/libraries/icubmod/embObjLib/ethResource.cpp
@@ -39,7 +39,6 @@ EthResource::EthResource()
 {
     ethManager                  = NULL;
     isInRunningMode             = false;
-    objLock                     = new Semaphore(1);
 
     verifiedBoardPresence       = false;
     askedBoardVersion           = false;
@@ -84,8 +83,6 @@ EthResource::EthResource()
 EthResource::~EthResource()
 {
     ethManager = NULL;
-    delete objLock;
-
 
     // Delete every initialized can_string_eth object
     for(int i=0; i<16; i++)
@@ -101,9 +98,9 @@ EthResource::~EthResource()
 bool EthResource::lock(bool on)
 {
     if(true == on)
-        objLock->wait();
+        objLock.lock();
     else
-        objLock->post();
+        objLock.unlock();
 
     return true;
 }

--- a/src/libraries/icubmod/embObjLib/ethResource.h
+++ b/src/libraries/icubmod/embObjLib/ethResource.h
@@ -24,13 +24,13 @@
 #ifndef _ETHRESOURCE_H_
 #define _ETHRESOURCE_H_
 
+#include <mutex>
 
 #include <abstractEthResource.h>
 #include <hostTransceiver.hpp>
 
 #include <ethMonitorPresence.h>
 #include <EoBoards.h>
-#include <yarp/os/Semaphore.h>
 
 #include <ethManager.h>
 
@@ -105,7 +105,7 @@ namespace eth {
 
         bool isInRunningMode;
 
-        yarp::os::Semaphore* objLock;
+        std::mutex          objLock;
 
 
 

--- a/src/libraries/icubmod/embObjLib/fakeEthResource.cpp
+++ b/src/libraries/icubmod/embObjLib/fakeEthResource.cpp
@@ -49,7 +49,6 @@ FakeEthResource::FakeEthResource()
 
     ethManager                  = NULL;
     isInRunningMode             = false;
-    objLock                     = new Semaphore(1);
 
     verifiedBoardPresence       = false;
     verifiedBoardTransceiver    = false;
@@ -65,16 +64,14 @@ FakeEthResource::FakeEthResource()
 FakeEthResource::~FakeEthResource()
 {
     ethManager = NULL;
-
-    delete objLock;
 }
 
 bool FakeEthResource::lock(bool on)
 {
     if(true == on)
-        objLock->wait();
+        objLock.lock();
     else
-        objLock->post();
+        objLock.unlock();
 
     return true;
 }

--- a/src/libraries/icubmod/embObjLib/fakeEthResource.h
+++ b/src/libraries/icubmod/embObjLib/fakeEthResource.h
@@ -24,10 +24,10 @@
 #define _FAKEETHRESOURCE_H_
 
 
+#include <mutex>
 
 #include<abstractEthResource.h>
 
-#include <yarp/os/Semaphore.h>
 #include <ethManager.h>
 
 
@@ -104,7 +104,7 @@ namespace eth {
         double            lastRecvMsgTimestamp;   //! stores the system time of the last received message, gettable with getLastRecvMsgTimestamp()
         bool              isInRunningMode;        //!< say if goToRun cmd has been sent to EMS
 
-        yarp::os::Semaphore* objLock;
+        std::mutex          objLock;
 
         bool                verifiedEPprotocol[eoprot_endpoints_numberof];
         bool                verifiedBoardPresence;

--- a/src/libraries/icubmod/embObjLib/hostTransceiver.cpp
+++ b/src/libraries/icubmod/embObjLib/hostTransceiver.cpp
@@ -63,9 +63,9 @@ bool HostTransceiver::lock_transceiver(bool on)
 {
 #if !defined(HOSTTRANSCEIVER_USE_INTERNAL_MUTEXES)
     if(on)
-        htmtx->wait();
+        htmtx.lock();
     else
-        htmtx->post();
+        htmtx.unlock();
 #endif
     return true;
 }
@@ -77,9 +77,9 @@ bool HostTransceiver::lock_nvs(bool on)
 {
 #if !defined(HOSTTRANSCEIVER_USE_INTERNAL_MUTEXES)
     if(on)
-        nvmtx->wait();
+        nvmtx.lock();
     else
-        nvmtx->post();
+        nvmtx.unlock();
 #endif
     return true;
 }
@@ -109,21 +109,11 @@ HostTransceiver::HostTransceiver():delayAfterROPloadingFailure(0.001) // 1ms
 
     capacityofTXpacket = defMaxSizeOfTXpacket;
     maxSizeOfROP = defMaxSizeOfROP;
-
-#if !defined(HOSTTRANSCEIVER_USE_INTERNAL_MUTEXES)
-    htmtx = new Semaphore(1);
-    nvmtx = new Semaphore(1);
-#endif
 }
 
 
 HostTransceiver::~HostTransceiver()
 {
-#if !defined(HOSTTRANSCEIVER_USE_INTERNAL_MUTEXES)
-    delete htmtx;
-    delete nvmtx;
-#endif
-
     if(NULL != p_RxPkt)
     {
         eo_packet_Delete(p_RxPkt);

--- a/src/libraries/icubmod/embObjLib/hostTransceiver.hpp
+++ b/src/libraries/icubmod/embObjLib/hostTransceiver.hpp
@@ -45,8 +45,7 @@
 //#include "EOpacket.h"
 #include "EoProtocol.h"
 
-
-#include <yarp/os/Semaphore.h>
+#include <mutex>
 
 #include <yarp/os/Searchable.h>
 
@@ -142,11 +141,11 @@ namespace eth {
         eOprotBRD_t get_protBRDnumber(void);    // the number in range [0, max-1]
 
         bool lock_transceiver(bool on);
-        yarp::os::Semaphore *htmtx;
+        std::mutex htmtx;
 
 
         bool lock_nvs(bool on);
-        yarp::os::Semaphore *nvmtx;
+        std::mutex nvmtx;
 
 
         bool addSetROP__(const eOprotID32_t id32, const void* data, const uint32_t signature, bool writelocalrxcache = false);

--- a/src/libraries/icubmod/embObjMais/embObjMais.cpp
+++ b/src/libraries/icubmod/embObjMais/embObjMais.cpp
@@ -439,8 +439,7 @@ int embObjMais::read(yarp::sig::Vector &out)
         return false;
     }
 
-    mutex.wait();
-
+    std::lock_guard<std::mutex> lck(mtx);
 
     // errors are not handled for now... it'll always be OK!!
     if (status != IAnalogSensor::AS_OK)
@@ -464,7 +463,6 @@ int embObjMais::read(yarp::sig::Vector &out)
                 counterError++;
             } break;
         }
-        mutex.post();
         return status;
     }
 
@@ -473,9 +471,6 @@ int embObjMais::read(yarp::sig::Vector &out)
     {
         out[k] = analogdata[k];
     }
-
-
-    mutex.post();
 
     return status;
 }
@@ -564,7 +559,7 @@ bool embObjMais::update(eOprotID32_t id32, double timestamp, void* rxdata)
         return false;
     }
 
-    mutex.wait();
+    std::lock_guard<std::mutex> lck(mtx);
 
     for (size_t k = 0; k<analogdata.size(); k++)
     {
@@ -576,8 +571,6 @@ bool embObjMais::update(eOprotID32_t id32, double timestamp, void* rxdata)
             analogdata[k] = (double)val;
         }
     }
-
-    mutex.post();
 
     return true;
 }

--- a/src/libraries/icubmod/embObjMais/embObjMais.h
+++ b/src/libraries/icubmod/embObjMais/embObjMais.h
@@ -6,10 +6,10 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/PeriodicThread.h>
 #include <string>
 #include <list>
+#include <mutex>
 
 #include <iCub/FactoryInterface.h>
 #include <iCub/LoggerInterfaces.h>
@@ -89,7 +89,7 @@ private:
     // parameters
     servConfigMais_t serviceConfig;
 
-    yarp::os::Semaphore mutex;
+    std::mutex mtx;
 
     vector<double> analogdata;
 

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -31,11 +31,11 @@
 using namespace std;
 
 #include <string>
+#include <mutex>
 //  Yarp stuff
 #include <yarp/os/Bottle.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardHelper.h>
 
 #include <yarp/dev/IVirtualAnalogSensor.h>
@@ -177,7 +177,7 @@ private:
     ServiceParser*             parser;
     eomc::Parser *             _mcparser;
     ControlBoardHelper*        _measureConverter;
-    yarp::os::Semaphore        _mutex;
+    std::mutex                 _mutex;
     
     bool opened; //internal state
 

--- a/src/libraries/icubmod/embObjMultiEnc/embObjMultiEnc.cpp
+++ b/src/libraries/icubmod/embObjMultiEnc/embObjMultiEnc.cpp
@@ -426,8 +426,7 @@ int embObjMultiEnc::read(yarp::sig::Vector &out)
         return false;
     }
 
-    mutex.wait();
-
+    std::lock_guard<std::mutex> lck(mtx);
 
     // errors are not handled for now... it'll always be OK!!
     if (status != IAnalogSensor::AS_OK)
@@ -451,7 +450,6 @@ int embObjMultiEnc::read(yarp::sig::Vector &out)
                 counterError++;
             } break;
         }
-        mutex.post();
         return status;
     }
 
@@ -460,9 +458,6 @@ int embObjMultiEnc::read(yarp::sig::Vector &out)
     {
         out[k] = analogdata[k];
     }
-
-
-    mutex.post();
 
     return status;
 }
@@ -547,12 +542,11 @@ bool embObjMultiEnc::update(eOprotID32_t id32, double timestamp, void* rxdata)
     
     int startindex = joint * numofencperjoint; 
     
-    mutex.wait();
+    std::lock_guard<std::mutex> lck(mtx);
     for(int i=0; i< numofencperjoint; i++)
     {
         analogdata[startindex + i]=((double) multienc[i])/encoderConversionFactor[startindex + i];
     }
-    mutex.post();
 
     return true;
 }

--- a/src/libraries/icubmod/embObjMultiEnc/embObjMultiEnc.h
+++ b/src/libraries/icubmod/embObjMultiEnc/embObjMultiEnc.h
@@ -5,10 +5,10 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/PeriodicThread.h>
 #include <string>
 #include <list>
+#include <mutex>
 
 #include <iCub/FactoryInterface.h>
 #include <iCub/LoggerInterfaces.h>
@@ -94,7 +94,7 @@ private:
     // parameters
     servConfigMais_t serviceConfig;
 
-    yarp::os::Semaphore mutex;
+    std::mutex mtx;
 
     vector<double> analogdata;
     vector<double> encoderConversionFactor;

--- a/src/libraries/icubmod/embObjSkin/embObjSkin.h
+++ b/src/libraries/icubmod/embObjSkin/embObjSkin.h
@@ -22,9 +22,9 @@
 #define __EMBOBJSKIN_H__
 
 #include <string>
+#include <mutex>
 
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/PolyDriver.h>
@@ -88,7 +88,7 @@ protected:
     eth::TheEthManager *ethManager;
     eth::AbstractEthResource *res;
 
-    Semaphore       mutex;
+    std::mutex        mtx;
     //int             totalCardsNum;
     //std::vector<SkinPatchInfo> patchInfoList;
     size_t          sensorsNum;

--- a/src/libraries/icubmod/embObjStrain/embObjStrain.cpp
+++ b/src/libraries/icubmod/embObjStrain/embObjStrain.cpp
@@ -492,8 +492,7 @@ int embObjStrain::read(yarp::sig::Vector &out)
         return false;
     }
 
-    mutex.wait();
-
+    std::lock_guard<std::mutex> lck(mtx);
 
     // errors are not handled for now... it'll always be OK!!
     if (status != IAnalogSensor::AS_OK)
@@ -517,7 +516,6 @@ int embObjStrain::read(yarp::sig::Vector &out)
               counterError++;
             } break;
         }
-        mutex.post();
         return status;
     }
 
@@ -526,9 +524,6 @@ int embObjStrain::read(yarp::sig::Vector &out)
     {
         out[k] = analogdata[k]+offset[k];
     }
-
-
-    mutex.post();
     
     return status;
 }
@@ -565,12 +560,11 @@ int embObjStrain::getChannels()
 
 int embObjStrain::calibrateSensor()
 {
-    mutex.wait();
+    std::lock_guard<std::mutex> lck(mtx);
     for (size_t i = 0; i < analogdata.size(); i++)
     {
         offset[i] = -analogdata[i];
     }
-    mutex.post();
     return AS_OK;
 }
 
@@ -621,7 +615,7 @@ bool embObjStrain::update(eOprotID32_t id32, double timestamp, void* rxdata)
     }
 
     // lock analogdata
-    mutex.wait();
+    std::lock_guard<std::mutex> lck(mtx);
 
     for (size_t k = 0; k<analogdata.size(); k++)
     {
@@ -642,9 +636,6 @@ bool embObjStrain::update(eOprotID32_t id32, double timestamp, void* rxdata)
             }
         }
     }
-
-    // unlock analogdata
-    mutex.post();
 
     return true;
 }

--- a/src/libraries/icubmod/embObjStrain/embObjStrain.h
+++ b/src/libraries/icubmod/embObjStrain/embObjStrain.h
@@ -6,10 +6,10 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/PeriodicThread.h>
 #include <string>
 #include <list>
+#include <mutex>
 
 #include <iCub/FactoryInterface.h>
 #include <iCub/LoggerInterfaces.h>
@@ -103,7 +103,7 @@ private:
     servConfigStrain_t serviceConfig;
 
 
-    yarp::os::Semaphore mutex;
+    std::mutex mutex;
 
     vector<double> analogdata;
     vector<double> offset;

--- a/src/libraries/icubmod/embObjStrain/embObjStrain.h
+++ b/src/libraries/icubmod/embObjStrain/embObjStrain.h
@@ -103,7 +103,7 @@ private:
     servConfigStrain_t serviceConfig;
 
 
-    std::mutex mutex;
+    std::mutex mtx;
 
     vector<double> analogdata;
     vector<double> offset;

--- a/src/tools/embObjProtoTools/boardTransceiver/boardTransceiver.cpp
+++ b/src/tools/embObjProtoTools/boardTransceiver/boardTransceiver.cpp
@@ -56,7 +56,7 @@ using namespace yarp::os;
 
 EOnvSet* arrayofnvsets[16] = {NULL};
 
-BoardTransceiver::BoardTransceiver() : transMutex(1)
+BoardTransceiver::BoardTransceiver()
 {
     yTrace();
 
@@ -330,7 +330,6 @@ void BoardTransceiver::onMsgReception(uint8_t *data, uint16_t size)
 
     // protezione per la scrittura dei dati all'interno della memoria del transceiver, su ricezione di un rop.
     // il mutex e' unico per tutto il transceiver
-    //transMutex.wait();
     eo_packet_Capacity_Get(p_RxPkt, &capacityrxpkt);
     if(size > capacityrxpkt)
     {
@@ -341,7 +340,6 @@ void BoardTransceiver::onMsgReception(uint8_t *data, uint16_t size)
     eo_packet_Payload_Set(p_RxPkt, data, size);
     eo_packet_Addressing_Set(p_RxPkt, remoteipaddr, remoteipport);
     eo_transceiver_Receive(transceiver, p_RxPkt, &numofrops, &txtime);
-    //transMutex.post();
 }
 
 

--- a/src/tools/embObjProtoTools/boardTransceiver/boardTransceiver.hpp
+++ b/src/tools/embObjProtoTools/boardTransceiver/boardTransceiver.hpp
@@ -53,12 +53,10 @@
 #include <ace/SOCK_Dgram_Bcast.h>
 
 #include <yarp/os/RFModule.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/dev/DeviceDriver.h>
 
 using namespace yarp::dev;
 
-//static yarp::os::Semaphore _all_transceivers_mutex = 1;
 #define	RECV_BUFFER_SIZE        4000
 
 
@@ -89,8 +87,6 @@ protected:
 public:
     BoardTransceiver();
     ~BoardTransceiver();
-
-    yarp::os::Semaphore   transMutex;
 
     // yarp module methods
     bool createSocket(ACE_INET_Addr local_addr);


### PR DESCRIPTION
This PR comes along #612 and #613 with the aim to replace the following components:
- `yarp::os::Semaphore`
- `yarp::os::Mutex`
- `yarp::os::LockGuard`
- `yarp::os::Event`
with their STD counterparts:
- `std::mutex`
- `std::condition_variable`
- `std::lock_guard`

The PR applies the required changes only to **`embObj`**. 

Take into consideration the following notes:
- when a `yarp::os::Semaphore` was employed just like a mutex, then a `std:mutex` has been selected.
- when a `yarp::os::Semaphore` or a `yarp::os::Event` was employed for synchronization purposes, then a `std::condition_variable` has been selected.
- I've favored `std::lock_guard` over the most recent `std::scope_guard` because the latter is C++17 whereas the former is C++11 and for certain compilers we should be more conservative.

I recall here below the syntax of a `std::condition_variable`:
#### to wait:
```c++
std::mutex mtx_event;
std::condition_variable cv_event;

std::unique_lock<std::mutex> lck(mtx_event);
cv_event.wait(lck);
```
#### to post:
```c++
cv_event.notify_one();
```

There exists also the equivalent syntax that lets wait until a timeout. See for ref. https://github.com/robotology/assistive-rehab/blob/master/modules/navController/src/main.cpp#L459-L465.