### PR TITLE
Support OpenCV4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         git clone https://github.com/microsoft/vcpkg.git --depth 1 --branch 2019.10 ${VCPKG_ROBOTOLOGY_ROOT}
         git clone https://github.com/robotology/robotology-vcpkg-binary-ports.git ${VCPKG_ROBOTOLOGY_BIN_PORTS_ROOT}
         ${VCPKG_ROBOTOLOGY_ROOT}/bootstrap-vcpkg.sh
-        ${VCPKG_ROBOTOLOGY_ROOT}/vcpkg.exe --overlay-ports=${VCPKG_ROBOTOLOGY_BIN_PORTS_ROOT} install --triplet x64-windows ace freeglut ode sdl1 gsl eigen3 libxml2 sdl1 opencv3 ipopt-binary
+        ${VCPKG_ROBOTOLOGY_ROOT}/vcpkg.exe --overlay-ports=${VCPKG_ROBOTOLOGY_BIN_PORTS_ROOT} install --triplet x64-windows ace freeglut ode sdl1 gsl eigen3 libxml2 sdl1 opencv ipopt-binary
         rm -rf ${VCPKG_ROBOTOLOGY_ROOT}/buildtrees ${VCPKG_ROBOTOLOGY_ROOT}/packages ${VCPKG_ROBOTOLOGY_ROOT}/downloads
         ${VCPKG_ROBOTOLOGY_ROOT}/vcpkg.exe --overlay-ports=${VCPKG_ROBOTOLOGY_BIN_PORTS_ROOT} install --triplet x64-windows qt5-base
         rm -rf ${VCPKG_ROBOTOLOGY_ROOT}/buildtrees ${VCPKG_ROBOTOLOGY_ROOT}/packages ${VCPKG_ROBOTOLOGY_ROOT}/downloads
@@ -52,7 +52,7 @@ jobs:
     - name: Dependencies [macOS]
       if: matrix.os == 'macOS-latest'
       run: |
-        brew install ace cmake eigen gsl ipopt opencv@3 pkg-config qt5
+        brew install ace cmake eigen gsl ipopt opencv pkg-config qt5
     
     - name: Dependencies [Ubuntu]
       if: matrix.os == 'ubuntu-latest'

--- a/src/modules/actionsRenderingEngine/include/iCub/VisuoThread.h
+++ b/src/modules/actionsRenderingEngine/include/iCub/VisuoThread.h
@@ -28,7 +28,7 @@
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Image.h>
 
-#include <cv.h>
+#include <opencv2/core/core_c.h>
 
 #include <mutex>
 #include <string>

--- a/src/modules/camCalib/include/iCub/CamCalibModule.h
+++ b/src/modules/camCalib/include/iCub/CamCalibModule.h
@@ -13,7 +13,7 @@
 #include <stdio.h>
 
 // opencv
-#include <cv.h>
+#include <opencv2/core/core_c.h>
 
 // yarp
 #include <yarp/os/all.h>

--- a/src/modules/camCalib/include/iCub/PinholeCalibTool.h
+++ b/src/modules/camCalib/include/iCub/PinholeCalibTool.h
@@ -16,7 +16,9 @@
 #include <math.h>
 
 // opencv
-#include <cv.h>
+#include <opencv2/core/core_c.h>
+#include <opencv2/calib3d/calib3d_c.h>
+#include <opencv2/calib3d.hpp>
 
 // yarp
 //#include <yarp/sig/Image.h>

--- a/src/modules/camCalib/include/iCub/SphericalCalibTool.h
+++ b/src/modules/camCalib/include/iCub/SphericalCalibTool.h
@@ -16,7 +16,7 @@
 #include <yarp/os/Value.h>
 
 // opencv
-#include <cv.h>
+#include <opencv2/core/core_c.h>
 
 // iCub
 #include <iCub/ICalibTool.h>

--- a/src/modules/camCalib/src/PinholeCalibTool.cpp
+++ b/src/modules/camCalib/src/PinholeCalibTool.cpp
@@ -179,8 +179,9 @@ bool PinholeCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
     _mapUndistortY = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
 
     /* init the undistortion matrices */
