### PR TITLE
Fix/cleanup of dependencies of embobj devices and tools

### DIFF
--- a/src/libraries/iCubDev/CMakeLists.txt
+++ b/src/libraries/iCubDev/CMakeLists.txt
@@ -2,8 +2,7 @@
 # Authors: Lorenzo Natale
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-SET(PROJECTNAME iCubDev)
-PROJECT(${PROJECTNAME})
+project(iCubDev)
 
 # Find .cpp and .h files automatically.  This is a bit lazy,
 # and in principle it would be better to list these files manually.
@@ -18,10 +17,13 @@ SOURCE_GROUP("Header Files" FILES ${folder_header})
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
 # Create everything needed to build our executable.
-add_library(${PROJECTNAME} ${folder_source} ${folder_header})
-target_link_libraries(${PROJECTNAME} ${YARP_LIBRARIES})
+add_library(${PROJECT_NAME} ${folder_source} ${folder_header})
+target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+target_link_libraries(${PROJECT_NAME} YARP::YARP_os
+                                      YARP::YARP_dev)
 
-icub_export_library(${PROJECTNAME} 
+icub_export_library(${PROJECT_NAME}
                     INTERNAL_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include 
                     DESTINATION include/iCub 
                     FILES ${folder_header})

--- a/src/libraries/icubmod/embObjAnalog/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjAnalog/CMakeLists.txt
@@ -12,10 +12,10 @@ IF (NOT SKIP_embObjAnalogSensor)
   set(ICUB_COMPILE_EMBOBJ_LIBRARY ON CACHE INTERNAL "use the embObjLib lib")
 
 #   message(INFO " embObjAnalogSensor - embObj_includes: ${embObj_includes}, ${CMAKE_CURRENT_SOURCE_DIR}/")
-  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${iCubDev_INCLUDE_DIRS})
+  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
   yarp_add_plugin(embObjAnalogSensor embObjAnalogSensor.cpp embObjAnalogSensor.h)
-  TARGET_LINK_LIBRARIES(embObjAnalogSensor ethResources ${YARP_LIBRARIES} ${ACE_LIBRARIES})
+  TARGET_LINK_LIBRARIES(embObjAnalogSensor ethResources iCubDev)
   icub_export_plugin(embObjAnalogSensor)
 
           yarp_install(TARGETS embObjAnalogSensor

--- a/src/libraries/icubmod/embObjFTsensor/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjFTsensor/CMakeLists.txt
@@ -13,10 +13,10 @@ IF (NOT SKIP_embObjFTsensor)
   set(ICUB_COMPILE_EMBOBJ_LIBRARY ON CACHE INTERNAL "use the embObjLib lib")
 
 #   message(INFO " embObjFTsensor - embObj_includes: ${embObj_includes}, ${CMAKE_CURRENT_SOURCE_DIR}/")
-  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${iCubDev_INCLUDE_DIRS} )
+  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
   yarp_add_plugin(embObjFTsensor embObjFTsensor.cpp embObjFTsensor.h eo_ftsens_privData.cpp eo_ftsens_privData.h)
-  TARGET_LINK_LIBRARIES(embObjFTsensor ethResources ${YARP_LIBRARIES} ${ACE_LIBRARIES})
+  TARGET_LINK_LIBRARIES(embObjFTsensor ethResources)
   icub_export_plugin(embObjFTsensor)
 
           yarp_install(TARGETS embObjFTsensor

--- a/src/libraries/icubmod/embObjIMU/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjIMU/CMakeLists.txt
@@ -13,10 +13,10 @@ IF (NOT SKIP_embObjIMU)
   set(ICUB_COMPILE_EMBOBJ_LIBRARY ON CACHE INTERNAL "use the embObjLib lib")
 
 #   message(INFO " embObjIMU - embObj_includes: ${embObj_includes}, ${CMAKE_CURRENT_SOURCE_DIR}/")
-  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${iCubDev_INCLUDE_DIRS} )
+  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
   yarp_add_plugin(embObjIMU embObjIMU.cpp embObjIMU.h eo_imu_privData.h  eo_imu_privData.cpp imuMeasureConverter.cpp imuMeasureConverter.h )
