### PR TITLE
Fix use of FindESDCANAPI.cmake with esdcan-binary vcpkg port

### DIFF
--- a/conf/FindESDCANAPI.cmake
+++ b/conf/FindESDCANAPI.cmake
@@ -68,8 +68,7 @@ if(NOT ESDCANAPI_FOUND)
     # Find library
     find_library(ESDCANAPI_LIB
                  NAMES "ntcan"
-                 PATHS ${ESDCAN_LIB_DIRS}
-                 NO_DEFAULT_PATH)
+                 PATHS ${ESDCAN_LIB_DIRS})
 
     # Find include file
     find_path(ESDCANAPI_INC_DIRS


### PR DESCRIPTION
This has been already fixed  in YCM in https://github.com/robotology/ycm/pull/320 .
The fix is backported to the master branch of icub-main to simplify the integration of esdcan-binary vcpkg port in the existing CI infrastructure, see https://github.com/robotology/robotology-superbuild/pull/397 . 