### PR TITLE
icubmod uses std::mutex + std::condition_variable (4)

### DIFF
--- a/src/libraries/icubmod/canBusAnalogSensor/CanBusAnalogSensor.cpp
+++ b/src/libraries/icubmod/canBusAnalogSensor/CanBusAnalogSensor.cpp
@@ -306,9 +306,9 @@ bool CanBusAnalogSensor::close()
 
 int CanBusAnalogSensor::read(yarp::sig::Vector &out)
 {
-    mutex.wait();
+    mtx.lock();
     out=data;
-    mutex.post();
+    mtx.unlock();
 
     if( this->diagnostic )
         return status;
@@ -445,7 +445,7 @@ bool CanBusAnalogSensor::decode8(const unsigned char *msg, int msg_id, double *d
 
 void CanBusAnalogSensor::run()
 {
-    mutex.wait();
+    lock_guard<mutex> lck(mtx);
 
     unsigned int canMessages=0;
     bool ret=true; //return true by default
@@ -513,8 +513,6 @@ void CanBusAnalogSensor::run()
     {
         status=IAnalogSensor::AS_TIMEOUT;
     }
-
-    mutex.post();
 }
 
 void CanBusAnalogSensor::threadRelease()

--- a/src/libraries/icubmod/canBusAnalogSensor/CanBusAnalogSensor.h
+++ b/src/libraries/icubmod/canBusAnalogSensor/CanBusAnalogSensor.h
@@ -7,8 +7,8 @@
 #ifndef __CANBUSANALOGSENSOR_H__
 #define __CANBUSANALOGSENSOR_H__
 
+#include <mutex>
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/CanBusInterface.h>
@@ -65,7 +65,7 @@ protected:
     CanBuffer          outBuffer;
     int                canDeviceNum;
 
-    yarp::os::Semaphore mutex;
+    std::mutex mtx;
 
     unsigned int       channelsNum;
     unsigned short     boardId;

--- a/src/libraries/icubmod/canBusAnalogSensor/CanBusAnalogSensor.h
+++ b/src/libraries/icubmod/canBusAnalogSensor/CanBusAnalogSensor.h
@@ -78,7 +78,7 @@ protected:
     bool               diagnostic;
 
 public:
-    CanBusAnalogSensor(int period=20) : PeriodicThread((double)period/1000.0), mutex(1)
+    CanBusAnalogSensor(int period=20) : PeriodicThread((double)period/1000.0)
     {}
 
 

--- a/src/libraries/icubmod/canBusDoubleFTSensor/CanBusDoubleFTSensor.cpp
+++ b/src/libraries/icubmod/canBusDoubleFTSensor/CanBusDoubleFTSensor.cpp
@@ -303,9 +303,9 @@ int CanBusDoubleFTSensor::read(yarp::sig::Vector &out)
     if( overallStatus == yarp::dev::IAnalogSensor::AS_OK
         || overallStatus == yarp::dev::IAnalogSensor::AS_OVF )
     {
-        mutex.wait();
+        mtx.lock();
         out=this->outputData;
-        mutex.post();
+        mtx.unlock();
         return yarp::dev::IAnalogSensor::AS_OK;
     }
 
@@ -403,7 +403,7 @@ bool CanBusDoubleFTSensor::decode16(const unsigned char *msg, int msg_id, int se
 
 void CanBusDoubleFTSensor::run()
 {
-    mutex.wait();
+    lock_guard<mutex> lck(mtx);
 
     unsigned int canMessages=0;
     bool ret=true; //return true by default
@@ -490,8 +490,6 @@ void CanBusDoubleFTSensor::run()
         combineDoubleSensorStatus();
         combineDoubleSensorReadings();
     }
-
-    mutex.post();
 }
 
 void CanBusDoubleFTSensor::combineDoubleSensorReadings()

--- a/src/libraries/icubmod/canBusDoubleFTSensor/CanBusDoubleFTSensor.h
+++ b/src/libraries/icubmod/canBusDoubleFTSensor/CanBusDoubleFTSensor.h
@@ -7,8 +7,8 @@
 #ifndef CANBUSDOUBLEFTSENSOR_H
 #define CANBUSDOUBLEFTSENSOR_H
 
+#include <mutex>
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/CanBusInterface.h>
@@ -92,7 +92,7 @@ protected:
     CanBuffer          outBuffer;
     int                canDeviceNum;
 
-    yarp::os::Semaphore mutex;
+    std::mutex mtx;
 
     unsigned int       sensorsChannelsNum;
     unsigned int       outputChannelsNum;

--- a/src/libraries/icubmod/canBusDoubleFTSensor/CanBusDoubleFTSensor.h
+++ b/src/libraries/icubmod/canBusDoubleFTSensor/CanBusDoubleFTSensor.h
@@ -113,7 +113,7 @@ protected:
     double frontSingleDistance;
 
 public:
-    CanBusDoubleFTSensor(int period=20) : PeriodicThread((double)period/1000.0),mutex(1),overallStatus(IAnalogSensor::AS_OK)
+    CanBusDoubleFTSensor(int period=20) : PeriodicThread((double)period/1000.0),overallStatus(IAnalogSensor::AS_OK)
     {
         status[0] = IAnalogSensor::AS_OK;
         status[1] = IAnalogSensor::AS_OK;

--- a/src/libraries/icubmod/canBusInertialMTB/CanBusInertialMTB.cpp
+++ b/src/libraries/icubmod/canBusInertialMTB/CanBusInertialMTB.cpp
@@ -270,22 +270,15 @@ bool CanBusInertialMTB::close()
 
 int CanBusInertialMTB::read(yarp::sig::Vector &out)
 {
-    int tmp=0;
-    mutex.wait();
+    lock_guard<mutex> lck(mtx);
     out=data;
-    tmp=this->sharedGlobalStatus;
-    mutex.post();
-
-    return tmp;
+    return this->sharedGlobalStatus;
 }
 
 int CanBusInertialMTB::getState(int ch)
 {
-    int tmp=0;
-    mutex.wait();
-    tmp=this->sharedStatus[ch];
-    mutex.post();
-    return tmp;
+    lock_guard<mutex> lck(mtx);
+    return this->sharedStatus[ch];
 }
 
 int CanBusInertialMTB::getChannels()
@@ -482,14 +475,13 @@ void CanBusInertialMTB::run()
     }
 
     // Copy the data in the output data
-    mutex.wait();
+    lock_guard<mutex> lck(mtx);
     memcpy(data.data(), privateData.data(), sizeof(double)*privateData.size());
     for(size_t ch=0; ch < privateStatus.size(); ch++ )
     {
         this->sharedStatus[ch] =  this->privateStatus[ch];
     }
     this->sharedGlobalStatus = this->privateGlobalStatus;
-    mutex.post();
 
     return;
 }

--- a/src/libraries/icubmod/canBusInertialMTB/CanBusInertialMTB.h
+++ b/src/libraries/icubmod/canBusInertialMTB/CanBusInertialMTB.h
@@ -95,7 +95,6 @@ protected:
     int               count;
 public:
     CanBusInertialMTB(int period=20) : PeriodicThread((double)period/1000.0),
-                                       mutex(1),
                                        initted(false),
                                        count(0)
     {}

--- a/src/libraries/icubmod/canBusInertialMTB/CanBusInertialMTB.h
+++ b/src/libraries/icubmod/canBusInertialMTB/CanBusInertialMTB.h
@@ -7,8 +7,8 @@
 #ifndef __CANBUSINERTIALMTB_H__
 #define __CANBUSINERTIALMTB_H__
 
+#include <mutex>
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/CanBusInterface.h>
@@ -78,7 +78,7 @@ protected:
     CanBuffer          inBuffer;
     CanBuffer          outBuffer;
 
-    yarp::os::Semaphore mutex;
+    std::mutex mtx;
 
     std::vector<MTBInertialBoardInfo> boards;
 

--- a/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.h
+++ b/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.h
@@ -19,10 +19,10 @@
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/CanBusInterface.h>
 #include <yarp/dev/PreciselyTimed.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/PeriodicThread.h>
 #include <string>
 #include <list>
+#include <mutex>
 
 #include <iCub/FactoryInterface.h>
 #include <iCub/LoggerInterfaces.h>
@@ -220,7 +220,6 @@ public:
     {return _data;}
 };
 
