### PR TITLE
iCubGui: In BVHNodeEYE switch from glutSolidSphere to gluSphere

### DIFF
--- a/src/tools/iCubGui/src/bvhnodeeye.h
+++ b/src/tools/iCubGui/src/bvhnodeeye.h
@@ -30,10 +30,10 @@ public:
     virtual void drawJoint()
     {
         glColor4f(1.0,1.0,1.0,1.0);
-        glutSolidSphere(20.32,16,16);
+        gluSphere(cyl,20.32,16,16);
         glTranslated(0.0,0.0,20.32);
         glColor4f(0.0,0.0,0.0,1.0);
-        glutSolidSphere(5.08,16,16);
+        gluSphere(cyl,5.08,16,16);
     }
 };
 


### PR DESCRIPTION
I am not an expert of glut, but apparently there are functions that start with `glu***` and take in input a pointer to `GLUquadricObj`, and functions that start with `glut` and do not take in input a pointer to `GLUquadricObj`. BVHNodeEYE  was the only class that used a `glut***` function, and during the call when used with freeglut installed via vcpkg it was crashing  with error: 
~~~
Exception thrown: read access violation.
fgStructure.**CurrentWindow** was nullptr. occurred
~~~
and the backtrace was: 
~~~
 	freeglutd.dll!fghDrawGeometrySolid(float * vertices, float * normals, float * textcs, int numVertices, wchar_t * vertIdxs, int numParts, int numVertIdxsPerPart) Line 181	C
 	freeglutd.dll!fghSphere(float radius, int slices, int stacks, unsigned char useWireMode) Line 1721	C
 	freeglutd.dll!glutSolidSphere(double radius, int slices, int stacks) Line 2066	C
>	iCubGui.exe!BVHNodeEYE::drawJoint() Line 34	C++
~~~

Changing from `glutSolidSphere` to `gluSphere` as done the other classes that inherit from `BVHNodeDH` fixes the crash. 

Fix https://github.com/robotology/robotology-superbuild/issues/355 .