### PR TITLE
emotioninterface: add the command for controlling the eyelids for the rfe configuration

### DIFF
--- a/app/faceExpressions/conf/emotions_rfe.ini
+++ b/app/faceExpressions/conf/emotions_rfe.ini
@@ -2,19 +2,19 @@
 emotions 10
 
 //configuration of facial expressions
-//index name Left-Eyebrow(HEX) Right-Eyebrow(HEX) Mouth(HEX) Eyelids(% open)
+//index name Left-Eyebrow(HEX) Right-Eyebrow(HEX) Mouth(HEX) Eyelids(% open, e.g 00=0%, 05=50%, 10 = 100%)
 //index starts at 1
 
-E1   neu 00h 00h 00h 38h
-E2   ta1 **h **h 00h **h
-E3   ta2 **h **h 03h **h
-E4   hap 01h 01h 01h 70h
-E5   sad 02h 02h 02h 38h
-E6   sur 03h 03h 03h 38h
-E7   ang 04h 04h 04h 70h
-E8   evi 05h 05h 05h 70h
-E9   shy 06h 06h 06h 70h
-E10  cun 07h 07h 07h 38h
+E1   neu 00h 00h 00h 00p
+E2   ta1 **h **h 00h **p
+E3   ta2 **h **h 03h **p
+E4   hap 01h 01h 01h 10p
+E5   sad 02h 02h 02h 00p
+E6   sur 03h 03h 03h 00p
+E7   ang 04h 04h 04h 10p
+E8   evi 05h 05h 05h 10p
+E9   shy 06h 06h 06h 10p
+E10  cun 07h 07h 07h 00p
 
 //number of colors
 colors 16

--- a/src/core/emotionInterface/emotionInterfaceModule.cpp
+++ b/src/core/emotionInterface/emotionInterfaceModule.cpp
@@ -11,6 +11,8 @@
 #include <bitset>
 #include <iomanip>
 #include <yarp/os/ResourceFinder.h>
+#include <yarp/dev/IControlMode.h>
+#include <yarp/dev/IControlLimits.h>
 #include "emotionInterfaceModule.h"
 
 
@@ -244,6 +246,39 @@ bool EmotionInterfaceModule::configure(ResourceFinder& config){
         }
 
     }
+    
+	yarp::os::Property rcb_face_conf{ {"device",Value("remote_controlboard")},
+                                      {"local", Value(getName("/face/remoteControlBoard"))},
+                                      {"remote",Value("/icub/face")},
+                                      {"part",Value("face")} };
+
+    if (_poly.open(rcb_face_conf))
+    {
+        yarp::dev::IControlMode* iCM{ nullptr };
+        yarp::dev::IControlLimits* iCtrlLim{ nullptr };
+        auto ok = _poly.view(iCM);
+        ok     &= _poly.view(_iPos);
+        ok     &= _poly.view(iCtrlLim);
+        if (iCM)
+            ok &= iCM->setControlMode(_joint_eylids, VOCAB_CM_POSITION);
+        if (iCtrlLim) {
+            ok &= iCtrlLim->getLimits(_joint_eylids, &_min, &_max);
+            _max = _max - 25.0; // safe zone for avoiding hw fault
+        }
+        if (_iPos) {
+            ok &= _iPos->setRefSpeed(_joint_eylids, 50.0); // max velocity that doesn't give problems
+            ok &= _iPos->setRefAcceleration(_joint_eylids,std::numeric_limits<double>::max());
+        }
+        if (!ok)
+        {
+            yError() << "Fail to configure correctly the remote_controlboard";
+            return false;
+        }
+    }
+    else
+    {
+        yWarning() << "Failed to open the remote_controlboard device for commanding the eyelids, you can ignore this warning if your robot doesn't have the rfe board";
+    }
 
       // open  ports
     _inputPort.open(getName("/in")); 
@@ -266,6 +301,12 @@ bool EmotionInterfaceModule::close(){
     {
         delete [] _emotion_table;
         _emotion_table = nullptr;
+    }
+
+    if(_poly.isValid())
+    {
+        _poly.close();
+        _iPos = nullptr;
     }
 
     return true;
@@ -500,19 +541,34 @@ bool EmotionInterfaceModule::setMouth(const std::string cmd)
 bool EmotionInterfaceModule::setEyelids(const std::string cmd)
 {
     char cmdbuffer[] = {0,0,0,0};
-    int i; 
-    i = getIndex(cmd);
+    const auto i = getIndex(cmd);
     if(i < 0)
         return false;
 
+    auto res{ true };
+
     if( _emotion_table[i].eli[0] == '*' || _emotion_table[i].eli[1] == '*') 
         return true;  //leave it in the same state
+    if (_iPos)
+    {
+        std::string percentage_str{ _emotion_table[i].eli[0] };
+        percentage_str += '.';
+        percentage_str += _emotion_table[i].eli[1];
+        auto percentage = std::stod(percentage_str);
+        if(percentage > 1.0)
+            percentage = 1.0;
+        auto target_pos = (1.0 - percentage) * (_max-_min); // because min-> open, max->closed
+        res = _iPos->positionMove(_joint_eylids, target_pos);
+    }
+    else
+    {
+        cmdbuffer[0] = 'S';
+        cmdbuffer[1] = _emotion_table[i].eli[0];
+        cmdbuffer[2] = _emotion_table[i].eli[1];
+        res = writePort(cmdbuffer);
+    }
 
-    cmdbuffer[0]= 'S';
-    cmdbuffer[1]=_emotion_table[i].eli[0];
-    cmdbuffer[2]=_emotion_table[i].eli[1];
-    writePort(cmdbuffer);
-    return true;
+    return res;
 }
 
 bool EmotionInterfaceModule::setAll(const std::string cmd)

--- a/src/core/emotionInterface/emotionInterfaceModule.h
+++ b/src/core/emotionInterface/emotionInterfaceModule.h
@@ -20,6 +20,8 @@
 
 // yarp
 #include <yarp/os/all.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/IPositionControl.h>
 #include <yarp/sig/all.h>
 
 using namespace yarp::os;
@@ -95,6 +97,14 @@ private:
     double _lasttime{};
     double _period{};
     int    _initEmotionTrigger{};
+
+    // PolyDriver and interface to command the eyelids in the rfe robots
+    yarp::dev::PolyDriver _poly;
+    yarp::dev::IPositionControl* _iPos{ nullptr };
+    double _min{ 0.0 }, _max{ 0.0 };
+    size_t _joint_eylids{ 0 };
+
+
 
     int getIndex(std::string cmd);
     bool writePort(const char* cmd);

--- a/src/core/emotionInterface/emotionInterfaceModule.h
+++ b/src/core/emotionInterface/emotionInterfaceModule.h
@@ -108,6 +108,7 @@ private:
 
     int getIndex(std::string cmd);
     bool writePort(const char* cmd);
+    double getEyelidsTarget(const char eli0, const char eli1);
 
 public:
 


### PR DESCRIPTION
This PR add the commands for controlling the eylids in the rfe iCub.

In particular in `emotion_rfe.ini` the eyelids column has been changed, the value is no more HEX but a representation of `% open`
E.g.

`00p` -> 0% open
`01p` -> 10% open
`05p` -> 50% open
`10p` -> 100% open

It has to be tested on both old and new robots. 