-#include <yarp/os/Semaphore.h>
 typedef int AnalogDataFormat;
 
 class TBR_CanBackDoor;
@@ -256,7 +255,7 @@ private:
     short status;
     double timeStamp;
     double* scaleFactor;
-    yarp::os::Semaphore mutex;
+    std::mutex mtx;
     AnalogDataFormat dataFormat;
     yarp::os::Bottle initMsg;
     yarp::os::Bottle speedMsg;
@@ -1115,8 +1114,7 @@ protected:
 
 protected:
     void *system_resources;
-    yarp::os::Semaphore _mutex;
-    yarp::os::Semaphore _done;
+    std::mutex _mutex;
     ICanBus *canController;
 
     bool _writerequested;

--- a/src/libraries/icubmod/canBusMotionControl/ThreadTable2.cpp
+++ b/src/libraries/icubmod/canBusMotionControl/ThreadTable2.cpp
@@ -20,7 +20,7 @@
 #include "ThreadTable2.h"
 #include "canControlConstants.h"
 
-ThreadTable2::ThreadTable2():_synch(0)
+ThreadTable2::ThreadTable2()
 {
     ic=0;
     clear();

--- a/src/libraries/icubmod/canBusSkin/CanBusSkin.cpp
+++ b/src/libraries/icubmod/canBusSkin/CanBusSkin.cpp
@@ -32,7 +32,6 @@ using yarp::dev::CanMessage;
 
 
 CanBusSkin::CanBusSkin() :  PeriodicThread(0.02),
-                            mutex(1),
                             _verbose(false),
                             _isDiagnosticPresent(false)
 { }
@@ -545,12 +544,8 @@ bool CanBusSkin::close()
 
 int CanBusSkin::read(yarp::sig::Vector &out) 
 {
-    mutex.wait();
+    lock_guard<mutex> lck(mtx);
     out=data;
-//    if(_isDiagnosticPresent)
-//        diagnoseSkin();
-    mutex.post();
-
     return yarp::dev::IAnalogSensor::AS_OK;
 }
 
@@ -598,7 +593,7 @@ bool CanBusSkin::threadInit() {
 
 void CanBusSkin::run() {
 
-    mutex.wait();
+    lock_guard<mutex> lck(mtx);
 
     unsigned int canMessages = 0;
     bool res = pCanBus->canRead(inBuffer, CAN_DRIVER_BUFFER_SIZE, &canMessages);
@@ -700,7 +695,6 @@ void CanBusSkin::run() {
             }
         }
     }
-    mutex.post();
 }
 
 void CanBusSkin::threadRelease()