-  TARGET_LINK_LIBRARIES(embObjIMU ethResources ${YARP_LIBRARIES} ${ACE_LIBRARIES})
+  TARGET_LINK_LIBRARIES(embObjIMU ethResources)
   icub_export_plugin(embObjIMU)
 
         yarp_install(TARGETS embObjIMU
@@ -25,5 +25,5 @@ IF (NOT SKIP_embObjIMU)
                ARCHIVE DESTINATION ${ICUB_STATIC_PLUGINS_INSTALL_DIR}
                YARP_INI DESTINATION ${ICUB_PLUGIN_MANIFESTS_INSTALL_DIR})
 
-ENDIF (NOT SKIP_embObjIMU)
+ENDIF ()
 

--- a/src/libraries/icubmod/embObjInertials/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjInertials/CMakeLists.txt
@@ -12,10 +12,10 @@ IF (NOT SKIP_embObjInertials)
   set(ICUB_COMPILE_EMBOBJ_LIBRARY ON CACHE INTERNAL "use the embObjLib lib")
 
 #   message(INFO " embObjInertials - embObj_includes: ${embObj_includes}, ${CMAKE_CURRENT_SOURCE_DIR}/")
-  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${iCubDev_INCLUDE_DIRS} )
+  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
   yarp_add_plugin(embObjInertials embObjInertials.cpp embObjInertials.h)
-  TARGET_LINK_LIBRARIES(embObjInertials ethResources ${YARP_LIBRARIES} ${ACE_LIBRARIES})
+  TARGET_LINK_LIBRARIES(embObjInertials ethResources iCubDev)
   icub_export_plugin(embObjInertials)
 
         yarp_install(TARGETS embObjInertials
@@ -24,5 +24,5 @@ IF (NOT SKIP_embObjInertials)
                ARCHIVE DESTINATION ${ICUB_STATIC_PLUGINS_INSTALL_DIR}
                YARP_INI DESTINATION ${ICUB_PLUGIN_MANIFESTS_INSTALL_DIR})
 
-ENDIF (NOT SKIP_embObjInertials)
+ENDIF ()
 

--- a/src/libraries/icubmod/embObjMais/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjMais/CMakeLists.txt
@@ -13,10 +13,10 @@ IF (NOT SKIP_embObjMais)
   set(ICUB_COMPILE_EMBOBJ_LIBRARY ON CACHE INTERNAL "use the embObjLib lib")
 
 #   message(INFO " embObjMais - embObj_includes: ${embObj_includes}, ${CMAKE_CURRENT_SOURCE_DIR}/")
-  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${iCubDev_INCLUDE_DIRS})
+  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
   yarp_add_plugin(embObjMais embObjMais.cpp embObjMais.h)
-  TARGET_LINK_LIBRARIES(embObjMais ethResources ${YARP_LIBRARIES} ${ACE_LIBRARIES})
+  TARGET_LINK_LIBRARIES(embObjMais ethResources iCubDev)
   icub_export_plugin(embObjMais)
 
        yarp_install(TARGETS embObjMais
@@ -25,5 +25,5 @@ IF (NOT SKIP_embObjMais)
                ARCHIVE DESTINATION ${ICUB_STATIC_PLUGINS_INSTALL_DIR}
                YARP_INI DESTINATION ${ICUB_PLUGIN_MANIFESTS_INSTALL_DIR})
 
-ENDIF (NOT SKIP_embObjMais)
+ENDIF ()
 

