### PR TITLE
Add the possibility to change the color of the face expression

### DIFF
--- a/app/faceExpressions/conf/emotions_rfe.ini
+++ b/app/faceExpressions/conf/emotions_rfe.ini
@@ -16,3 +16,22 @@ E8   evi 05h 05h 05h 70h
 E9   shy 06h 06h 06h 70h
 E10  cun 07h 07h 07h 38h
 
+//number of colors
+colors 16
+
+C0   black   00h
+C1   white   01h
+C2   red     02h
+C3   lime    03h
+C4   blue    04h
+C5   yellow  05h
+C6   cyan    06h
+C7   magenta 07h
+C8   silver  08h
+C9   gray    09h
+C10  maroon  0Ah
+C11  olive   0Bh
+C12  green   0Ch
+C13  purple  0Dh
+C14  teal    0Eh
+C15  navy    0Fh

--- a/app/faceExpressions/conf/emotions_rfe.ini
+++ b/app/faceExpressions/conf/emotions_rfe.ini
@@ -35,3 +35,17 @@ C12  green   0Ch
 C13  purple  0Dh
 C14  teal    0Eh
 C15  navy    0Fh
+
+// number of bitmask expressions
+bitmask_eyebrow_emotions 4
+BM_EB0 (0 4 8 12 16)  //00011111h // neutral, happy
+BM_EB1 (1 5 9 13 17)  //00022222h // surprised
+BM_EB2 (2 6 10 14 18) //00044444h // sad
+BM_EB3 (3 7 11 15 19) //00044444h //
+
+bitmask_mouth_emotions 5
+BM_M0  (6 9 10 18)                     //00020300h // neutral
+BM_M1  (0 2 6 9 10 12 14 18)           //00045645h // happy
+BM_M2  (4 5 6 9 10 16 17 18)           //00070670h // sad
+BM_M3  (1 2 3 5 7 8 11 13 14 15 17 19) //000AE9AEh // surprised
+BM_M4  (4 5 6 9 10 16 17 18)           //00070670h // angry

--- a/src/core/emotionInterface/emotionInterface.h
+++ b/src/core/emotionInterface/emotionInterface.h
@@ -10,6 +10,8 @@
 #define __EMOTIONINTERFACE__
 
 #include <string>
+#include <yarp/os/Vocab.h>
+
 #include <yarp/os/Bottle.h>
 
 namespace iCub {
@@ -37,18 +39,20 @@ public:
 
 };
 
-#define EMOTION_VOCAB_SET           yarp::os::createVocab('s','e','t')
-#define EMOTION_VOCAB_GET           yarp::os::createVocab('g','e','t')
-#define EMOTION_VOCAB_IS            yarp::os::createVocab('i','s')
-#define EMOTION_VOCAB_FAILED        yarp::os::createVocab('f','a','i','l')
-#define EMOTION_VOCAB_OK            yarp::os::createVocab('o','k')
+constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_SET = yarp::os::createVocab('s','e','t');
+constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_GET = yarp::os::createVocab('g','e','t');
+constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_IS  = yarp::os::createVocab('i','s');
+constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_FAILED        = yarp::os::createVocab('f','a','i','l');
+constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_OK            = yarp::os::createVocab('o','k');
 
