### PR TITLE
embobjMotionControl: fix windows execution

### DIFF
--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -124,16 +124,16 @@ bool embObjMotionControl::alloc(int nj)
     _cacheImpedance = allocAndCheck<eOmc_impedance_t>(nj);
 
 
-     _rotorsLimits.reserve(nj);
-    _jointsLimits.reserve(nj);
-    _currentLimits.reserve(nj);
-    _jsets.reserve(nj);
-    _joint2set.reserve(nj);
-    _timeouts.reserve(nj);
-    _impedance_params.reserve(nj);
-    _axesInfo.reserve(nj);
-    _jointEncs.reserve(nj);
-    _motorEncs.reserve(nj);
+    _rotorsLimits.resize(nj);
+    _jointsLimits.resize(nj);
+    _currentLimits.resize(nj);
+    _jsets.resize(nj);
+    _joint2set.resize(nj);
+    _timeouts.resize(nj);
+    _impedance_params.resize(nj);
+    _axesInfo.resize(nj);
+    _jointEncs.resize(nj);
+    _motorEncs.resize(nj);
     
     //debug purpose
 


### PR DESCRIPTION
Under Windows using `reserve` without any `resize` throws a "out of range" exception. 
This is due to the fact that after that `reserve` the `capacity` is `nj`, the size is `0`.
I am surprised that this code is allowed under linux, but maybe I am missing something.

BTW this code is tested on windows and it works