### PR TITLE
[iKin] Fix handling of hand abduction/adduction joints in class iCubFinger

### DIFF
--- a/src/libraries/iKin/include/iCub/iKin/iKinFwd.h
+++ b/src/libraries/iKin/include/iCub/iKin/iKinFwd.h
@@ -1124,6 +1124,7 @@ protected:
     std::string hand;
     std::string finger;
     std::string version;
+    double fingers_abduction_max;
 
     virtual void allocate(const std::string &_type);
     virtual void clone(const iCubFinger &finger);

--- a/src/libraries/iKin/src/iKinFwd.cpp
+++ b/src/libraries/iKin/src/iKinFwd.cpp
@@ -2038,8 +2038,8 @@ bool iCubFinger::alignJointsBounds(const deque<IControlLimits*> &lim)
         if (!limFinger.getLimits(7,&min,&max))
             return false;
 
-        (*this)[0].setMin(CTRL_DEG2RAD*min);
-        (*this)[0].setMax(CTRL_DEG2RAD*max/3.0);
+        (*this)[0].setMin(0.0);
+        (*this)[0].setMax(CTRL_DEG2RAD*(max-min)/3.0);
 
         if (!limFinger.getLimits(11,&min,&max))
             return false;
@@ -2076,8 +2076,8 @@ bool iCubFinger::alignJointsBounds(const deque<IControlLimits*> &lim)
         if (!limFinger.getLimits(7,&min,&max))
             return false;
 
-        (*this)[0].setMin(CTRL_DEG2RAD*min);
-        (*this)[0].setMax(CTRL_DEG2RAD*max/3.0);
+        (*this)[0].setMin(0.0);
+        (*this)[0].setMax(CTRL_DEG2RAD*(max-min)/3.0);
 
         if (!limFinger.getLimits(15,&min,&max))
             return false;

--- a/src/libraries/iKin/src/iKinFwd.cpp
+++ b/src/libraries/iKin/src/iKinFwd.cpp
@@ -2124,7 +2124,7 @@ bool iCubFinger::getChainJoints(const Vector &motorEncoders,
     else if (finger=="index")
     {
         chainJoints.resize(4);
-        chainJoints[0]=motorEncoders[offs+0]/3.0;
+        chainJoints[0]=(fingers_abduction_max-motorEncoders[offs+0])/3.0;
         chainJoints[1]=motorEncoders[offs+4];
         chainJoints[2]=motorEncoders[offs+5]/2.0;
         chainJoints[3]=chainJoints[2];
@@ -2139,7 +2139,7 @@ bool iCubFinger::getChainJoints(const Vector &motorEncoders,
     else if ((finger=="ring") || (finger=="little"))
     {
         chainJoints.resize(4);
-        chainJoints[0]=motorEncoders[offs+0]/3.0;
+        chainJoints[0]=(fingers_abduction_max-motorEncoders[offs+0])/3.0;
         chainJoints[1]=motorEncoders[offs+8]/3.0;
         chainJoints[3]=chainJoints[2]=chainJoints[1];
     }
@@ -2188,7 +2188,7 @@ bool iCubFinger::getChainJoints(const Vector &motorEncoders,
     else if (finger=="index")
     {
         chainJoints.resize(4);
-        chainJoints[0]=motorEncoders[offs+0]/3.0;
+        chainJoints[0]=(fingers_abduction_max-motorEncoders[offs+0])/3.0;
         for (unsigned int i=1; i<chainJoints.length(); i++)
         {
             double c=0.0;
@@ -2217,7 +2217,7 @@ bool iCubFinger::getChainJoints(const Vector &motorEncoders,
     else if (finger=="ring")
     {
         chainJoints.resize(4);
-        chainJoints[0]=motorEncoders[offs+0]/3.0;
+        chainJoints[0]=(fingers_abduction_max-motorEncoders[offs+0])/3.0;
         for (unsigned int i=1; i<chainJoints.length(); i++)
         {
             double c=0.0;
@@ -2232,7 +2232,7 @@ bool iCubFinger::getChainJoints(const Vector &motorEncoders,
     else if (finger=="little")
     {
         chainJoints.resize(4);
-        chainJoints[0]=motorEncoders[offs+0]/3.0;
+        chainJoints[0]=(fingers_abduction_max-motorEncoders[offs+0])/3.0;
         for (unsigned int i=1; i<chainJoints.length(); i++)
         {
             double c=0.0;

--- a/src/libraries/iKin/src/iKinFwd.cpp
+++ b/src/libraries/iKin/src/iKinFwd.cpp
@@ -1998,6 +1998,12 @@ void iCubFinger::allocate(const string &_type)
         pushLink(new iKinLink(0.0168, 0.0, -M_PI/2.0, 0.0, 0.0, 90.0*CTRL_DEG2RAD));
     }
 
+    if((finger=="index") || (finger=="ring") || (finger=="little"))
+    {
+        // evaluate maximum fingers abduction using the default limits
+        fingers_abduction_max = (*this)[0].getMax()*3.0*CTRL_RAD2DEG;
+    }
+
     setH0(H0);
 }
 
@@ -2038,6 +2044,8 @@ bool iCubFinger::alignJointsBounds(const deque<IControlLimits*> &lim)
         if (!limFinger.getLimits(7,&min,&max))
             return false;
 
+        fingers_abduction_max = max;
+
         (*this)[0].setMin(0.0);
         (*this)[0].setMax(CTRL_DEG2RAD*(max-min)/3.0);
 
@@ -2075,6 +2083,8 @@ bool iCubFinger::alignJointsBounds(const deque<IControlLimits*> &lim)
     {
         if (!limFinger.getLimits(7,&min,&max))
             return false;
+
+        fingers_abduction_max = max;
 
         (*this)[0].setMin(0.0);
         (*this)[0].setMax(CTRL_DEG2RAD*(max-min)/3.0);


### PR DESCRIPTION
Following up #694,

this PR make sure that the hand adduction/abduction is properly handled in `iKinFwd::iCubFinger` in terms of:

- limits of the 0-th link of the fingers `index`, `ring` and `little
- handling of reversed open/close logic in the reading from the encoder of the joint `*_hand_finger`