-    cvInitUndistortMap( _intrinsic_matrix_scaled, _distortion_coeffs,
-                        _mapUndistortX, _mapUndistortY);
+    cv::initUndistortRectifyMap(cv::cvarrToMat(_intrinsic_matrix_scaled), cv::cvarrToMat(_distortion_coeffs), cv::Mat(),
+                                cv::cvarrToMat(_intrinsic_matrix_scaled), cv::Size(currImgSize.width, currImgSize.height),
+                                CV_32FC1,cv::cvarrToMat(_mapUndistortX), cv::cvarrToMat(_mapUndistortY));
 
     _needInit = false;
     return true;

--- a/src/modules/camCalib/src/main.cpp
+++ b/src/modules/camCalib/src/main.cpp
@@ -133,7 +133,7 @@
 #include <iCub/CamCalibModule.h>
 
 // OpenCV
-#include <cv.h>
+#include <opencv2/core/core_c.h>
 
 using namespace std;
 using namespace yarp::os;

--- a/src/modules/camCalibWithPose/include/iCub/CamCalibModule.h
+++ b/src/modules/camCalibWithPose/include/iCub/CamCalibModule.h
@@ -15,7 +15,7 @@
 #include <map>
 
 // opencv
-#include <cv.h>
+#include <opencv2/core/core_c.h>
 
 // yarp
 #include <yarp/os/all.h>

--- a/src/modules/camCalibWithPose/include/iCub/PinholeCalibTool.h
+++ b/src/modules/camCalibWithPose/include/iCub/PinholeCalibTool.h
@@ -16,7 +16,9 @@
 #include <math.h>
 
 // opencv
-#include <cv.h>
+#include <opencv2/core/core_c.h>
+#include <opencv2/calib3d/calib3d_c.h>
+#include <opencv2/calib3d.hpp>
 
 // yarp
 //#include <yarp/sig/Image.h>

--- a/src/modules/camCalibWithPose/include/iCub/SphericalCalibTool.h
+++ b/src/modules/camCalibWithPose/include/iCub/SphericalCalibTool.h
@@ -16,7 +16,7 @@
 #include <yarp/os/Value.h>
 
 // opencv
-#include <cv.h>
+#include <opencv2/core/core_c.h>
 
 // iCub
 #include <iCub/ICalibTool.h>

--- a/src/modules/camCalibWithPose/src/PinholeCalibTool.cpp
+++ b/src/modules/camCalibWithPose/src/PinholeCalibTool.cpp
@@ -179,8 +179,9 @@ bool PinholeCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
     _mapUndistortY = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
 
     /* init the undistortion matrices */
-    cvInitUndistortMap( _intrinsic_matrix_scaled, _distortion_coeffs,
-                        _mapUndistortX, _mapUndistortY);
+    cv::initUndistortRectifyMap(cv::cvarrToMat(_intrinsic_matrix_scaled), cv::cvarrToMat(_distortion_coeffs), cv::Mat(),
+                                cv::cvarrToMat(_intrinsic_matrix_scaled), cv::Size(currImgSize.width, currImgSize.height),
+                                CV_32FC1,cv::cvarrToMat(_mapUndistortX), cv::cvarrToMat(_mapUndistortY));
 
     _needInit = false;
     return true;

--- a/src/modules/camCalibWithPose/src/main.cpp
+++ b/src/modules/camCalibWithPose/src/main.cpp
@@ -133,7 +133,7 @@
 #include <iCub/CamCalibModule.h>
 
 // OpenCV
-#include <cv.h>
+#include <opencv2/core/core_c.h>
 
 using namespace std;
 using namespace yarp::os;

--- a/src/modules/dualCamCalib/include/iCub/DualCamCalibModule.h
+++ b/src/modules/dualCamCalib/include/iCub/DualCamCalibModule.h
@@ -8,7 +8,7 @@
 #define __DUALCAMCALIBMODULE__
 
 // opencv
-#include <cv.h>
+#include <opencv2/core/core_c.h>
 
 // yarp
 #include <yarp/os/BufferedPort.h>

--- a/src/modules/dualCamCalib/include/iCub/PinholeCalibTool.h
+++ b/src/modules/dualCamCalib/include/iCub/PinholeCalibTool.h
@@ -16,7 +16,9 @@
 #include <math.h>
 
 // opencv
-#include <cv.h>
+#include <opencv2/core/core_c.h>
+#include <opencv2/calib3d/calib3d_c.h>
+#include <opencv2/calib3d.hpp>
 
 // yarp
 //#include <yarp/sig/Image.h>

--- a/src/modules/dualCamCalib/include/iCub/SphericalCalibTool.h
+++ b/src/modules/dualCamCalib/include/iCub/SphericalCalibTool.h
@@ -16,7 +16,7 @@
 #include <yarp/os/Value.h>
 
 // opencv