-#define EMOTION_VOCAB_MOUTH         yarp::os::createVocab('m','o','u')
-#define EMOTION_VOCAB_EYELIDS       yarp::os::createVocab('e','l','i') 
-#define EMOTION_VOCAB_LEFTEYEBROW   yarp::os::createVocab('l','e','b')
-#define EMOTION_VOCAB_RIGHTEYEBROW  yarp::os::createVocab('r','e','b')
-#define EMOTION_VOCAB_ALL           yarp::os::createVocab('a','l','l')
-#define EMOTION_VOCAB_RAW           yarp::os::createVocab('r','a','w')
+constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_MOUTH         = yarp::os::createVocab('m','o','u');
+constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_EYELIDS       = yarp::os::createVocab('e','l','i');
+constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_LEFTEYEBROW   = yarp::os::createVocab('l','e','b');
+constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_RIGHTEYEBROW  = yarp::os::createVocab('r','e','b');
+constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_ALL           = yarp::os::createVocab('a','l','l');
+constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_RAW           = yarp::os::createVocab('r','a','w');
+constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_COLOR         = yarp::os::createVocab('c','o','l');
+
 
 
 inline bool EMOTION_CHECK_FAIL(bool ok, yarp::os::Bottle& response) {

--- a/src/core/emotionInterface/emotionInterface.h
+++ b/src/core/emotionInterface/emotionInterface.h
@@ -53,6 +53,7 @@ constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_ALL           = yarp::os::createV
 constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_RAW           = yarp::os::createVocab('r','a','w');
 constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_COLOR         = yarp::os::createVocab('c','o','l');
 constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_BRIG        = yarp::os::createVocab('b','r','i','g');
+constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_MASK          = yarp::os::createVocab('m','a','s','k');
 
 
 

--- a/src/core/emotionInterface/emotionInterface.h
+++ b/src/core/emotionInterface/emotionInterface.h
@@ -52,6 +52,7 @@ constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_RIGHTEYEBROW  = yarp::os::createV
 constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_ALL           = yarp::os::createVocab('a','l','l');
 constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_RAW           = yarp::os::createVocab('r','a','w');
 constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_COLOR         = yarp::os::createVocab('c','o','l');
+constexpr  yarp::conf::vocab32_t EMOTION_VOCAB_BRIG        = yarp::os::createVocab('b','r','i','g');
 
 
 

--- a/src/core/emotionInterface/emotionInterfaceModule.cpp
+++ b/src/core/emotionInterface/emotionInterfaceModule.cpp
@@ -258,6 +258,10 @@ bool EmotionInterfaceModule::respond(const Bottle &command,Bottle &reply){
                 ok = setColor(command.get(2).toString());
                 break;
             }
+            case EMOTION_VOCAB_BRIG: {
+                ok = setBrightness(command.get(2).toString());
+                break;
+            }
             default:
                 cout << "received an unknown request after a VOCAB_SET" << endl;
                 break;
@@ -446,3 +450,12 @@ bool EmotionInterfaceModule::setColor(const std::string& cmd)
     return writePort(cmdbuffer);
 }
 
+bool EmotionInterfaceModule::setBrightness(const std::string& cmd)
+{
+    char cmdbuffer[] = {0,0,0,0};
+
+    cmdbuffer[0]= 'B';
+    cmdbuffer[1]= '0';
+    cmdbuffer[2]= cmd[0];
+    return writePort(cmdbuffer);
+}

--- a/src/core/emotionInterface/emotionInterfaceModule.cpp
+++ b/src/core/emotionInterface/emotionInterfaceModule.cpp
@@ -13,7 +13,7 @@
 
 
 void EmotionInitReport::report(const PortInfo &info) {
-    if ((emo!=NULL) && info.created && !info.incoming)
+    if ((emo!= nullptr) && info.created && !info.incoming)
         emo->initEmotion();
 }
 
