### PR TITLE
[WBD] fixed handling of MAS periodicity

### DIFF
--- a/src/modules/wholeBodyDynamics/main.cpp
+++ b/src/modules/wholeBodyDynamics/main.cpp
@@ -145,7 +145,7 @@ private:
 public:
     dataFilter(BufferedPort<Vector> &_port_filtered_output,
                IThreeAxisGyroscopes* iGyro,
-               IThreeAxisLinearAccelerometers* iAcc): PeriodicThread(0.001),
+               IThreeAxisLinearAccelerometers* iAcc): PeriodicThread(0.01),
                                                       port_filtered_output(_port_filtered_output),
                                                       m_iGyro(iGyro),
                                                       m_iAcc(iAcc)
@@ -626,7 +626,7 @@ public:
         Property masConf {{"device",Value("multipleanalogsensorsclient")},
                           {"local", Value("/"+local_name+"/inertials")},
                           {"remote",Value(remoteInertialName)},
-                          {"timeout",Value(0.04)}};
+                          {"timeout",Value(0.1)}};
 
         if (!dd_MASClient.open(masConf))
         {


### PR DESCRIPTION
Upon analyses @julijenv reported in https://github.com/robotology/icub-tech-support/issues/976, this PR does the following:
- Increase the reading timeout of IMU data from 0.04 s to 0.1 s as it was in the past. @Nicogene any clue why this has been made tighter?
- Make the filtering thread run at 100 Hz instead of 1 kHz, which was unnecessarily too high given the sampling frequency of the received data plus streaming the results at 1 kHz on YARP is hazardous. 

@Nicogene @traversaro please review/comment.

After merging, we need to update `devel` and then tags `1.16.1` and `1.17.0`.

cc @maggia80 @marcoaccame @davidetome @violadelbono