### PR TITLE
FirmwareUpdater - configurable IPs

### DIFF
--- a/src/tools/FirmwareUpdater/firmwareupdatercore.h
+++ b/src/tools/FirmwareUpdater/firmwareupdatercore.h
@@ -59,6 +59,7 @@ public:
 
 private:
     bool compile_ip_addresses(const char* addr,unsigned int *remoteAddr,unsigned int *localAddr);
+    bool isValidIpAddress(QString addr);
 private:
 
     QList < QPair<QString,QVariant> > devices;
@@ -71,6 +72,7 @@ private:
     int currentId;
     QList <sBoard> canBoards;
     int verbosity;
+    eOipv4addr_t hostIPaddress;
 
 signals:
     void updateProgress(float);

--- a/src/tools/ethLoader/ethLoaderLib/EthMaintainer.cpp
+++ b/src/tools/ethLoader/ethLoaderLib/EthMaintainer.cpp
@@ -60,6 +60,8 @@ ACE_UINT32 ipv4toace(eOipv4addr_t ipv4)
 {
     return ntohl(ipv4);
 }
+
+
 #if defined(WIN32)
 
 #else
@@ -1932,18 +1934,12 @@ bool EthMaintainer::command_changeaddress(eOipv4addr_t ipv4, eOipv4addr_t ipv4ne
         stopit = true;
     }
 
-    // we must have 10.0.1.x, where x is not 0 or 255
-    if((10 != command.address[0]) || (0 != command.address[1]) || (1 != command.address[2]))
+    // 09/2020 davide.tome@iit.it - possible to give 10.X.X.X IP address
+    if(!((10 == command.address[0]) || (0 < command.address[1] < 255) || (0 < command.address[2] < 255) || (0 < command.address[3] < 255)))
     {
         stopit =  true;
     }
-
-    if((0 == command.address[3]) || (255 == command.address[3]))
-    {
-        stopit = true;
-    }
-
-
+    
     if(true == stopit)
     {
         if(_verbose)


### PR DESCRIPTION
This PR allows configuring the IP's of the EMS boards through the `FirmwareUpdater` as per the request in https://github.com/robotology/QA/issues/423.