@@ -43,7 +43,7 @@ bool EmotionInterfaceModule::configure(ResourceFinder& config){
     _period = config.check("period", Value(10.0), "Period for expression switching in auto mode").asDouble();
     if(_highlevelemotions == 0) 
     {
-        _emotion_table = NULL;
+        _emotion_table = nullptr;
     }
     else //allocate space for facial expression codes
     {
@@ -155,10 +155,10 @@ bool EmotionInterfaceModule::close(){
     _inputPort.close();
     _outputPort.close();
     
-    if (_emotion_table != NULL)
+    if (_emotion_table != nullptr)
     {
         delete [] _emotion_table;
-        _emotion_table = NULL;
+        _emotion_table = nullptr;
     }
 
     return true;

--- a/src/core/emotionInterface/emotionInterfaceModule.cpp
+++ b/src/core/emotionInterface/emotionInterfaceModule.cpp
@@ -21,9 +21,6 @@ void EmotionInitReport::report(const PortInfo &info) {
 EmotionInterfaceModule::EmotionInterfaceModule() : emotionInitReport(this) {
 }
 
-EmotionInterfaceModule::~EmotionInterfaceModule(){
-}
-
 bool EmotionInterfaceModule::configure(ResourceFinder& config){
   
     char name[10];

--- a/src/core/emotionInterface/emotionInterfaceModule.h
+++ b/src/core/emotionInterface/emotionInterfaceModule.h
@@ -118,6 +118,7 @@ public:
     bool setRaw(const std::string cmd) override;
 
     bool setColor(const string& cmd);
+    bool setBrightness(const string& cmd);
 };
 
 

--- a/src/core/emotionInterface/emotionInterfaceModule.h
+++ b/src/core/emotionInterface/emotionInterfaceModule.h
@@ -82,10 +82,13 @@ private:
     // number of high level emotions
     size_t _highlevelemotions{};
     size_t _numberOfColors{};
+    size_t _eyebrowmaskemotions{};
+    size_t _mouthmaskemotions{};
 
     // table with the setting for each emotion - from config file
     EM_CODE* _emotion_table{};
-    std::map<std::string, char[2] > _color_table;
+    std::map<std::string, std::string > _bitmask_emotion_table;
+    std::map<std::string, std::string > _color_table;
 
     //Time variables for automatic expression switching
     bool   _auto{};
@@ -119,6 +122,7 @@ public:
 
     bool setColor(const string& cmd);
     bool setBrightness(const string& cmd);
+    bool setMask(const Bottle& cmd);
 };
 
 

--- a/src/core/emotionInterface/emotionInterfaceModule.h
+++ b/src/core/emotionInterface/emotionInterfaceModule.h
@@ -85,6 +85,7 @@ private:
 
     // table with the setting for each emotion - from config file
     EM_CODE* _emotion_table{};
+    std::map<std::string, char[2] > _color_table;
 
     //Time variables for automatic expression switching
     bool   _auto{};
@@ -115,6 +116,8 @@ public:
     bool setMouth(const std::string cmd) override;
     bool setAll(const std::string cmd) override;
     bool setRaw(const std::string cmd) override;
+
+    bool setColor(const string& cmd);
 };
 
 

--- a/src/core/emotionInterface/emotionInterfaceModule.h
+++ b/src/core/emotionInterface/emotionInterfaceModule.h
@@ -100,21 +100,21 @@ public:
     EmotionInterfaceModule();
     ~EmotionInterfaceModule() override = default;
     
-    virtual bool configure(ResourceFinder& config);//virtual bool open(Searchable& config);
-    virtual bool close();
-    virtual bool interruptModule();
-    virtual bool updateModule();
-    virtual double getPeriod();
-    virtual bool respond(const Bottle &command,Bottle &reply);
+    bool configure(ResourceFinder& config) override;//virtual bool open(Searchable& config);
+    bool close() override;
+    bool interruptModule() override;
+    bool updateModule() override;
+    double getPeriod() override;
+    bool respond(const Bottle &command,Bottle &reply)override;
     void initEmotion();
 
     // interface functions
-    virtual bool setLeftEyebrow(const std::string cmd);
-    virtual bool setRightEyebrow(const std::string cmd);
-    virtual bool setEyelids(const std::string cmd);
-    virtual bool setMouth(const std::string cmd);
-    virtual bool setAll(const std::string cmd);
-    virtual bool setRaw(const std::string cmd);
+    bool setLeftEyebrow(const std::string cmd) override;
+    bool setRightEyebrow(const std::string cmd) override;
+    bool setEyelids(const std::string cmd) override;
+    bool setMouth(const std::string cmd) override;
+    bool setAll(const std::string cmd) override;
+    bool setRaw(const std::string cmd) override;
 };
 
 

--- a/src/core/emotionInterface/emotionInterfaceModule.h
+++ b/src/core/emotionInterface/emotionInterfaceModule.h
@@ -76,28 +76,29 @@ private:
     // reporter put on the init emotion
     EmotionInitReport emotionInitReport;
 
-    // output command port         
+    // output command port
     BufferedPort<Bottle> _outputPort;
 
     // number of high level emotions
-    int _highlevelemotions;
+    size_t _highlevelemotions{};
+    size_t _numberOfColors{};
 
     // table with the setting for each emotion - from config file
-    EM_CODE* _emotion_table;
+    EM_CODE* _emotion_table{};
 
     //Time variables for automatic expression switching
-    bool   _auto;
-    double _lasttime;
-    double _period;
-    int    _initEmotionTrigger;
+    bool   _auto{};
+    double _lasttime{};
+    double _period{};
+    int    _initEmotionTrigger{};
 
-    int getIndex(const std::string cmd);
+    int getIndex(std::string cmd);
     bool writePort(const char* cmd);
 
 public:
 
     EmotionInterfaceModule();
-    virtual ~EmotionInterfaceModule();
+    ~EmotionInterfaceModule() override = default;
     
     virtual bool configure(ResourceFinder& config);//virtual bool open(Searchable& config);
     virtual bool close();


### PR DESCRIPTION
It has been added a new rpc request:
```bash
$ set col <color>
```
Where color is:

One of the following: black, white, red, lime, blue, yellow, cyan, magenta, silver, gray, maroon, olive, green, purple, teal, navy.


:warning: 
This new feature work only if the icub mount the new rfe board.

Please review code.
