### PR TITLE
Network performance tool

### DIFF
--- a/src/libraries/icubmod/embObjLib/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjLib/CMakeLists.txt
@@ -183,11 +183,31 @@ set(EXTRA_SOURCE            ${EXTRA_FOLDER}/hostTransceiver.cpp
                             ${EXTRA_FOLDER}/theNVmanager.cpp
                             ${EXTRA_FOLDER}/embObjGeneralDevPrivData.cpp
                             )
+                            
+message("EXTRA_SOURCE= " ${EXTRA_SOURCE})
 
 set(DEBUG_SOURCE            ${DEBUG_FOLDER}/eODeb_eoProtoParser.c
                             ${DEBUG_FOLDER}/eOtheEthLowLevelParser.c)
 
+option(NETWORK_PERFORMANCE_BANCHMARK "Enable embedded network perfomance bamchmark." OFF)
+mark_as_advanced(NETWORK_PERFORMANCE_BANCHMARK)
 
+if(NETWORK_PERFORMANCE_BANCHMARK)
+
+set(TOOLS_FOLDER    ${EXTRA_FOLDER}/tools)
+set(TOOLS_HEADER    ${TOOLS_FOLDER}/include/PeriodicEventsVerifier.h)
+set(TOOLS_SOURCE    ${TOOLS_FOLDER}/src/PeriodicEventsVerifier.cpp 
+                    ${TOOLS_FOLDER}/src/embot_tools.cpp)
+else()
+
+set(TOOLS_FOLDER  ""  )
+set(TOOLS_HEADER  ""  )
+set(TOOLS_SOURCE  ""  )
+
+endif()
+
+
+message("tools source= " ${TOOLS_SOURCE})
 
 set(embobj_source
                             ${CORE_FOLDER_SOURCE}
@@ -203,14 +223,13 @@ set(embobj_source
                             ${NVS_USR_SOURCE}
                             ${NVS_CBK_SOURCE}
                             ${ICUB_INTERFACE_SOURCE}
-                            )
+                            ${TOOLS_SOURCE} )
 
 set(embobj_header           ${BODY_COMMON_SOURCE}
                             ${CORE_API_HEADER}
                             ${PROT_HEADER}
                             ${NVS_EB_SRC_FOLDER}
-                            )
-
+                            ${TOOLS_HEADER} )
 
 
 SOURCE_GROUP("EmbObj Source Files" FILES ${embobj_source})
@@ -221,7 +240,7 @@ include_directories(SYSTEM ${ACE_INCLUDE_DIRS} ${FIRMWARE_SHARED_INC})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}
                     ${embObj_includes}
                     ${iCubDev_INCLUDE_DIRS}
-                    ${CMAKE_CURRENT_SOURCE_DIR}/../motionControlLib/)
+                    ${CMAKE_CURRENT_SOURCE_DIR}/../motionControlLib)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 add_library(${PROJECTNAME} SHARED ${embobj_source} ${embobj_header})

--- a/src/libraries/icubmod/embObjLib/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjLib/CMakeLists.txt
@@ -189,10 +189,10 @@ message("EXTRA_SOURCE= " ${EXTRA_SOURCE})
 set(DEBUG_SOURCE            ${DEBUG_FOLDER}/eODeb_eoProtoParser.c
                             ${DEBUG_FOLDER}/eOtheEthLowLevelParser.c)
 
-option(NETWORK_PERFORMANCE_BANCHMARK "Enable embedded network perfomance bamchmark." OFF)
-mark_as_advanced(NETWORK_PERFORMANCE_BANCHMARK)
+option(NETWORK_PERFORMANCE_BENCHMARK "Enable embedded network perfomance bamchmark." OFF)
+mark_as_advanced(NETWORK_PERFORMANCE_BENCHMARK)
 
-if(NETWORK_PERFORMANCE_BANCHMARK)
+if(NETWORK_PERFORMANCE_BENCHMARK)
 
 set(TOOLS_FOLDER    ${EXTRA_FOLDER}/tools)
 set(TOOLS_HEADER    ${TOOLS_FOLDER}/include/PeriodicEventsVerifier.h)

--- a/src/libraries/icubmod/embObjLib/ethReceiver.cpp
+++ b/src/libraries/icubmod/embObjLib/ethReceiver.cpp
@@ -76,6 +76,13 @@ EthReceiver::EthReceiver(int raterx): PeriodicThread((double)raterx/1000.0)
 //    {
 //        statPrintInterval = 0.0;
 //    }
+#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+    /* We would like to verify if the receiver thread is ticked(running) every 5 millisecond, with a tollerance of 0.05 millisec.
+       the m_perEvtVerifier object after 1 second, prints an istogram with values from 4 to 6 millisec with a step of 0.1 millisec
+     */
+    //m_perEvtVerifier.init(0.005, 0.00005, 0.004, 0.006, 0.0001, 1);
+    m_perEvtVerifier.init(raterx, (raterx/100), raterx-0.001, raterx+0.001, 0.0001, 1);
+#endif
 }
 
 void EthReceiver::onStop()
@@ -161,6 +168,11 @@ void EthReceiver::run()
     uint64_t      incoming_msg_data[TheEthManager::maxRXpacketsize/8];   // 8-byte aligned local buffer for incoming packet: it must be able to accomodate max size of packet
     const ssize_t incoming_msg_capacity = TheEthManager::maxRXpacketsize;
 
+#ifdef NETWORK_PERFORMANCE_BANCHMARK
+    m_perEvtVerifier.tick(yarp::os::Time::now());
+#endif
+    
+    
     int flags = 0;
 #ifndef WIN32
     flags |= MSG_DONTWAIT;

--- a/src/libraries/icubmod/embObjLib/ethReceiver.cpp
+++ b/src/libraries/icubmod/embObjLib/ethReceiver.cpp
@@ -76,7 +76,7 @@ EthReceiver::EthReceiver(int raterx): PeriodicThread((double)raterx/1000.0)
 //    {
 //        statPrintInterval = 0.0;
 //    }
-#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+#ifdef NETWORK_PERFORMANCE_BENCHMARK 
     /* We would like to verify if the receiver thread is ticked(running) every 5 millisecond, with a tollerance of 0.05 millisec.
        the m_perEvtVerifier object after 1 second, prints an istogram with values from 4 to 6 millisec with a step of 0.1 millisec
      */
@@ -168,7 +168,7 @@ void EthReceiver::run()
     uint64_t      incoming_msg_data[TheEthManager::maxRXpacketsize/8];   // 8-byte aligned local buffer for incoming packet: it must be able to accomodate max size of packet
     const ssize_t incoming_msg_capacity = TheEthManager::maxRXpacketsize;
 
-#ifdef NETWORK_PERFORMANCE_BANCHMARK
+#ifdef NETWORK_PERFORMANCE_BENCHMARK
     m_perEvtVerifier.tick(yarp::os::Time::now());
 #endif
     