--- a/src/libraries/icubmod/embObjMotionControl/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjMotionControl/CMakeLists.txt
@@ -16,12 +16,11 @@ yarp_prepare_plugin(embObjMotionControl
 
   set(ICUB_COMPILE_EMBOBJ_LIBRARY ON CACHE INTERNAL "use the embObjLib lib")
   
-  INCLUDE_DIRECTORIES(SYSTEM ${ACE_INCLUDE_DIRS})
-  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${iCubDev_INCLUDE_DIRS})
+  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
 #    yarp_add_plugin(embObjMotionControl embObjMotionControl.cpp embObjMotionControl.h usrcbk/eOcfg_nvsEP_mc_usrcbk_pippo.c )
     yarp_add_plugin(embObjMotionControl embObjMotionControl.cpp embObjMotionControl.h eomcParser.cpp eomcParser.h measuresConverter.cpp measuresConverter.h eomcUtils.h)
-    TARGET_LINK_LIBRARIES(embObjMotionControl ethResources iCubDev ${YARP_LIBRARIES} ${ACE_LIBRARIES})
+    TARGET_LINK_LIBRARIES(embObjMotionControl ethResources iCubDev)
     icub_export_plugin(embObjMotionControl)
     
       yarp_install(TARGETS embObjMotionControl
@@ -30,5 +29,5 @@ yarp_prepare_plugin(embObjMotionControl
                ARCHIVE DESTINATION ${ICUB_STATIC_PLUGINS_INSTALL_DIR}
                YARP_INI DESTINATION ${ICUB_PLUGIN_MANIFESTS_INSTALL_DIR})
         
-ENDIF (NOT SKIP_embObjMotionControl)
+ENDIF ()
 

--- a/src/libraries/icubmod/embObjMultiEnc/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjMultiEnc/CMakeLists.txt
@@ -13,10 +13,10 @@ IF (NOT SKIP_embObjMultiEnc)
   set(ICUB_COMPILE_EMBOBJ_LIBRARY ON CACHE INTERNAL "use the embObjLib lib")
 
 #   message(INFO " embObjMultiEnc - embObj_includes: ${embObj_includes}, ${CMAKE_CURRENT_SOURCE_DIR}/")
-  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${iCubDev_INCLUDE_DIRS} )
+  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
   yarp_add_plugin(embObjMultiEnc embObjMultiEnc.cpp embObjMultiEnc.h)
-  TARGET_LINK_LIBRARIES(embObjMultiEnc ethResources ${YARP_LIBRARIES} ${ACE_LIBRARIES})
+  TARGET_LINK_LIBRARIES(embObjMultiEnc ethResources iCubDev)
   icub_export_plugin(embObjMultiEnc)
 
    yarp_install(TARGETS embObjMultiEnc
@@ -26,5 +26,5 @@ IF (NOT SKIP_embObjMultiEnc)
                YARP_INI DESTINATION ${ICUB_PLUGIN_MANIFESTS_INSTALL_DIR})
 
 
-ENDIF (NOT SKIP_embObjMultiEnc)
+ENDIF ()
 

--- a/src/libraries/icubmod/embObjPSC/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjPSC/CMakeLists.txt
@@ -12,10 +12,10 @@ IF (NOT SKIP_embObjPSC)
 
   set(ICUB_COMPILE_EMBOBJ_LIBRARY ON CACHE INTERNAL "use the embObjLib lib")
 
-  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${iCubDev_INCLUDE_DIRS})
+  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
   yarp_add_plugin(embObjPSC embObjPSC.cpp embObjPSC.h)
-  TARGET_LINK_LIBRARIES(embObjPSC ethResources ${YARP_LIBRARIES} ${ACE_LIBRARIES})
+  TARGET_LINK_LIBRARIES(embObjPSC ethResources iCubDev)
   icub_export_plugin(embObjPSC)
 
  yarp_install(TARGETS embObjPSC

--- a/src/libraries/icubmod/embObjStrain/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjStrain/CMakeLists.txt
@@ -13,10 +13,10 @@ IF (NOT SKIP_embObjStrain)
   set(ICUB_COMPILE_EMBOBJ_LIBRARY ON CACHE INTERNAL "use the embObjLib lib")
 
 #   message(INFO " embObjStrain - embObj_includes: ${embObj_includes}, ${CMAKE_CURRENT_SOURCE_DIR}/")
-  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${iCubDev_INCLUDE_DIRS} )
+  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
   yarp_add_plugin(embObjStrain embObjStrain.cpp embObjStrain.h)