--- a/src/libraries/icubmod/canBusSkin/CanBusSkin.h
+++ b/src/libraries/icubmod/canBusSkin/CanBusSkin.h
@@ -7,10 +7,10 @@
 #ifndef __CANBUSSKIN_H__
 #define __CANBUSSKIN_H__
 
+#include <mutex>
 #include <string>
 
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/PolyDriver.h>
@@ -70,7 +70,7 @@ protected:
     yarp::dev::CanBuffer inBuffer;
     yarp::dev::CanBuffer outBuffer;
 
-    yarp::os::Semaphore mutex;
+    std::mutex mtx;
 
     /** The CAN net ID. */
     int netID;

--- a/src/libraries/icubmod/canBusVirtualAnalogSensor/CanBusVirtualAnalogSensor.cpp
+++ b/src/libraries/icubmod/canBusVirtualAnalogSensor/CanBusVirtualAnalogSensor.cpp
@@ -468,7 +468,7 @@ bool CanBusVirtualAnalogSensor::decode8(const unsigned char *msg, int msg_id, do
 
 void CanBusVirtualAnalogSensor::run()
 {    
-    mutex.wait();
+    std::lock_guard<std::mutex> lck(mtx);
 
     unsigned int canMessages=0;
     bool ret=true; //return true by default
@@ -564,8 +564,6 @@ void CanBusVirtualAnalogSensor::run()
     {
         status= yarp::dev::VAS_status::VAS_TIMEOUT;
     }
-
-    mutex.post();
 }
 
 void CanBusVirtualAnalogSensor::threadRelease()

--- a/src/libraries/icubmod/canBusVirtualAnalogSensor/CanBusVirtualAnalogSensor.h
+++ b/src/libraries/icubmod/canBusVirtualAnalogSensor/CanBusVirtualAnalogSensor.h
@@ -59,7 +59,7 @@ protected:
     bool               useCalibration;
 
 public:
-    CanBusVirtualAnalogSensor(int period=20) : PeriodicThread((double)period/1000.0),mutex(1)
+    CanBusVirtualAnalogSensor(int period=20) : PeriodicThread((double)period/1000.0)
     {}
     
 

--- a/src/libraries/icubmod/canBusVirtualAnalogSensor/CanBusVirtualAnalogSensor.h
+++ b/src/libraries/icubmod/canBusVirtualAnalogSensor/CanBusVirtualAnalogSensor.h
@@ -7,17 +7,15 @@
 #ifndef __CANBUS_VIRTUAL_ANALOG_SENSOR_H__
 #define __CANBUS_VIRTUAL_ANALOG_SENSOR_H__
 
-//#include <stdio.h>
 #include <string>
+#include <mutex>
 
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/IVirtualAnalogSensor.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/CanBusInterface.h>
 #include <yarp/sig/Vector.h>
-#include <string>
 
 using namespace yarp::os;
 using namespace yarp::dev;
@@ -47,7 +45,7 @@ protected:
     CanBuffer          inBuffer;
     CanBuffer          outBuffer;
    
-    yarp::os::Semaphore mutex;
+    std::mutex         mtx;
 
     unsigned int       channelsNum;
     unsigned short     boardId;
@@ -132,7 +130,7 @@ private:
     short status;
     double timeStamp;
     double* scaleFactor;
-    yarp::os::Semaphore mutex;
+    std::mutex mtx;
     AnalogDataFormat dataFormat;
     yarp::os::Bottle initMsg;
     yarp::os::Bottle speedMsg;

--- a/src/libraries/icubmod/esdSniffer/EsdMessageSniffer.h
+++ b/src/libraries/icubmod/esdSniffer/EsdMessageSniffer.h
@@ -14,10 +14,12 @@
 #ifndef __YARPEsdMessageSnifferh__
 #define __YARPEsdMessageSnifferh__
 
+#include <mutex>
+#include <condition_variable>
+
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/ControlBoardInterfacesImpl.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/Thread.h>
 
 namespace yarp{
@@ -241,8 +243,9 @@ protected:
 
 protected:
 	void *system_resources;
-    yarp::os::Semaphore _mutex;
-    yarp::os::Semaphore _done;
+    std::mutex _mutex;
+    std::mutex mtx_done;
+    std::condition_variable cv_done;
 
 	bool _writerequested;
 	bool _noreply;

--- a/src/libraries/icubmod/fakeCan/msgList.h
+++ b/src/libraries/icubmod/fakeCan/msgList.h
@@ -8,8 +8,8 @@
 #ifndef __MSGLIST__
 #define __MSGLIST__
 
+#include <mutex>
 #include <yarp/dev/CanBusInterface.h>
-#include <yarp/os/Semaphore.h>
 #include "fbCanBusMessage.h"
 
 #include <list>
@@ -19,10 +19,10 @@ typedef std::list<FCMSG>::const_iterator MsgConstIt;
 
 class MsgList: public std::list<FCMSG>
 {
-    yarp::os::Semaphore _mutex;
+    std::mutex _mutex;
 public:
-    void lock() {_mutex.wait(); }
-    void unlock() {_mutex.post(); }
+    void lock() { _mutex.lock(); }
+    void unlock() { _mutex.unlock(); }
 };
 
 #endif

--- a/src/libraries/icubmod/parametricCalibrator/parametricCalibrator.cpp
+++ b/src/libraries/icubmod/parametricCalibrator/parametricCalibrator.cpp
@@ -64,7 +64,6 @@ parametricCalibrator::parametricCalibrator() :
     zeroPosThreshold(0),
     abortCalib(false),
     isCalibrated(false),
-    calibMutex(1),
     skipCalibration(false),
     clearHwFault(false),
     n_joints(0),
@@ -595,9 +594,8 @@ bool parametricCalibrator::calibrate()
         }
         return false;
     }