-#include <cv.h>
+#include <opencv2/core/core_c.h>
 
 // iCub
 #include <iCub/ICalibTool.h>

--- a/src/modules/dualCamCalib/src/PinholeCalibTool.cpp
+++ b/src/modules/dualCamCalib/src/PinholeCalibTool.cpp
@@ -179,9 +179,9 @@ bool PinholeCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
     _mapUndistortY = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
 
     /* init the undistortion matrices */
-    cvInitUndistortMap( _intrinsic_matrix_scaled, _distortion_coeffs,
-                        _mapUndistortX, _mapUndistortY);
-
+    cv::initUndistortRectifyMap(cv::cvarrToMat(_intrinsic_matrix_scaled), cv::cvarrToMat(_distortion_coeffs), cv::Mat(),
+                                cv::cvarrToMat(_intrinsic_matrix_scaled), cv::Size(currImgSize.width, currImgSize.height),
+                                CV_32FC1,cv::cvarrToMat(_mapUndistortX), cv::cvarrToMat(_mapUndistortY));
     _needInit = false;
     return true;
 }

--- a/src/modules/dualCamCalib/src/main.cpp
+++ b/src/modules/dualCamCalib/src/main.cpp
@@ -16,7 +16,7 @@
 #include <iCub/DualCamCalibModule.h>
 
 // OpenCV
-#include <cv.h>
+#include <opencv2/core/core_c.h>
 
 using namespace std;
 using namespace yarp::os;

--- a/src/modules/templatePFTracker/include/iCub/particleFilter.h
+++ b/src/modules/templatePFTracker/include/iCub/particleFilter.h
@@ -40,9 +40,8 @@
 #include <iostream>
 #include <iomanip>
 #include <deque>
-
-#include <cv.h>
-#include <highgui.h>
+#include <opencv2/core/core_c.h>
+#include <opencv2/imgproc/imgproc_c.h>
 
 /* default number of particles */
 #define PARTICLES 1000

--- a/src/tools/depth2kin/src/module.cpp
+++ b/src/tools/depth2kin/src/module.cpp
@@ -26,6 +26,7 @@
 #include <utility>
 
 #include <yarp/cv/Cv.h>
+#include <opencv2/imgproc/imgproc_c.h>
 #include <yarp/math/Math.h>
 #include <yarp/math/Rand.h>
 #include <yarp/math/NormRand.h>

--- a/src/tools/stereoCalib/include/stereoCalibThread.h
+++ b/src/tools/stereoCalib/include/stereoCalibThread.h
@@ -3,7 +3,13 @@
 #include <string>
 #include <mutex>
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/calib3d/calib3d_c.h>
+#include <opencv2/calib3d.hpp>
+#include <opencv2/core/core_c.h>
+#include <opencv2/core/types_c.h>
+#include <opencv2/imgcodecs.hpp>
+
+
 
 #include <yarp/os/all.h>
 #include <yarp/dev/all.h>

--- a/src/tools/stereoCalib/src/stereoCalibThread.cpp
+++ b/src/tools/stereoCalib/src/stereoCalibThread.cpp
@@ -830,7 +830,7 @@ void stereoCalibThread::saveCalibration(const string& extrinsicFilePath, const s
             return;
     }
 
-    FileStorage fs(intrinsicFilePath+".yml", CV_STORAGE_WRITE);
+    FileStorage fs(intrinsicFilePath+".yml", cv::FileStorage::Mode::WRITE);
     if( fs.isOpened() )
     {
         fs << "M1" << Kleft << "D1" << DistL << "M2" << Kright << "D2" << DistR;
@@ -839,7 +839,7 @@ void stereoCalibThread::saveCalibration(const string& extrinsicFilePath, const s
     else
         cout << "Error: can not save the intrinsic parameters\n";
 
-    fs.open(extrinsicFilePath+".yml", CV_STORAGE_WRITE);
+    fs.open(extrinsicFilePath+".yml", cv::FileStorage::Mode::WRITE);
     if( fs.isOpened() )
     {
         fs << "R" << R << "T" << T <<"Q" << Q;


### PR DESCRIPTION
This PR drops the support of OpenCV 2 and add the support to OpenCV 4.

TODO:

- [x] Compile with `opencv` 3.
- [x] Compile with `opencv` 4.
- [x] Test `camCalib`s.

It fixes #634 