-  TARGET_LINK_LIBRARIES(embObjStrain ethResources ${YARP_LIBRARIES} ${ACE_LIBRARIES})
+  TARGET_LINK_LIBRARIES(embObjStrain ethResources iCubDev)
   icub_export_plugin(embObjStrain)
 
   yarp_install(TARGETS embObjStrain
@@ -25,5 +25,5 @@ IF (NOT SKIP_embObjStrain)
                ARCHIVE DESTINATION ${ICUB_STATIC_PLUGINS_INSTALL_DIR}
                YARP_INI DESTINATION ${ICUB_PLUGIN_MANIFESTS_INSTALL_DIR})
 
-ENDIF (NOT SKIP_embObjStrain)
+ENDIF ()
 

--- a/src/libraries/icubmod/embObjVirtualAnalogSensor/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjVirtualAnalogSensor/CMakeLists.txt
@@ -7,11 +7,11 @@ yarp_prepare_plugin(embObjVirtualAnalogSensor CATEGORY device TYPE yarp::dev::em
 IF (NOT SKIP_embObjVirtualAnalogSensor)
 
     set(ICUB_COMPILE_EMBOBJ_LIBRARY ON CACHE INTERNAL "use the embObjLib lib")
-    INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${iCubDev_INCLUDE_DIRS} )
+    INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
     yarp_add_plugin(embObjVirtualAnalogSensor embObjVirtualAnalogSensor.cpp embObjVirtualAnalogSensor.h)
 
-    TARGET_LINK_LIBRARIES(embObjVirtualAnalogSensor ethResources ${YARP_LIBRARIES} ${ACE_LIBRARIES})
+    TARGET_LINK_LIBRARIES(embObjVirtualAnalogSensor ethResources iCubDev)
     icub_export_plugin(embObjVirtualAnalogSensor)
 
   yarp_install(TARGETS embObjVirtualAnalogSensor
@@ -20,5 +20,5 @@ IF (NOT SKIP_embObjVirtualAnalogSensor)
                ARCHIVE DESTINATION ${ICUB_STATIC_PLUGINS_INSTALL_DIR}
                YARP_INI DESTINATION ${ICUB_PLUGIN_MANIFESTS_INSTALL_DIR})
 
-ENDIF (NOT SKIP_embObjVirtualAnalogSensor)
+ENDIF ()
 

--- a/src/libraries/icubmod/parametricCalibrator/CMakeLists.txt
+++ b/src/libraries/icubmod/parametricCalibrator/CMakeLists.txt
@@ -6,11 +6,10 @@
 yarp_prepare_plugin(parametricCalibrator CATEGORY device TYPE yarp::dev::parametricCalibrator INCLUDE parametricCalibrator.h)
 
 if(ENABLE_parametricCalibrator)
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR}
-                       ${iCubDev_INCLUDE_DIRS})
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
     yarp_add_plugin(parametricCalibrator parametricCalibrator.h parametricCalibrator.cpp)
-    target_link_libraries(parametricCalibrator ${YARP_LIBRARIES})
+    target_link_libraries(parametricCalibrator iCubDev)
     icub_export_plugin(parametricCalibrator)
     
   yarp_install(TARGETS parametricCalibrator

--- a/src/libraries/icubmod/parametricCalibratorEth/CMakeLists.txt
+++ b/src/libraries/icubmod/parametricCalibratorEth/CMakeLists.txt
@@ -5,11 +5,10 @@
 yarp_prepare_plugin(parametricCalibratorEth CATEGORY device TYPE yarp::dev::parametricCalibratorEth INCLUDE parametricCalibratorEth.h)
 
 if(ENABLE_parametricCalibratorEth)
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR}
-                       ${iCubDev_INCLUDE_DIRS})
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
     yarp_add_plugin(parametricCalibratorEth parametricCalibratorEth.h parametricCalibratorEth.cpp)
