### PR TITLE
Checker board calib

### DIFF
--- a/src/tools/stereoCalib/include/stereoCalibModule.h
+++ b/src/tools/stereoCalib/include/stereoCalibModule.h
@@ -6,7 +6,9 @@
 #include <yarp/os/Network.h>
 #include <yarp/os/Thread.h>
 #include "stereoCalibThread.h"
- 
+
+#define PATH_LEN 255
+
 using namespace std;
 using namespace yarp::os; 
 using namespace yarp::sig;
@@ -21,10 +23,11 @@ class stereoCalibModule:public RFModule
     string outputPortNameLeft;  
     string handlerPortName;
     string outputCalibPath;
+    string dir;
 
     int thresholdValue;
 
-
+    char dirName[PATH_LEN];
 
     BufferedPort<ImageOf<PixelBgr> > imageOut;
     Port handlerPort;

--- a/src/tools/stereoCalib/include/stereoCalibThread.h
+++ b/src/tools/stereoCalib/include/stereoCalibThread.h
@@ -17,6 +17,8 @@
 #include <yarp/math/Math.h>
 
 #include <iCub/iKin/iKinFwd.h>
+#include <dirent.h>
+#include <random>
 
 using namespace std;
 using namespace cv;
@@ -57,6 +59,7 @@ private:
     double version;
 
     bool standalone;
+    bool cfiShuffle;
     yarp::dev::PolyDriver polyHead;
     yarp::dev::IEncoders *posHead;
 
@@ -90,16 +93,23 @@ private:
     string boardType;
     char pathL[256];
     char pathR[256];
+    
+    string calibFileName;
+
+    string cfiFolder;
+    string cfiCalibFile;
+    int cfiReshuffle;
+
     void printMatrix(Mat &matrix);
     bool checkTS(double TSLeft, double TSRight, double th=0.08);
     void preparePath(const char * imageDir, char* pathL, char* pathR, int num);
     void saveStereoImage(const char * imageDir, const Mat& left, const Mat& right, int num);
-    void monoCalibration(const vector<string>& imageList, int boardWidth, int boardHeight, Mat &K, Mat &Dist);
-    void stereoCalibration(const vector<string>& imagelist, int boardWidth, int boardHeight,float sqsizee);
+    float monoCalibration(const vector<string>& imageList, int boardWidth, int boardHeight, Mat &K, Mat &Dist);
+    float stereoCalibration(const vector<string>& imagelist, int boardWidth, int boardHeight,float sqsizee);
     void saveCalibration(const string& extrinsicFilePath, const string& intrinsicFilePath);
     void calcChessboardCorners(Size boardSize, float squareSize, vector<Point3f>& corners);
-    bool updateIntrinsics( int width, int height, double fx, double fy,double cx, double cy, double k1, double k2, double p1, double p2, const string& groupname);
-    bool updateExtrinsics(Mat Rot, Mat Tr, const string& groupname);
+    bool updateIntrinsics( int width, int height, double fx, double fy,double cx, double cy, double k1, double k2, double p1, double p2, const string& groupname, string fileName);
+    bool updateExtrinsics(Mat Rot, Mat Tr, const string& groupname, string fileName);
     void saveImage(const char * imageDir, const Mat& left, int num);
     void stereoCalibRun();
     void monoCalibRun();
@@ -107,13 +117,15 @@ private:
 public:
 
 
-    stereoCalibThread(ResourceFinder &rf, Port* commPort, const char *imageDir);
-    void startCalib();
+    stereoCalibThread(ResourceFinder &rf, Port* commPort);
+    void startCalib(const char *imageDir);
     void stopCalib();
     bool threadInit();
     void threadRelease();
     void run(); 
     void onStop();
+    
+    void calibFromImages();
 
 };
 

--- a/src/tools/stereoCalib/src/main.cpp
+++ b/src/tools/stereoCalib/src/main.cpp
@@ -1,7 +1,7 @@
 /* 
  * Copyright (C) 2011 RobotCub Consortium
- * Author: Sean Ryan Fanello
- * email:   sean.fanello@iit.it
+ * Authors: Sean Ryan Fanello, Leandro de Souza Rosa
+ * email:   (sean.fanello, leandro.desouzarosa) @iit.it
  * website: www.robotcub.org
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any
@@ -25,9 +25,10 @@ Calibrate the iCub's stereo system (both intrinsics and extrinsics).
 
 Copyright (C) 2011 RobotCub Consortium
  
-Author: Sean Ryan Fanello
+Authors: Sean Ryan Fanello, Leandro de Souza Rosa
  
 Date: first release on 26/03/2011
+      update on 07/11/2019
 
 CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
@@ -44,6 +45,9 @@ boardHeight H
 boardSize S
 numberOfImages N
 MonoCalib value
+standalone
+cfi_shuffle
+cfi_reshuffle N
 \endcode
 
 This is the ONLY group used by the module. Other groups in your config file will be discarded. See below for the parameter description. Calibration results will be saved in the specified context (default is: $ICUB_ROOT/main/app/cameraCalibration/conf/outputCalib.ini). You should replace your old calibration file (e.g. icubEyes.ini) with this new one.
@@ -72,6 +76,18 @@ YARP libraries and OpenCV
 --MonoCalib \e Val 
 - The parameter \e Val identifies if the module has to run the stereo calibration (Val=0) or the mono calibration (Val=1). For the mono calibration connect only the camera that you want to calibrate.
 
+--calibFileName \e fileName
+- Saves the intrinsic and extrinsic calibration parameters in the fileName file (default fileName=outputCalib.ini).
+
+--standalone
+- Enables the calibration with two different cameras
+
+--cfi_shuffle
+- Shuffles the images before performing the calibration with the cfi command
+
+--cfi_reshuffle \e Num
+- Re-adds the images for calibration Num-time in a random order to create more sets for calibration. Requires cfi_shuffle.
+
 \section portsc_sec Ports Created
 - <i> /stereoCalib/cam/left:i </i> accepts the incoming images from the left eye. 
 - <i> /stereoCalib/cam/right:i </i> accepts the incoming images from the right eye. 
@@ -82,17 +98,20 @@ YARP libraries and OpenCV
 - <i> /stereoCalib/cmd </i> for terminal commands comunication. 
  Recognized remote commands:
     - [start]: Starts the calibration procedure, you have to show the chessboard image in different positions and orientations. After N times (N specified in the config file, see above). the module will run the stereo calibration
+    - [cfi]: Reads images on calibFromImages/calibImgXXX folders and performs a different stereo calibration for every N images (N specified in the config file, see above).
 
 \section in_files_sec Input Data Files
 None.
 
 \section out_data_sec Output Data Files
 outputCalib.ini 
- 
+
 \section tested_os_sec Tested OS
-Windows and Linux.
+start - Windows and Linux.
+cfi - Linux.
 
 \author Sean Ryan Fanello
+\author Leandro de Souza Rosa
 */ 
 
 #include "stereoCalibModule.h"


### PR DESCRIPTION
Modifications to enable the event-camera calibration with the flashing screen.

Some improvements on the calibration flow:
   1. Output calibration file backup.
   2. RSM values backup.
   3. Folders creation moved within the "`start`" `rpc` command.
   4. New `rpc` command that enables to perform the calibration using a set of images instead of taking new images with the camera.
   5. Few modifications on saving intrinsic and extrinsic values to reuse the functions with both `rpc` commands.
   6. Added few module options and documentation.