-    calibMutex.wait();
+    lock_guard<mutex> lck(calibMutex);
     isCalibrated = true;
-    calibMutex.post();
     return isCalibrated;
 }
 
@@ -777,14 +775,14 @@ bool parametricCalibrator::park(DeviceDriver *dd, bool wait)
     bool ret=false;
     abortParking=false;
 
-    calibMutex.wait();
+    calibMutex.lock();
     if(!isCalibrated)
     {
         yWarning() << deviceName << ": Calling park without calibration... skipping";
-        calibMutex.post();
+        calibMutex.unlock();
         return true;
     }
-    calibMutex.post();
+    calibMutex.unlock();
 
     if(skipCalibration)
     {
@@ -957,14 +955,14 @@ bool parametricCalibrator::parkSingleJoint(int j, bool _wait)
     int nj=0;
     abortParking=false;
 
-    calibMutex.wait();
+    calibMutex.lock();
     if(!isCalibrated)
     {
         yWarning() << deviceName << ": Calling park without calibration... skipping";
-        calibMutex.post();
+        calibMutex.unlock();
         return true;
     }
-    calibMutex.post();
+    calibMutex.unlock();
 
     if(skipCalibration)
     {

--- a/src/libraries/icubmod/parametricCalibrator/parametricCalibrator.cpp
+++ b/src/libraries/icubmod/parametricCalibrator/parametricCalibrator.cpp
@@ -594,7 +594,7 @@ bool parametricCalibrator::calibrate()
         }
         return false;
     }
