### PR TITLE
Backport of IPOPT_INCLUDE_DIRS fix

### DIFF
--- a/conf/FindIPOPT.cmake
+++ b/conf/FindIPOPT.cmake
@@ -82,7 +82,7 @@ if(NOT WIN32)
       set(IPOPT_DIR /usr            CACHE PATH "Path to IPOPT build directory")
     endif()
 
-    set(IPOPT_INCLUDE_DIRS ${IPOPT_DIR}/include/coin)
+    find_path(IPOPT_INCLUDE_DIRS NAMES IpIpoptApplication.hpp coin/IpIpoptApplication.hpp PATHS ${IPOPT_DIR}/include/coin)
     find_library(IPOPT_LIBRARIES ipopt ${IPOPT_DIR}/lib
                                        ${IPOPT_DIR}/lib/coin)
 
@@ -127,7 +127,7 @@ else()
 
   set(IPOPT_DIR $ENV{IPOPT_DIR} CACHE PATH "Path to IPOPT build directory")
 
-  set(IPOPT_INCLUDE_DIRS ${IPOPT_DIR}/include/coin)
+  find_path(IPOPT_INCLUDE_DIRS NAMES IpIpoptApplication.hpp coin/IpIpoptApplication.hpp PATHS ${IPOPT_DIR}/include/coin)
   find_library(IPOPT_IPOPT_LIBRARY_RELEASE libipopt ${IPOPT_DIR}/lib
                                                     ${IPOPT_DIR}/lib/coin)
   find_library(IPOPT_IPOPT_LIBRARY_DEBUG   libipoptD ${IPOPT_DIR}/lib


### PR DESCRIPTION
See https://github.com/robotology/ycm/pull/276 .
This had already landed in devel, but it is convenient to have it in master to fix soonish https://github.com/robotology/robotology-superbuild/pull/296 .