### PR TITLE
Fix compilation of the bindings after mutexes cleanup

### DIFF
--- a/bindings/icub.i
+++ b/bindings/icub.i
@@ -92,6 +92,7 @@ using namespace yarp::sig;
 // skinDynLib
 %include <iCub/skinDynLib/common.h>
 %include <iCub/skinDynLib/Taxel.h>
+%ignore  iCub::skinDynLib::skinPartBase::recursive_mtx;
 %include <iCub/skinDynLib/skinPart.h>
 %include <iCub/skinDynLib/iCubSkin.h>
 %include <iCub/skinDynLib/dynContact.h>


### PR DESCRIPTION
This PR fixes #645 .

The compilation should be fine my only concern is that maybe there could be runtime issues, but I don't know how to test it. I might need help on it.