-    target_link_libraries(parametricCalibratorEth ${YARP_LIBRARIES})
+    target_link_libraries(parametricCalibratorEth iCubDev)
     icub_export_plugin(parametricCalibratorEth)
 
   yarp_install(TARGETS parametricCalibratorEth
@@ -18,4 +17,4 @@ if(ENABLE_parametricCalibratorEth)
                ARCHIVE DESTINATION ${ICUB_STATIC_PLUGINS_INSTALL_DIR}
                YARP_INI DESTINATION ${ICUB_PLUGIN_MANIFESTS_INSTALL_DIR})
 
-endif(ENABLE_parametricCalibratorEth)
+endif()

--- a/src/libraries/icubmod/skinWrapper/CMakeLists.txt
+++ b/src/libraries/icubmod/skinWrapper/CMakeLists.txt
@@ -2,18 +2,17 @@
 # Authors: Alberto Cardellino
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-SET(PROJECTNAME skinWrapper)
-PROJECT(${PROJECTNAME})
+project(skinWrapper)
 
-yarp_prepare_plugin(${PROJECTNAME} CATEGORY device TYPE skinWrapper INCLUDE ${PROJECTNAME}.h)
+yarp_prepare_plugin(${PROJECT_NAME} CATEGORY device TYPE skinWrapper INCLUDE ${PROJECT_NAME}.h)
 
-IF (NOT SKIP_${PROJECTNAME})
+IF (NOT SKIP_${PROJECT_NAME})
   INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/src/libraries/icubmod/analogServer)
-  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${iCubDev_INCLUDE_DIRS})
+  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
-  yarp_add_plugin(${PROJECTNAME} ${PROJECTNAME}.cpp ${PROJECTNAME}.h)
-  TARGET_LINK_LIBRARIES(${PROJECTNAME} ${YARP_LIBRARIES} ${ACE_LIBRARIES})
-  icub_export_plugin(${PROJECTNAME})
+  yarp_add_plugin(${PROJECT_NAME} ${PROJECT_NAME}.cpp ${PROJECT_NAME}.h)
+  TARGET_LINK_LIBRARIES(${PROJECT_NAME} iCubDev ACE::ACE)
+  icub_export_plugin(${PROJECT_NAME})
 
   yarp_install(TARGETS skinWrapper
                COMPONENT Runtime
@@ -21,4 +20,4 @@ IF (NOT SKIP_${PROJECTNAME})
                ARCHIVE DESTINATION ${ICUB_STATIC_PLUGINS_INSTALL_DIR}
                YARP_INI DESTINATION ${ICUB_PLUGIN_MANIFESTS_INSTALL_DIR})
 
-ENDIF (NOT SKIP_${PROJECTNAME})
+ENDIF ()

--- a/src/tools/canLoader/canLoader/CMakeLists.txt
+++ b/src/tools/canLoader/canLoader/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors: Lorenzo Natale
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-set(PROJECTNAME canLoader)
+project(canLoader)
 
 file(GLOB folder_source *.cpp)
 file(GLOB folder_header *.h)
@@ -12,21 +12,12 @@ source_group("Header Files" FILES ${folder_header})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../canLoaderLib)
 include_directories(${GTK2_INCLUDE_DIRS})
-include_directories(${ACE_INCLUDE_DIRS})
-include_directories(${icub_firmware_shared_canProtocolLib_INCLUDE_DIR})
 
 
-include_directories(${icub_firmware_shared_canProtocolLib_INCLUDE_DIR}/canProtocolLib)
-include_directories(${icub_firmware_shared_embobj_INCLUDE_DIR}/embobj/plus/comm-v2/icub/)
-include_directories(${icub_firmware_shared_embobj_INCLUDE_DIR}/embobj/core/core)
+add_executable(${PROJECT_NAME} ${folder_source} ${folder_header})
 