--- a/src/libraries/icubmod/embObjLib/ethReceiver.h
+++ b/src/libraries/icubmod/embObjLib/ethReceiver.h
@@ -34,7 +34,7 @@
 #include <yarp/os/PeriodicThread.h>
 
 
-#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+#ifdef NETWORK_PERFORMANCE_BENCHMARK 
 #include <./tools/include/PeriodicEventsVerifier.h>
 #endif
 
@@ -51,7 +51,7 @@ namespace eth {
         ACE_SOCK_Dgram *recv_socket;
         eth::TheEthManager *ethManager;
         double statPrintInterval;
-#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+#ifdef NETWORK_PERFORMANCE_BENCHMARK 
         Tools::Emb_PeriodicEventVerifier m_perEvtVerifier;
 #endif
 

--- a/src/libraries/icubmod/embObjLib/ethReceiver.h
+++ b/src/libraries/icubmod/embObjLib/ethReceiver.h
@@ -34,6 +34,11 @@
 #include <yarp/os/PeriodicThread.h>
 
 
+#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+#include <./tools/include/PeriodicEventsVerifier.h>
+#endif
+
+
 namespace eth {
 
     class TheEthManager;
@@ -46,7 +51,9 @@ namespace eth {
         ACE_SOCK_Dgram *recv_socket;
         eth::TheEthManager *ethManager;
         double statPrintInterval;
-
+#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+        Tools::Emb_PeriodicEventVerifier m_perEvtVerifier;
+#endif
 
     public:
 

--- a/src/libraries/icubmod/embObjLib/ethSender.cpp
+++ b/src/libraries/icubmod/embObjLib/ethSender.cpp
@@ -65,7 +65,7 @@ EthSender::EthSender(int txrate) : PeriodicThread((double)txrate/1000.0)
     yDebug() << "EthSender is a PeriodicThread with txrate =" << rateofthread << "ms";
     yTrace();
 
-#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+#ifdef NETWORK_PERFORMANCE_BENCHMARK 
     /* We would like to verify if the receiver thread is ticked(running) every 1 millisecond, with a tollerance of 0.05 millisec.
        The m_perEvtVerifier object after 1 second, prints an istogram with values from 0 to 3 millisec with a step of 0.1 millisec
     */
@@ -115,7 +115,7 @@ void EthSender::run()
     // embObjMotionControl etc which adds or releases its resources.
     ethManager->Transmission();
 
-#ifdef NETWORK_PERFORMANCE_BANCHMARK
+#ifdef NETWORK_PERFORMANCE_BENCHMARK
     m_perEvtVerifier.tick(yarp::os::Time::now());
 #endif
 }

--- a/src/libraries/icubmod/embObjLib/ethSender.cpp
+++ b/src/libraries/icubmod/embObjLib/ethSender.cpp
@@ -64,6 +64,14 @@ EthSender::EthSender(int txrate) : PeriodicThread((double)txrate/1000.0)
     rateofthread = txrate;
     yDebug() << "EthSender is a PeriodicThread with txrate =" << rateofthread << "ms";
     yTrace();
+
+#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+    /* We would like to verify if the receiver thread is ticked(running) every 1 millisecond, with a tollerance of 0.05 millisec.
+       The m_perEvtVerifier object after 1 second, prints an istogram with values from 0 to 3 millisec with a step of 0.1 millisec
+    */
+    //m_perEvtVerifier.init(0.001, 0.00005, 0.0, 0.003, 0.0001, 1);
+    m_perEvtVerifier.init(txrate, 5*txrate/100, 0.0, txrate+0.002, 0.0001, 1);
+#endif
 }
 
 EthSender::~EthSender()
@@ -106,6 +114,10 @@ void EthSender::run()
     // for tx we must protect the EthResource not being changed. they can be changed by a device such as
     // embObjMotionControl etc which adds or releases its resources.
     ethManager->Transmission();
+
+#ifdef NETWORK_PERFORMANCE_BANCHMARK
+    m_perEvtVerifier.tick(yarp::os::Time::now());
+#endif
 }
 
 

--- a/src/libraries/icubmod/embObjLib/ethSender.h
+++ b/src/libraries/icubmod/embObjLib/ethSender.h
@@ -33,6 +33,10 @@
 
 #include <yarp/os/PeriodicThread.h>
 
