### PR TITLE
[SWIG] Add support for std::deque of yarp::dev::IControlLimits*

### DIFF
--- a/bindings/icub.i
+++ b/bindings/icub.i
@@ -164,6 +164,7 @@ typedef yarp::os::BufferedPort<iCub::skinDynLib::dynContactList> BufferedPortDyn
 %template(TypedReaderCallbackDynContactList) yarp::os::TypedReaderCallback<iCub::skinDynLib::dynContactList>;
 %template(BufferedPortDynContactList) yarp::os::BufferedPort<iCub::skinDynLib::dynContactList>;
 
+%template(dequeIControlLimitsPtr) std::deque<yarp::dev::IControlLimits*>;
 
 bool init();
 


### PR DESCRIPTION
As per the title, this PR add SWIG support for `std::deque<yarp::dev::IControlLimits*>` that is used, among others, in `iCub::iKin` derived classes implementing the method `alignJointsBounds`.

Fixes #710