### PR TITLE
Fix bindings compilation from a clean directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig libopencv-dev qtbase5-dev \
-                                 qtdeclarative5-dev qtmultimedia5-dev libtinyxml-dev libgsl-dev 
+                                 qtdeclarative5-dev qtmultimedia5-dev libtinyxml-dev libgsl-dev libpython3-dev swig
         
     - name: Source-based Dependencies [Windows] 
       if: matrix.os == 'windows-latest'
@@ -155,6 +155,12 @@ jobs:
               -DENABLE_icubmod_embObjVirtualAnalogSensor:BOOL=ON -DENABLE_icubmod_parametricCalibrator:BOOL=ON \
               -DENABLE_icubmod_parametricCalibratorEth:BOOL=ON \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+    - name: Enable python bindings on Ubuntu 
+      if: matrix.os == 'ubuntu-latest'
+      run: | 
+        cd build
+        # Enable ICUB_COMPILE_BINDINGS in Ubuntu 
+        cmake -DICUB_COMPILE_BINDINGS:BOOL=ON -DCREATE_PYTHON:BOOL=ON .
       
     - name: Build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         cd ${GITHUB_WORKSPACE}
         git clone https://github.com/robotology/yarp.git --depth 1 --branch master
         cd yarp && mkdir -p build && cd build
-        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
+        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DYARP_COMPILE_GUIS:BOOL=OFF \
               -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL
         # icub-firmware-shared
@@ -103,7 +103,7 @@ jobs:
         cd ${GITHUB_WORKSPACE}
         git clone https://github.com/robotology/yarp.git --depth 1 --branch master
         cd yarp && mkdir -p build && cd build
-        cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+        cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DYARP_COMPILE_GUIS:BOOL=OFF ..
         cmake --build . --config ${{ matrix.build_type }} --target install
         # icub-firmware-shared
         cd ${GITHUB_WORKSPACE}

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -13,22 +13,25 @@ foreach(_component conf os sig dev math gsl)
   include_directories(${YARP_${_component}_INCLUDE_DIRS})
 endforeach()
 
-find_package(ICUB REQUIRED)
-include_directories(${ICUB_INCLUDE_DIRS})
-link_directories(${ICUB_LIBRARY_DIRS})
-link_libraries(${ICUB_LIBRARIES})
-
 # Work-around for missing paths to OpenCV libraries
 find_package(OpenCV)
 if(OpenCV_FOUND)
     link_directories(${OpenCV_LINK_DIRECTORIES} ${OPENCV_LINK_DIRECTORIES})
 endif()
 
+set(ICUB_SWIG_LIBRARIES ctrlLib
+                        iDyn
+                        iKin
+                        skinDynLib
+                        optimization)
+
+#TODO this has to been removed as soon as swig fully support target_include_directories
 include_directories(${CMAKE_SOURCE_DIR}/src/libraries/iDyn/include)
 include_directories(${CMAKE_SOURCE_DIR}/src/libraries/iKin/include)
 include_directories(${CMAKE_SOURCE_DIR}/src/libraries/ctrlLib/include)
 include_directories(${CMAKE_SOURCE_DIR}/src/libraries/skinDynLib/include)
 include_directories(${CMAKE_SOURCE_DIR}/src/libraries/optimization/include)
+
 
 # for yarp.i
 include_directories(${YARP_BINDINGS})
@@ -56,7 +59,7 @@ if(CREATE_PYTHON)
     swig_add_library(icub_python
                      LANGUAGE python
                      SOURCES icub.i)
-    target_link_libraries(${SWIG_MODULE_icub_python_REAL_NAME} Python::Python)
+    target_link_libraries(${SWIG_MODULE_icub_python_REAL_NAME} Python::Python ${ICUB_SWIG_LIBRARIES})
     set_target_properties(${SWIG_MODULE_icub_python_REAL_NAME} PROPERTIES OUTPUT_NAME "_icub")
 
     # installation path is determined reliably on most platforms using distutils
@@ -97,7 +100,7 @@ if(CREATE_RUBY)
     swig_add_library(icub_ruby
                      LANGUAGE ruby
                      SOURCES icub.i)
-    swig_link_libraries(icub_ruby ${RUBY_LIBRARY})
+    target_link_libraries(${SWIG_MODULE_icub_ruby_REAL_NAME} ${RUBY_LIBRARY} ${ICUB_SWIG_LIBRARIES})
     target_include_directories(${SWIG_MODULE_icub_ruby_REAL_NAME} SYSTEM PRIVATE ${RUBY_INCLUDE_PATH})
     set_target_properties(${SWIG_MODULE_icub_ruby_REAL_NAME} PROPERTIES OUTPUT_NAME "icub"
                                                                       LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/ruby")
@@ -114,9 +117,9 @@ if(CREATE_JAVA)
                      LANGUAGE java
                      SOURCES icub.i)
 
-    swig_link_libraries(icub_java ${SWIG_YARP_LIBRARIES})
+    target_link_libraries(${SWIG_MODULE_icub_java_REAL_NAME} ${SWIG_ICUB_LIBRARIES})
     if(APPLE)
-      set_target_properties(icub PROPERTIES SUFFIX ".jnilib")
+      set_target_properties(${SWIG_MODULE_icub_java_REAL_NAME} PROPERTIES SUFFIX ".jnilib")
     endif(APPLE)
 endif()
 
@@ -126,7 +129,7 @@ if(CREATE_CSHARP)
                      LANGUAGE csharp
                      SOURCES icub.i)
 
-  swig_link_libraries(icub_csharp ${SWIG_YARP_LIBRARIES})
+  target_link_libraries(${SWIG_MODULE_icub_csharp_REAL_NAME} ${SWIG_ICUB_LIBRARIES})
   set_target_properties(${SWIG_MODULE_icub_csharp_REAL_NAME} PROPERTIES OUTPUT_NAME "icub" LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/csharp")
 endif()
 
@@ -137,6 +140,6 @@ if(CREATE_LUA)
   swig_add_library(icub_lua
                    LANGUAGE lua
                    SOURCES icub.i)
-  swig_link_libraries(icub_lua ${LUA_LIBRARY})
+  target_link_libraries(${SWIG_MODULE_icub_lua_REAL_NAME} ${LUA_LIBRARY} ${ICUB_SWIG_LIBRARIES})
   set_target_properties(${SWIG_MODULE_icub_lua_REAL_NAME} PROPERTIES OUTPUT_NAME "icub" LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/lua")
 endif()

--- a/src/tools/canLoader/canLoaderLib/CMakeLists.txt
+++ b/src/tools/canLoader/canLoaderLib/CMakeLists.txt
@@ -14,8 +14,10 @@ source_group("Header Files" FILES ${folder_header})
 
 add_library(${PROJECT_NAME} ${folder_source} ${folder_header})
 
-target_link_libraries(${PROJECT_NAME} PUBLIC YARP::YARP_dev
-                                             ethResources)
+target_link_libraries(${PROJECT_NAME} PUBLIC YARP::YARP_os
+                                             YARP::YARP_dev
+                                             ACE::ACE
+                                             icub_firmware_shared::embobj)
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
                                                   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 


### PR DESCRIPTION
This cleanup make possible to compile the bindings from a clean build.
In this sense I enabled it in the CI for see if now they works.