-    lock_guard<mutex> lck(calibMutex);
+    std::lock_guard<std::mutex> lck(calibMutex);
     isCalibrated = true;
     return isCalibrated;
 }

--- a/src/libraries/icubmod/parametricCalibrator/parametricCalibrator.h
+++ b/src/libraries/icubmod/parametricCalibrator/parametricCalibrator.h
@@ -13,10 +13,10 @@
 #ifndef __ICUB_PARAMETRIC_CALIBRATOR__
 #define __ICUB_PARAMETRIC_CALIBRATOR__
 
+#include <mutex>
 #include <string>
 #include <list>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/dev/CalibratorInterfaces.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 
@@ -96,7 +96,7 @@ public:
     virtual bool parkWholePart()  override;
 
 private:
-    yarp::os::Semaphore calibMutex;
+    std::mutex calibMutex;
 
     bool calibrate();
     bool calibrateJoint(int j);

--- a/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.h
+++ b/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.h
@@ -17,7 +17,6 @@
 #include <string>
 #include <atomic>
 #include <vector>
-#include <yarp/os/Semaphore.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/CalibratorInterfaces.h>
 #include <yarp/dev/ControlBoardInterfaces.h>

--- a/src/libraries/icubmod/sharedCan/SharedCanBus.h
+++ b/src/libraries/icubmod/sharedCan/SharedCanBus.h
@@ -82,7 +82,7 @@ public:
 
     bool pushReadMsg(CanMessage& msg)
     {
-        lock_guard<mutex> lck(synchroMutex);
+        std::lock_guard<std::mutex> lck(synchroMutex);
 
         if (nRecv>=mBufferSize)
         {
@@ -121,7 +121,7 @@ public:
         {
             waitingOnRead=true;
             synchroMutex.unlock();
-            unique_lock<mutex> lck(mtx_waitRead);
+            std::unique_lock<std::mutex> lck(mtx_waitRead);
             cv_waitRead.wait(lck);
             synchroMutex.lock();
         }

--- a/src/libraries/icubmod/sharedCan/SharedCanBus.h
+++ b/src/libraries/icubmod/sharedCan/SharedCanBus.h
@@ -15,8 +15,10 @@
 #ifndef __SHARED_CAN_BUS_H__
 #define __SHARED_CAN_BUS_H__
 
+#include <mutex>
+#include <condition_variable>
+
 #include <yarp/os/Time.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/Log.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/CanBusInterface.h>
@@ -51,7 +53,7 @@ class yarp::dev::CanBusAccessPoint :
     public DeviceDriver
 {
 public:
-    CanBusAccessPoint() : waitReadMutex(0),synchroMutex(1)
+    CanBusAccessPoint()
     {
         mSharedPhysDevice=NULL;
 
@@ -80,11 +82,10 @@ public:
 
     bool pushReadMsg(CanMessage& msg)
     {
-        synchroMutex.wait();
+        lock_guard<mutex> lck(synchroMutex);
 
         if (nRecv>=mBufferSize)
         {
-            synchroMutex.post();
             yError("recv buffer overrun (%4d > %4d)", nRecv, mBufferSize);
             return false;
         }
@@ -94,10 +95,9 @@ public:
         if (waitingOnRead)
         {
             waitingOnRead=false;
-            waitReadMutex.post();
+            cv_waitRead.notify_one();
         }
         
-        synchroMutex.post();
         return true;
     }
 
@@ -115,14 +115,15 @@ public:
 
     virtual bool canRead(CanBuffer &msgs, unsigned int size, unsigned int *nmsg, bool wait=false)
     {
-        synchroMutex.wait();
+        synchroMutex.lock();
 
         if (wait && !nRecv)
         {
             waitingOnRead=true;
-            synchroMutex.post();
-            waitReadMutex.wait();
-            synchroMutex.wait();
+            synchroMutex.unlock();
+            unique_lock<mutex> lck(mtx_waitRead);
+            cv_waitRead.wait(lck);
+            synchroMutex.lock();
         }
 
         if (nRecv)
@@ -134,13 +135,13 @@ public:
 
             *nmsg=nRecv;
             nRecv=0;
-            synchroMutex.post();
+            synchroMutex.unlock();
             return true;
         }
         else
         {
             *nmsg=0;
-            synchroMutex.post();
+            synchroMutex.unlock();
             return true;
         }
     }
@@ -164,8 +165,9 @@ public:
     /////////////////
 
 protected:
-    yarp::os::Semaphore waitReadMutex;
-    yarp::os::Semaphore synchroMutex;
+    std::mutex mtx_waitRead;
+    std::condition_variable cv_waitRead;
+    std::mutex synchroMutex;
     
     bool waitingOnRead;
 


### PR DESCRIPTION
This PR comes along #612 #613 #614 #615 #616 #617 with the aim to replace the following components:
- `yarp::os::Semaphore`
- `yarp::os::Mutex`
- `yarp::os::LockGuard`
- `yarp::os::Event`
with their STD counterparts:
- `std::mutex`
- `std::condition_variable`
- `std::lock_guard`

The PR applies the required changes to a subset of `icubmod` components.

Take into consideration the following notes:
- when a `yarp::os::Semaphore` was employed just like a mutex, then a `std:mutex` has been selected.
- when a `yarp::os::Semaphore` or a `yarp::os::Event` was employed for synchronization purposes, then a `std::condition_variable` has been selected.
- I've favored `std::lock_guard` over the most recent `std::scope_guard` because the latter is C++17 whereas the former is C++11 and for certain compilers we should be more conservative.

I recall here below the syntax of a `std::condition_variable`:
#### to wait:
```c++
std::mutex mtx_event;
std::condition_variable cv_event;

std::unique_lock<std::mutex> lck(mtx_event);
cv_event.wait(lck);
```
#### to post:
```c++
cv_event.notify_one();
```

There exists also the equivalent syntax that lets wait until a timeout. See for ref. https://github.com/robotology/assistive-rehab/blob/master/modules/navController/src/main.cpp#L459-L465.