+target_link_libraries(${PROJECT_NAME} canLoaderLib
+                                     ${GTK2_LIBRARIES})
 
-add_executable(${PROJECTNAME} ${folder_source} ${folder_header})
-
-target_link_libraries(${PROJECTNAME} canLoaderLib
-                                     ${GTK2_LIBRARIES}
-                                     ${YARP_LIBRARIES}
-                                     ${ACE_LIBRARIES})
-
-install(TARGETS ${PROJECTNAME} DESTINATION bin)
+install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 

--- a/src/tools/canLoader/canLoaderLib/CMakeLists.txt
+++ b/src/tools/canLoader/canLoaderLib/CMakeLists.txt
@@ -14,11 +14,8 @@ source_group("Header Files" FILES ${folder_header})
 
 add_library(${PROJECT_NAME} ${folder_source} ${folder_header})
 
-target_link_libraries(${PROJECT_NAME} PUBLIC YARP::YARP_os
-                                             YARP::YARP_dev
-                                             ACE::ACE
-                                             ethResources
-                                             icub_firmware_shared::embobj)
+target_link_libraries(${PROJECT_NAME} PUBLIC YARP::YARP_dev
+                                             ethResources)
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
                                                   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 

--- a/src/tools/controlBoardDumper/CMakeLists.txt
+++ b/src/tools/controlBoardDumper/CMakeLists.txt
@@ -24,8 +24,7 @@ FILE(GLOB folder_header *.h)
 SOURCE_GROUP("Source Files" FILES ${folder_source})
 SOURCE_GROUP("Header Files" FILES ${folder_header})
 
-include_directories(${iCubDev_INCLUDE_DIRS})
 ADD_EXECUTABLE(controlBoardDumper ${folder_source} ${folder_header})
-target_link_libraries(controlBoardDumper ${YARP_LIBRARIES})
+target_link_libraries(controlBoardDumper iCubDev YARP::YARP_init)
 INSTALL(TARGETS controlBoardDumper DESTINATION bin)
 

--- a/src/tools/ethLoader/ethLoader/CMakeLists.txt
+++ b/src/tools/ethLoader/ethLoader/CMakeLists.txt
@@ -3,6 +3,7 @@
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
 set(PROJECTNAME ethLoader)
+project(ethLoader)
 
 file(GLOB folder_source *.cpp)
 file(GLOB folder_header *.h)
@@ -11,21 +12,15 @@ source_group("Source Files" FILES ${folder_source})
 source_group("Header Files" FILES ${folder_header})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../ethLoaderLib)
-include_directories(${ACE_INCLUDE_DIRS})
 include_directories(${GTK2_INCLUDE_DIRS})
 
-include_directories(${icub_firmware_shared_canProtocolLib_INCLUDE_DIR}/canProtocolLib)
-include_directories(${icub_firmware_shared_embobj_INCLUDE_DIR}/embobj/plus/comm-v2/icub/)
-include_directories(${icub_firmware_shared_embobj_INCLUDE_DIR}/embobj/core/core)
 
 
-add_executable(${PROJECTNAME} ${folder_source} ${folder_header})
+add_executable(${PROJECT_NAME} ${folder_source} ${folder_header})
 
-target_link_libraries(${PROJECTNAME}
+target_link_libraries(${PROJECT_NAME}
                       ethLoaderLib 
-                      ${GTK2_LIBRARIES}
-                      ${YARP_LIBRARIES}
-                      ${ACE_LIBRARIES})
+                      ${GTK2_LIBRARIES})
 
-install(TARGETS ${PROJECTNAME} DESTINATION bin)
+install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 


### PR DESCRIPTION
This PR add `target_include_directories` to `iCubDev` and it does some cleanup in the `CmakeLists.txt` in order that each target link only the libraries it need.

It should fix the regression on Ubuntu builds of #649 (see https://github.com/robotology/robotology-superbuild/issues/372#issue-592419756)

I tested it on my machine and it compiles fine from a clean setup