+#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+#include <./tools/include/PeriodicEventsVerifier.h>
+#endif
+
 
 namespace eth {
 
@@ -46,6 +50,10 @@ namespace eth {
         uint8_t *p_sendData;
         TheEthManager *ethManager;
         ACE_SOCK_Dgram *send_socket;
+
+#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+        Tools::Emb_PeriodicEventVerifier m_perEvtVerifier;
+#endif
         void run();
 
 

--- a/src/libraries/icubmod/embObjLib/ethSender.h
+++ b/src/libraries/icubmod/embObjLib/ethSender.h
@@ -33,7 +33,7 @@
 
 #include <yarp/os/PeriodicThread.h>
 
-#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+#ifdef NETWORK_PERFORMANCE_BENCHMARK 
 #include <./tools/include/PeriodicEventsVerifier.h>
 #endif
 
@@ -51,7 +51,7 @@ namespace eth {
         TheEthManager *ethManager;
         ACE_SOCK_Dgram *send_socket;
 
-#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+#ifdef NETWORK_PERFORMANCE_BENCHMARK 
         Tools::Emb_PeriodicEventVerifier m_perEvtVerifier;
 #endif
         void run();

--- a/src/libraries/icubmod/embObjLib/tools/include/PeriodicEventsVerifier.h
+++ b/src/libraries/icubmod/embObjLib/tools/include/PeriodicEventsVerifier.h
@@ -1,36 +1,29 @@
-/*
- * Copyright (C) 2019 iCub-Tech Facility - Istituto Italiano di Tecnologia
- * Author:  Valentina Gaggero
- * email:   Valentina.gaggero@iit.it
- * website: www.robotcub.org
- * Permission is granted to copy, distribute, and/or modify this program
- * under the terms of the GNU General Public License, version 2 or any
- * later version published by the Free Software Foundation.
- *
- * A copy of the license can be found at
- * http://www.robotcub.org/icub/license/gpl.txt
- *
- * This program is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details
-*/
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2019 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
 
-// - include guard ----------------------------------------------------------------------------------------------------
+ 
+
+/**
+ * @file PeriodicEventsVerifier.h
+ * @authors: Valentina Gaggero <valentina.gaggero@iit.it>
+ */
 
 
 #ifndef _PERIODIC_EVENTS_VERIFIER_H_
 #define _PERIODIC_EVENTS_VERIFIER_H_
 
-// - namespace embot::tools belongs to the embot (emBEDDED RObot) libray of C++11 classes and functions which are 
-// - designed to run in the icub/r1 robot's embedded environment.
-// - the objects inside this namespace are tools used to validate behaviours in the microcontrollers inside the robot
-// - but can also be used inside icub-main classes which runs on the PC104 platform
-// - hence particular attention was put in avoiding any call to YARP or embot::sys (RTOS) or embot::hw (HW of the micro). 
-// - we also don't use in here any embot::common funtions or types to guarantee maximum portability.
-
-
-
+//!  In the Tools namespace there are classes useful to check some kinds of performance on robot. 
+/*!
+  Currently, the available classes are Emb_PeriodicEventVerifier and Emb_RensponseTimingVerifier: 
+  the first let you to verify the frequency of a periodic event, while the second let you to analyze the trend of response time 
+  to a request.
+  This class are based on classes belonging to emBEDDED RObot library of C++11, 
+  so these classes are very suitable for working with high precision time, like 1 millisecond.
+*/
 
 
 namespace Tools 
@@ -39,32 +32,97 @@ namespace Tools
     class Emb_RensponseTimingVerifier;
 }
 
+
+//!  Tools::Emb_PeriodicEventVerifier 
+/*!
+  This class let you to verify if a periodic event is triggered with the desired frequency.
+  After its initialization, you need to tick it every event occurrence.
+  The class prints the histogram of effective event timing every @reportPeriod, by yarp logger mechanism and resets the data collected until now.
+*/
 class Tools::Emb_PeriodicEventVerifier
 {
 
     public:
-                
+        
+        /*!
+         * Costructor.
+        */
         Emb_PeriodicEventVerifier();
+        
+        /*!
+         * Descructor.
+        */
         ~Emb_PeriodicEventVerifier();
     
+    /*!
+     * Initializes the object with custom parameters
+     * \param period is the desired period of the event [expressed in seconds].
+     * \param tolerance is the acceptable tolerance of the desired period [expressed in seconds].
+     * \param min is the minimum period you expected [expressed in seconds].
+     * \param max is the maximum period you expected [expressed in seconds].
+     * \param step is the step of the histogram. [expressed in seconds].
+     * \param reportPeriod the class prints the histogram every @reportPeriod seconds. [expressed in seconds].
+     * \return true/false on success/failure.
+     *
+     * \note the number of histogram columns are: ((@max-@min)/@step ) +2 
+     */
         bool init(double period, double tolerance, double min, double max, double step, double reportPeriod);
+        
+        
+    /*!
+     * Signals occurrence of the event to the object
+     * \param currentTime the current time [expressed in seconds].
+     */
+ 
         void tick(double currentTime);
     private:
         struct Impl;
         Impl *pImpl;
     
 };
+    
 
-
+//!  Tools::Emb_RensponseTimingVerifier 
+/*!
+  This class let you to analyze the needed time of a request to get a response during a given amount of time.
+  This class has been developed with the idea in mind of monitoring the the response time of a request along a period
+  in order to understand how many situations there are jitter, other than to calculate the medium value.
+  This class needs to be initialize and then you need to add the current response time and its relative absolute request time.
+  The class prints the histogram of real response timing every @reportPeriod, by yarp logger mechanism and resets the data collected until now.
+*/
 class Tools::Emb_RensponseTimingVerifier
 {
 
     public:
-                
+        /*!
+         * Costructor.
+        */                
         Emb_RensponseTimingVerifier();
+        
+        /*!
+         * Descructor.
+        */
         ~Emb_RensponseTimingVerifier();
-    
+        
+        /*!
+        * Initializes the object with custom parameters
+        * \param desiredResponseTime is the desired response period [expressed in seconds].
+        * \param tolerance is the acceptable tolerance of the desired response period [expressed in seconds].
+        * \param min is the minimum response period you expected [expressed in seconds].
+        * \param max is the maximum response period you expected [expressed in seconds].
+        * \param step is the step of the histogram. [expressed in seconds].
+        * \param reportPeriod the class prints the histogram every @reportPeriod seconds. [expressed in seconds].
+        * \return true/false on success/failure.
+        *
+        * \note the number of histogram columns are: ((@max-@min)/@step ) +2 
+        */    
         bool init(double desiredResponseTime, double tolerance, double min, double max, double step, double reportPeriod);
+        
+        /*!
+        * Adds the current response time to the collection of data of the object.
+        * \param currentResponseTime is the time needed to the current request to get a response [expressed in seconds].
+        * \param requestTime the time when request has been done [expressed in seconds].
+        */        
         void tick(double currentResponseTime, double requestTime);
     private:
         struct Impl;

--- a/src/libraries/icubmod/embObjLib/tools/include/PeriodicEventsVerifier.h
+++ b/src/libraries/icubmod/embObjLib/tools/include/PeriodicEventsVerifier.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2019 iCub-Tech Facility - Istituto Italiano di Tecnologia
+ * Author:  Valentina Gaggero
+ * email:   Valentina.gaggero@iit.it
+ * website: www.robotcub.org
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+*/
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+
+#ifndef _PERIODIC_EVENTS_VERIFIER_H_
+#define _PERIODIC_EVENTS_VERIFIER_H_
+
+// - namespace embot::tools belongs to the embot (emBEDDED RObot) libray of C++11 classes and functions which are 
+// - designed to run in the icub/r1 robot's embedded environment.
+// - the objects inside this namespace are tools used to validate behaviours in the microcontrollers inside the robot
+// - but can also be used inside icub-main classes which runs on the PC104 platform
+// - hence particular attention was put in avoiding any call to YARP or embot::sys (RTOS) or embot::hw (HW of the micro). 
+// - we also don't use in here any embot::common funtions or types to guarantee maximum portability.
+
+
+
+
+
+namespace Tools 
+{ 
+    class Emb_PeriodicEventVerifier;
+    class Emb_RensponseTimingVerifier;
+}
+
+class Tools::Emb_PeriodicEventVerifier
+{
+
+    public:
+                
+        Emb_PeriodicEventVerifier();
+        ~Emb_PeriodicEventVerifier();
+    
+        bool init(double period, double tolerance, double min, double max, double step, double reportPeriod);
+        void tick(double currentTime);
+    private:
+        struct Impl;
+        Impl *pImpl;
+    
+};
+
+
+class Tools::Emb_RensponseTimingVerifier
+{
+
+    public:
+                
+        Emb_RensponseTimingVerifier();
+        ~Emb_RensponseTimingVerifier();
+    
+        bool init(double desiredResponseTime, double tolerance, double min, double max, double step, double reportPeriod);
+        void tick(double currentResponseTime, double requestTime);
+    private:
+        struct Impl;
+        Impl *pImpl;
+    
+};
+
+
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+

--- a/src/libraries/icubmod/embObjLib/tools/src/PeriodicEventsVerifier.cpp
+++ b/src/libraries/icubmod/embObjLib/tools/src/PeriodicEventsVerifier.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2019 iCub Facility - Istituto Italiano di Tecnologia
+ * Author: Valentina Gaggero
+ * email:  Valentina.gaggero@iit.it
+ * website: www.robotcub.org
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+*/
+
+
+
+#include "../include/PeriodicEventsVerifier.h"
+#include "embot_tools.h"
+#include <yarp/os/LogStream.h>
+
+
+using yarp::os::Log;
+
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
+// --------------------------------------------------------------------------------------------------------------------
+
+struct Tools::Emb_PeriodicEventVerifier::Impl
+{
+
+    embot::tools::PeriodValidator m_perVal;
+
+
+    Impl()
+    {
+
+    }
+
+    bool init(double period, double tolerance, double min, double max, double step, double reportPeriod)
+    {
+        // now transform each parameter expressed in seconds to microseconds
+        uint64_t period_us=period*1000000;
+        uint64_t tolerance_us=tolerance*1000000;
+        uint64_t min_us=min*1000000;
+        uint64_t max_us=max*1000000;
+        uint32_t step_us=step*1000000;
+        uint64_t reportPeriod_us=reportPeriod*1000000;
+        
+        
+        return m_perVal.init({period_us, period_us+tolerance_us,  reportPeriod_us, 
+                        {min_us, max_us, step_us}});
+
+    }
+
+    void tick(double currentTime)
+    {
+        
+        uint64_t tnow = static_cast<std::uint64_t>(currentTime);
+        uint64_t delta = 0;
+        m_perVal.tick(tnow, delta);
+        if(true == m_perVal.report())
+        {
+            std::vector<double> vect_prob;
+            m_perVal.histogram()->probabilitydensityfunction(vect_prob);
+            uint32_t min = m_perVal.histogram()->getconfig()->min;
+            uint32_t step = m_perVal.histogram()->getconfig()->step;
+            yWarning() << "---------- PRINT HISTO RECEIVER ---------------";
+            for(int i=0; i<vect_prob.size(); i++)
+            {
+                if(vect_prob[i]==0)
+                    continue;
+
+                yWarning() << "-- histo RX [" << min+step*i << "]="<< vect_prob[i];
+            }
+            yWarning() << "---------- END PRINT HISTO RECEIVER ---------------";
+            m_perVal.reset();
+        }
+
+    }
+
+}; //end Tools::Emb_PeriodicEventVerifier::Impl
+
+struct Tools::Emb_RensponseTimingVerifier::Impl
+{
+    embot::tools::RoundTripValidator m_roundTripVal;
+
+
+    Impl()
+    {
+    }
+
+    bool init(double desiredResponseTime, double tolerance, double min, double max, double step, double reportPeriod)
+    {
+
+        // now transform each parameter expressed in seconds to microseconds
+        uint64_t desiredResponseTime_us=desiredResponseTime*1000000;
+        uint64_t tolerance_us=tolerance*1000000;
+        uint64_t min_us=min*1000000;
+        uint64_t max_us=max*1000000;
+        uint32_t step_us=step*1000000;
+        uint64_t reportPeriod_us=reportPeriod*1000000;
+        
+        return m_roundTripVal.init({desiredResponseTime_us, desiredResponseTime_us+tolerance_us, reportPeriod_us,  
+                                   {min_us, max_us, step_us}}); 
+    }
+
+
+
+    void tick(double currentResponseTime, double requestTime)
+    {
+        m_roundTripVal.tick(currentResponseTime, static_cast<std::uint64_t>(1000000.0*requestTime));
+
+        if(true == m_roundTripVal.report())
+        {
+            const embot::tools::Histogram * histo = m_roundTripVal.histogram();
+            const embot::tools::Histogram::Values* val=histo->getvalues();
+
+            std::vector<double> vect_prob;
+            m_roundTripVal.histogram()->probabilitydensityfunction(vect_prob);
+            uint32_t min = m_roundTripVal.histogram()->getconfig()->min;
+            uint32_t step = m_roundTripVal.histogram()->getconfig()->step;
+            yInfo() << "---------- PRINT HISTO GETPID ---------------";
+            for(int i=0; i<vect_prob.size(); i++)
+            {
+                if(vect_prob[i]==0)
+                    continue;
+                yInfo() << "-- histo PID [" << min+step*i << "]="<< vect_prob[i];
+            }
+            yInfo() << "---------- END PRINT HISTO GETPID ---------------";
+            m_roundTripVal.reset();
+        }
+    }
+
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+// - all the rest
+// --------------------------------------------------------------------------------------------------------------------
+
+
+
+Tools::Emb_PeriodicEventVerifier::Emb_PeriodicEventVerifier():pImpl(new Impl)
+{;}
+
+Tools::Emb_PeriodicEventVerifier::~Emb_PeriodicEventVerifier()
+{
+    delete pImpl;
+}
+
+
+bool Tools::Emb_PeriodicEventVerifier::init(double period, double tolerance, double min, double max, double step, double reportPeriod)
+{
+    // now transform each parameter expressed in seconds to microseconds
+    uint64_t period_us=period*1000000;
+    uint64_t tolerance_us=tolerance*1000000;
+    uint64_t min_us=min*1000000;
+    uint64_t max_us=max*1000000;
+    uint64_t step_us=step*1000000;
+    uint64_t reportPeriod_us=reportPeriod*1000000;
+    
+    
+    return pImpl->init(period_us, tolerance_us, min_us, max_us, step_us, reportPeriod_us);
+}
+
+void Tools::Emb_PeriodicEventVerifier::tick(double currentTime)
+{
+    pImpl->tick(currentTime);
+}
+
+
+Tools::Emb_RensponseTimingVerifier::Emb_RensponseTimingVerifier(): pImpl(new Impl)
+{;}
+
+Tools::Emb_RensponseTimingVerifier::~Emb_RensponseTimingVerifier()
+{
+    delete pImpl;
+}
+
+
+bool Tools::Emb_RensponseTimingVerifier::init(double desiredResponseTime, double tolerance, double min, double max, double step, double reportPeriod)
+{
+    return pImpl->init(desiredResponseTime, tolerance, min, max, step, reportPeriod);
+}
+
+
+void Tools::Emb_RensponseTimingVerifier::tick(double currentResponseTime, double requestTime)
+{
+    return pImpl->tick(currentResponseTime, requestTime);
+}
+
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/src/libraries/icubmod/embObjLib/tools/src/PeriodicEventsVerifier.cpp
+++ b/src/libraries/icubmod/embObjLib/tools/src/PeriodicEventsVerifier.cpp
@@ -1,20 +1,15 @@
-/*
- * Copyright (C) 2019 iCub Facility - Istituto Italiano di Tecnologia
- * Author: Valentina Gaggero
- * email:  Valentina.gaggero@iit.it
- * website: www.robotcub.org
- * Permission is granted to copy, distribute, and/or modify this program
- * under the terms of the GNU General Public License, version 2 or any
- * later version published by the Free Software Foundation.
- *
- * A copy of the license can be found at
- * http://www.robotcub.org/icub/license/gpl.txt
- *
- * This program is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details
-*/
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2019 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+ 
+
+/**
+ * @file PeriodicEventsVerifier.cpp
+ * @authors: Valentina Gaggero <valentina.gaggero@iit.it>
+ */
 
 
 

--- a/src/libraries/icubmod/embObjLib/tools/src/embot_tools.cpp
+++ b/src/libraries/icubmod/embObjLib/tools/src/embot_tools.cpp
@@ -1,0 +1,625 @@
+/*
+ * Copyright (C) 2017 iCub Facility - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame, Valentina Gaggero
+ * email:   marco.accame@iit.it, Valentina.gaggero@iit.it
+ * website: www.robotcub.org
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+*/
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - public interface
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_tools.h"
+
+
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - external dependencies
+// --------------------------------------------------------------------------------------------------------------------
+
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
+// --------------------------------------------------------------------------------------------------------------------
+
+struct embot::tools::Histogram::Impl
+{
+
+    struct Status
+    {
+        Config                      config;
+        std::uint32_t               numofbins;
+        Values                      values;
+        Status() { numofbins = 0; values.total = values.below = values.beyond = 0; values.inside.clear(); }
+    };
+
+    Status status;
+
+    Impl()
+    {
+
+    }
+
+    bool init(const Config &config)
+    {
+        if(false == config.isvalid())
+        {
+            return false;
+        }
+
+        status.config = config;
+
+        status.numofbins = status.config.nsteps();
+
+        status.values.inside.reserve(status.config.nsteps());
+        status.values.inside.resize(status.config.nsteps(), 0);
+
+        status.values.total = status.values.below = status.values.beyond = 0;
+
+        return true;
+    }
+
+
+
+    bool add(std::uint64_t val)
+    {
+        if(false == status.config.isvalid())
+        {   // not yet initted
+            return false;
+        }
+
+        if(val < status.config.min)
+        {
+            status.values.below ++;
+            status.values.total ++;
+        }
+        else if(val < status.config.max)
+        {
+            std::uint64_t index = (val - status.config.min) / status.config.step;
+            if(index < status.numofbins)
+            {
+                status.values.inside[index] ++;
+                status.values.total ++;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else //if(val >= status.config.max)
+        {
+            status.values.beyond ++;
+            status.values.total ++;
+        }
+
+        return true;
+    }
+
+
+    bool reset()
+    {
+        std::fill(status.values.inside.begin(), status.values.inside.end(), 0);
+        status.values.below = status.values.beyond = status.values.total = 0;
+        return true;
+    }
+
+};
+
+
+
+
+
+struct embot::tools::PeriodValidator::Impl
+{
+    std::uint64_t previous;
+    std::uint64_t delta;
+    std::uint64_t prevreport;
+    bool enabledReport;
+    bool enabledAlert;
+    bool usehisto;
+
+    Config configuration;
+
+    embot::tools::Histogram histo;
+
+
+    Impl()
+    {
+        previous = 0;
+        delta = 0;
+        prevreport = 0;
+        enabledReport = false;
+        enabledAlert = false;
+
+        usehisto = false;
+    }
+
+    bool init(const Config &config)
+    {
+        if(false == config.isvalid())
+        {
+            return false;
+        }
+
+        configuration = config;
+
+        // ok, now i load the
+
+        if(true == configuration.histoconfig.isvalid())
+        {
+            usehisto = true;
+            histo.init(configuration.histoconfig);
+        }
+
+        return true;
+    }
+
+
+
+    bool tick(std::uint64_t currtime_usec, std::uint64_t &deltatime_usec)
+    {
+        if(0 == previous)
+        {
+            previous = currtime_usec;
+            delta = 0;
+            prevreport = currtime_usec;
+            deltatime_usec = delta;
+            return true;
+        }
+        else if(currtime_usec < previous)
+        {
+            return false;
+        }
+
+        delta = currtime_usec - previous;
+        previous = currtime_usec;
+
+        if(true == usehisto)
+        {
+            histo.add(delta);
+        }
+
+        enabledAlert = false;
+        enabledReport = false;
+
+        // now i check ... should i alert?
+        if(delta >= configuration.alertvalue)
+        {
+            enabledAlert = true;
+        }
+
+
+        if((true == usehisto) && ((currtime_usec - prevreport) > configuration.reportinterval))
+        {
+            prevreport = currtime_usec;
+            enabledReport = (configuration.reportinterval > 0) ? true : false;
+        }
+
+        deltatime_usec = delta;
+        return true;
+    }
+
+
+    bool reset()
+    {
+        previous = 0;
+        delta = 0;
+        prevreport = 0;
+        enabledReport = false;
+        enabledAlert = false;
+
+        histo.reset();
+
+        return true;
+    }
+
+
+    bool alert(std::uint64_t &deltatime_usec) const
+    {
+        deltatime_usec = delta;
+        return enabledAlert;
+    }
+
+
+    bool report() const
+    {
+        return enabledReport;
+    }
+
+};
+
+
+
+struct embot::tools::RoundTripValidator::Impl
+{
+    std::uint64_t previous;
+    std::uint64_t delta;
+    std::uint64_t prevreport;
+    bool enabledReport;
+    bool enabledAlert;
+    bool usehisto;
+    bool inited;
+
+    Config configuration;
+
+    embot::tools::Histogram histo;
+
+
+    Impl()
+    {
+        previous = 0;
+        delta = 0;
+        prevreport = 0;
+        enabledReport = false;
+        enabledAlert = false;
+        inited = false;
+
+        usehisto = false;
+    }
+
+    bool init(const Config &config)
+    {
+        if(false == config.isvalid())
+        {
+            return false;
+        }
+
+        configuration = config;
+
+        // ok, now i load the
+
+        if(true == configuration.histoconfig.isvalid())
+        {
+            usehisto = true;
+            histo.init(configuration.histoconfig);
+        }
+        inited=true;
+        return true;
+    }
+
+
+
+    bool tick(std::uint64_t deltatime_usec, std::uint64_t timestamp)
+    {
+        if(0 == previous)
+        {
+            prevreport=timestamp;
+            previous = timestamp;
+            return true;
+        }
+        else if(deltatime_usec <= 0)
+        {
+            return false;
+        }
+
+
+        if(true == usehisto)
+        {
+            histo.add(deltatime_usec);
+        }
+
+        enabledAlert = false;
+        enabledReport = false;
+
+        // now i check ... should i alert?
+        if(deltatime_usec >= configuration.alertvalue)
+        {
+            enabledAlert = true;
+        }
+
+
+        if((true == usehisto) && ((timestamp - prevreport) > configuration.reportinterval))
+        {
+            prevreport = timestamp;
+            enabledReport = (configuration.reportinterval > 0) ? true : false;
+        }
+        return true;
+    }
+
+
+    bool reset()
+    {
+        previous = 0;
+        delta = 0;
+        prevreport = 0;
+        enabledReport = false;
+        enabledAlert = false;
+
+        histo.reset();
+
+        return true;
+    }
+
+
+    bool alert(std::uint64_t &deltatime_usec) const
+    {
+        deltatime_usec = delta;
+        return enabledAlert;
+    }
+
+
+    bool report() const
+    {
+        return enabledReport;
+    }
+
+    bool isInited() const
+    {
+        return inited;
+    }
+
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+// - all the rest
+// --------------------------------------------------------------------------------------------------------------------
+
+
+
+embot::tools::Histogram::Histogram()
+: pImpl(new Impl)
+{
+
+}
+
+embot::tools::Histogram::~Histogram()
+{
+    delete pImpl;
+}
+
+
+bool embot::tools::Histogram::init(const Config &config)
+{
+    return pImpl->init(config);
+}
+
+
+bool embot::tools::Histogram::reset()
+{
+    return pImpl->reset();
+}
+
+
+bool embot::tools::Histogram::add(std::uint64_t value)
+{
+    return pImpl->add(value);
+}
+
+const embot::tools::Histogram::Config * embot::tools::Histogram::getconfig() const
+{
+    return &pImpl->status.config;
+}
+
+const embot::tools::Histogram::Values * embot::tools::Histogram::getvalues() const
+{
+    return &pImpl->status.values;
+}
+
+//bool embot::tools::Histogram::probabilitydensityfunction(std::vector<std::uint32_t> &values, const std::uint32_t scale, const bool underflowisONE) const
+//{
+//    if(0 == pImpl->status.values.total)
+//    {
+//        values.clear();
+//        return false;
+//    }
+//
+//    values.resize(pImpl->status.values.inside.size() + 2);
+//
+//    std::uint32_t *ref = &values[0];
+//    std::uint64_t v64 = pImpl->status.values.below;
+//
+//    if(0 == v64)
+//    {
+//        *ref = 0;
+//    }
+//    else
+//    {
+//        *ref = static_cast<std::uint32_t>(scale * v64 / pImpl->status.values.total);
+//        if((0 == *ref) && (true == underflowisONE))
+//        {
+//            *ref = 1;
+//        }
+//    }
+//
+//    for(int i=0; i<pImpl->status.values.inside.size(); i++)
+//    {
+//        ref = &values[i+1];
+//        v64 = pImpl->status.values.inside[i];
+//        if(0 == v64)
+//        {
+//            *ref = 0;
+//        }
+//        else
+//        {
+//            *ref = static_cast<std::uint32_t>(scale * v64 / pImpl->status.values.total);
+//            if((0 == *ref) && (true == underflowisONE))
+//            {
+//                *ref = 1;
+//            }
+//        }
+//    }
+//
+//    ref = &values[values.size()-1];
+//    v64 = pImpl->status.values.beyond;
+//
+//    if(0 == v64)
+//    {
+//        *ref = 0;
+//    }
+//    else
+//    {
+//        *ref = static_cast<std::uint32_t>(scale * v64 / pImpl->status.values.total);
+//        if((0 == *ref) && (true == underflowisONE))
+//        {
+//            *ref = 1;
+//        }
+//    }
+//
+//    return true;
+//
+//}
+
+bool embot::tools::Histogram::probabilitydensityfunction(std::vector<double> &values) const
+{
+    if(0 == pImpl->status.values.total)
+    {
+        values.clear();
+        return false;
+    }
+
+    values.resize(pImpl->status.values.inside.size() + 2);
+
+    values[0] = static_cast<double>(pImpl->status.values.below) / static_cast<double>(pImpl->status.values.total);
+
+    for(int i=0; i<pImpl->status.values.inside.size(); i++)
+    {
+        values[i+1] = static_cast<double>(pImpl->status.values.inside[i]) / static_cast<double>(pImpl->status.values.total);
+    }
+
+    values[values.size()-1] = static_cast<double>(pImpl->status.values.beyond) / static_cast<double>(pImpl->status.values.total);
+
+    return true;
+}
+
+bool embot::tools::Histogram::probabilitydensityfunction(std::vector<std::uint32_t> &values, const std::uint32_t scale) const
+{
+    if(0 == pImpl->status.values.total)
+    {
+        values.clear();
+        return false;
+    }
+
+    values.resize(pImpl->status.values.inside.size() + 2);
+
+    values[0] = static_cast<std::uint32_t>(scale * pImpl->status.values.below / pImpl->status.values.total);
+
+    for(int i=0; i<pImpl->status.values.inside.size(); i++)
+    {
+        values[i+1] = static_cast<std::uint32_t>(scale * pImpl->status.values.inside[i] / pImpl->status.values.total);
+    }
+
+    values[values.size()-1] = static_cast<std::uint32_t>(scale * pImpl->status.values.beyond / pImpl->status.values.total);
+
+    return true;
+}
+
+
+embot::tools::PeriodValidator::PeriodValidator()
+: pImpl(new Impl)
+{
+
+}
+
+embot::tools::PeriodValidator::~PeriodValidator()
+{
+    delete pImpl;
+}
+
+
+bool embot::tools::PeriodValidator::init(const Config &config)
+{
+    return pImpl->init(config);
+}
+
+
+bool embot::tools::PeriodValidator::tick(std::uint64_t currtime_usec, std::uint64_t &deltatime_usec)
+{
+    return pImpl->tick(currtime_usec, deltatime_usec);
+}
+
+
+bool embot::tools::PeriodValidator::reset()
+{
+    return pImpl->reset();
+}
+
+
+bool embot::tools::PeriodValidator::alert(std::uint64_t &deltatime_usec) const
+{
+    return pImpl->alert(deltatime_usec);
+}
+
+bool embot::tools::PeriodValidator::report() const
+{
+    return pImpl->report();
+}
+
+
+const embot::tools::Histogram * embot::tools::PeriodValidator::histogram() const
+{
+    return &pImpl->histo;
+}
+
+
+
+
+
+embot::tools::RoundTripValidator::RoundTripValidator()
+: pImpl(new Impl)
+{
+
+}
+
+embot::tools::RoundTripValidator::~RoundTripValidator()
+{
+    delete pImpl;
+}
+
+
+bool embot::tools::RoundTripValidator::init(const Config &config)
+{
+    return pImpl->init(config);
+}
+
+
+bool embot::tools::RoundTripValidator::tick(std::uint64_t deltatime_usec, std::uint64_t  timestamp)
+{
+    return pImpl->tick(deltatime_usec, timestamp);
+}
+
+
+bool embot::tools::RoundTripValidator::reset()
+{
+    return pImpl->reset();
+}
+
+
+bool embot::tools::RoundTripValidator::alert(std::uint64_t &deltatime_usec) const
+{
+    return pImpl->alert(deltatime_usec);
+}
+
+bool embot::tools::RoundTripValidator::report() const
+{
+    return pImpl->report();
+}
+
+
+const embot::tools::Histogram * embot::tools::RoundTripValidator::histogram() const
+{
+    return &pImpl->histo;
+}
+
+
+bool embot::tools::RoundTripValidator::isInited() const
+{
+    return pImpl->isInited();
+}
+
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/src/libraries/icubmod/embObjLib/tools/src/embot_tools.h
+++ b/src/libraries/icubmod/embObjLib/tools/src/embot_tools.h
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2017 iCub Facility - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame, Valentina Gaggero
+ * email:   marco.accame@iit.it, Valentina.gaggero@iit.it
+ * website: www.robotcub.org
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+*/
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+
+#ifndef _EMBOT_TOOLS_H_
+#define _EMBOT_TOOLS_H_
+
+// - namespace embot::tools belongs to the embot (emBEDDED RObot) libray of C++11 classes and functions which are 
+// - designed to run in the icub/r1 robot's embedded environment.
+// - the objects inside this namespace are tools used to validate behaviours in the microcontrollers inside the robot
+// - but can also be used inside icub-main classes which runs on the PC104 platform
+// - hence particular attention was put in avoiding any call to YARP or embot::sys (RTOS) or embot::hw (HW of the micro). 
+// - we also don't use in here any embot::common funtions or types to guarantee maximum portability.
+
+#include <cstdint>
+#include <vector>
+
+namespace embot { namespace tools {
+    
+    class Histogram
+    {
+    public:
+        
+        struct Config
+        {   // there are nsteps() intervals each containing .step values which fill the range [.min, ... , .max)
+            std::uint64_t min {0};        // the start value of first interval.
+            std::uint64_t max {0};        // the upper limit of all possible values (which is actually max-1).
+            std::uint32_t step {0};       // the width of the interval 
+            Config() = default;
+            Config(std::uint64_t mi, std::uint64_t ma, std::uint32_t st) : min(mi), max(ma), step(st) {}
+            std::uint64_t range() const { return max - min; }
+            std::uint32_t nsteps() const { return ( (range() + step - 1) / step); }
+            bool isvalid() const { return ((0 == step) || (min >= max)) ? false : true; }
+        };
+        
+        struct Values
+        {
+            std::uint64_t               total {0};          // cumulative number = below + sum(inside) + beyond
+            std::uint64_t               below {0};          // number of occurrences in ( -INF, config.min )
+            std::uint64_t               beyond {0};         // number of occurrenced in [ inside.size() * config.step, +INF )
+            std::vector<std::uint64_t>  inside;             // inside[i] contains the number of occurrences in [ config.min + i*config.step, config.min + (i+1)*config.step )  
+        };
+            
+        
+        Histogram();
+        ~Histogram();
+    
+        bool init(const Config &config);
+        
+        bool add(std::uint64_t value);
+        
+        bool reset();  
+        
+        const embot::tools::Histogram::Config * getconfig() const;
+        const embot::tools::Histogram::Values * getvalues() const;
+        
+        // it generates the pdf in a vector which is long Config::nsteps()+2 item. 
+        // the first position contains probability that the value is < Config::min. 
+        // the last position keeps probability that the value is >= Config::max. 
+        // position i-th contain probability that value belongs inside [Config:min + i*Config::step, Config:min + (i+1)*Config::step).
+        bool probabilitydensityfunction(std::vector<std::uint32_t> &values, const std::uint32_t scale) const;
+        bool probabilitydensityfunction(std::vector<double> &values) const;
+        
+    private:        
+        struct Impl;
+        Impl *pImpl;    
+    };    
+    
+} } // namespace embot { namespace tools {
+
+
+
+
+namespace embot { namespace tools {
+    
+    // the object validates a given period expressed in micro-seconds.
+    class PeriodValidator
+    {
+    public:
+        
+        struct Config
+        {   
+            std::uint64_t                       period {0};                     // the period under test.
+            std::uint64_t                       alertvalue {0};                 // it is the value beyond which we produce an alert string. it must be > period.  
+            std::uint64_t                       reportinterval {0};             // if not zero, it keeps the value in usec between two reports
+            embot::tools::Histogram::Config     histoconfig {};                 // if is valid(), then we produce an histogram  
+            Config() = default;
+            Config(std::uint64_t pe, std::uint64_t al, std::uint64_t ri, const embot::tools::Histogram::Config &hi) 
+                : period(pe), alertvalue(al), reportinterval(ri), histoconfig(hi) {}
+            bool isvalid() const { return ((0 == period) || (period >= alertvalue)) ? false : true; }
+        };
+        
+        
+        PeriodValidator();
+        ~PeriodValidator();
+    
+        bool init(const Config &config);
+        
+        // it must be regularly called every Config.period micro-seconds.
+        // it accepts the current time, returns delta time from previous call of tick(), it computes a histogram of deltas.
+        // currtime_usec is the absolute time in micro-seconds (e.g., as generated by embot::sys::now() or by static_cast<std::uint64_t>(1000000.0*yarp::os::Time::now()))
+        bool tick(std::uint64_t currtime_usec, std::uint64_t &deltatime_usec);
+        
+        // it removes all that was previously added with tick().
+        bool reset();  
+        
+        // if true it is time for the regular report because more  than Config.reportinterval micro-seconds have passed from previous report time.
+        bool report() const;
+        
+        // if true: there is an alert because the current delta is > Config.alertvalue 
+        bool alert(std::uint64_t &deltatime_usec) const;
+        
+        // it returns the histogram
+        const embot::tools::Histogram * histogram() const;
+
+        bool isInited() const;
+
+        // example of usage: call it as regularly as possible
+        void how2use()
+        {
+            static bool initted = false;
+            if(!initted)
+            {
+                init({5000, 5000+50,  1000000,  // period is 5ms, with tolerance of 50us (1%), with report period every 1 sec.
+                      {4000, 6000, 100}});       // the histogram collects data in range [4ms, 6ms] with steps of 100 us, hence there are 20+2 entries
+
+                initted = true;
+            }
+            uint64_t tnow = 0; // e.g., = embot::sys::now() OR = static_cast<std::uint64_t>(1000000.0*yarp::os::Time::now())
+            uint64_t delta = 0;
+            tick(tnow, delta);
+            if(true == report())
+            {
+                const embot::tools::Histogram * histo = histogram();
+                // now you can print histo and if you like you can reset it
+                reset();
+            }
+        }
+               
+    private:        
+        struct Impl;
+        Impl *pImpl;    
+    };    
+    
+} } // namespace embot { namespace tools {
+
+
+namespace embot { namespace tools {
+
+    // the object validates a given period expressed in micro-seconds.
+    class RoundTripValidator
+    {
+    public:
+
+        struct Config
+        {
+            std::uint64_t                       period {0};                     // the period under test.
+            std::uint64_t                       alertvalue {0};                 // it is the value beyond which we produce an alert string. it must be > period.
+            std::uint64_t                       reportinterval {0};             // if not zero, it keeps the value in usec between two reports
+            embot::tools::Histogram::Config     histoconfig {};                 // if is valid(), then we produce an histogram
+            Config() = default;
+            Config(std::uint64_t pe, std::uint64_t al, std::uint64_t ri, const embot::tools::Histogram::Config &hi)
+            : period(pe), alertvalue(al), reportinterval(ri), histoconfig(hi) {}
+            bool isvalid() const { return ((0 == period) || (period >= alertvalue)) ? false : true; }
+        };
+
+
+        RoundTripValidator();
+        ~RoundTripValidator();
+
+        bool init(const Config &config);
+
+        // it must be regularly called every Config.period micro-seconds.
+        // it accepts the current time, returns delta time from previous call of tick(), it computes a histogram of deltas.
+        // currtime_usec is the absolute time in micro-seconds (e.g., as generated by embot::sys::now() or by static_cast<std::uint64_t>(1000000.0*yarp::os::Time::now()))
+        bool tick(std::uint64_t deltatime_usec, std::uint64_t timestamp);
+
+        // it removes all that was previously added with tick().
+        bool reset();
+
+        // if true it is time for the regular report because more  than Config.reportinterval micro-seconds have passed from previous report time.
+        bool report() const;
+
+        // if true: there is an alert because the current delta is > Config.alertvalue
+        bool alert(std::uint64_t &deltatime_usec) const;
+
+        // it returns the histogram
+        const embot::tools::Histogram * histogram() const;
+
+        bool isInited() const;
+
+
+
+    private:
+        struct Impl;
+        Impl *pImpl;
+    };
+
+} } // namespace embot { namespace tools {
+
+
+
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -265,7 +265,7 @@ embObjMotionControl::embObjMotionControl() :
     parser = NULL;
     _mcparser = NULL;
     
-#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+#ifdef NETWORK_PERFORMANCE_BENCHMARK 
        /* We would like to verify if the round trimp of request and answer from embedded board is about 3 milliseconds, with a tollerance 0f 0.250 milliseconds.
        The m_responseTimingVerifier object, after 3 seconds, prints an istogram with values from 1 to 10 millisec with a step of 0.5 millisec
     */
@@ -1574,13 +1574,13 @@ bool embObjMotionControl::helper_getPosPidRaw(int j, Pid *pid)
     eOmc_PID_t eoPID = {0};
 
     
-#ifdef NETWORK_PERFORMANCE_BANCHMARK  
+#ifdef NETWORK_PERFORMANCE_BENCHMARK  
     double start = yarp::os::Time::now();
 #endif
     
     bool ret = askRemoteValue(protid, &eoPID, size);
 
-#ifdef NETWORK_PERFORMANCE_BANCHMARK  
+#ifdef NETWORK_PERFORMANCE_BENCHMARK  
     double end = yarp::os::Time::now();
     m_responseTimingVerifier.tick(end-start, start);
 #endif

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -264,7 +264,13 @@ embObjMotionControl::embObjMotionControl() :
     }
     parser = NULL;
     _mcparser = NULL;
-
+    
+#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+       /* We would like to verify if the round trimp of request and answer from embedded board is about 3 milliseconds, with a tollerance 0f 0.250 milliseconds.
+       The m_responseTimingVerifier object, after 3 seconds, prints an istogram with values from 1 to 10 millisec with a step of 0.5 millisec
+    */
+     m_responseTimingVerifier.init(0.003, 0.00025, 0.001, 0.01, 0.0005, 30);
+#endif
 
 }
 
@@ -1566,7 +1572,20 @@ bool embObjMotionControl::helper_getPosPidRaw(int j, Pid *pid)
 
     uint16_t size;
     eOmc_PID_t eoPID = {0};
-    if(!askRemoteValue(protid, &eoPID, size))
+
+    
+#ifdef NETWORK_PERFORMANCE_BANCHMARK  
+    double start = yarp::os::Time::now();
+#endif
+    
+    bool ret = askRemoteValue(protid, &eoPID, size);
+
+#ifdef NETWORK_PERFORMANCE_BANCHMARK  
+    double end = yarp::os::Time::now();
+    m_responseTimingVerifier.tick(end-start, start);
+#endif
+    
+     if(!ret)
         return false;
 
     copyPid_eo2iCub(&eoPID, pid);

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -51,7 +51,7 @@ using namespace std;
 #include "eomcParser.h"
 #include "measuresConverter.h"
 
-#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+#ifdef NETWORK_PERFORMANCE_BENCHMARK 
 #include <PeriodicEventsVerifier.h>
 #endif
 
@@ -252,7 +252,7 @@ private:
     eOmc_impedance_t *_cacheImpedance;    /* cache impedance value to split up the 2 sets */
     
 
-#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+#ifdef NETWORK_PERFORMANCE_BENCHMARK 
     Tools:Emb_RensponseTimingVerifier m_responseTimingVerifier;
 #endif
 

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -51,6 +51,10 @@ using namespace std;
 #include "eomcParser.h"
 #include "measuresConverter.h"
 
+#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+#include <PeriodicEventsVerifier.h>
+#endif
+
 // - public #define  --------------------------------------------------------------------------------------------------
 
 #undef  VERIFY_ROP_SETIMPEDANCE     // this macro let you send setimpedence rop with signature.
@@ -248,6 +252,9 @@ private:
     eOmc_impedance_t *_cacheImpedance;    /* cache impedance value to split up the 2 sets */
     
 
+#ifdef NETWORK_PERFORMANCE_BANCHMARK 
+    Tools:Emb_RensponseTimingVerifier m_responseTimingVerifier;
+#endif
 
 private:
 


### PR DESCRIPTION
In this PR I developed two simple classes called `Emb_PeriodicEventVerifier and Emb_RensponseTimingVerifier: the first lets you to verify the frequency of a periodic event, while the second lets you to analyze the trend of response time to a request. Both classes prints an histogram with the collected information using the yarp log system.

I used these classes to check the embedded network performance.
I was interested in verifying if the `sender` and `receiver` singletons, that manage communication between `robotinterface` and the robot embedded network, run at configured frequency.
Moreover I also analyzed the response time of a request done to the embedded board. So I used `Emb_RensponseTimingVerifier` in the function `getPidRaw`, in order to examine the needed time to get a response from the motion control device driver.

Both above checks can be enabled by an advanced cmake flag called ` NETWORK_PERFORMANCE_BANCHMARK`.

