### PR TITLE
Movement of the fingers of the new hand in open/close mode

### DIFF
--- a/src/libraries/icubmod/embObjLib/serviceParser.h
+++ b/src/libraries/icubmod/embObjLib/serviceParser.h
@@ -205,22 +205,23 @@ typedef struct
 
     int                                 numofjoints;
     eObrd_ethtype_t                     ethboardtype;
-    std::vector<servCanBoard_t>              canboards;
+    std::vector<servCanBoard_t>         canboards;
 
     eObrd_canlocation_t                 maislocation;
     std::vector<eObrd_canlocation_t>    psclocations;
+    std::vector<eObrd_canlocation_t>    poslocations;
 
     eOmc_mc4shifts_t                    mc4shifts;
-    std::vector<eOmc_mc4broadcast_t>         mc4broadcasts;
-    std::vector<eObrd_canlocation_t>         mc4joints;
+    std::vector<eOmc_mc4broadcast_t>    mc4broadcasts;
+    std::vector<eObrd_canlocation_t>    mc4joints;
 
     //servMC_controller_t                 controller;
 
-    std::vector<servMC_actuator_t>           actuators;
-    std::vector<servMC_encoder_t>            encoder1s;
-    std::vector<servMC_encoder_t>            encoder2s;
+    std::vector<servMC_actuator_t>      actuators;
+    std::vector<servMC_encoder_t>       encoder1s;
+    std::vector<servMC_encoder_t>       encoder2s;
 
-    //std::vector<int>                         joint2set;
+    //std::vector<int>                    joint2set;
     //int                                 numofjointsets;
     //std::vector<eOmc_jointset_configuration_t> jointset_cfgs;
 } servMCproperties_t;
@@ -285,6 +286,9 @@ public:
 
     bool parse_psc(std::string const &fromstring, eObrd_portpsc_t &ppsc, bool &formaterror);
     bool parse_port_psc(std::string const &fromstring, uint8_t &toport, bool &formaterror);
+
+    bool parse_pos(std::string const &fromstring, eObrd_portpos_t &ppos, bool &formaterror);
+    bool parse_port_pos(std::string const &fromstring, uint8_t &toport, bool &formaterror);
 
 #endif
 

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -16,7 +16,7 @@
 #include "embObjMotionControl.h"
 #include <ethManager.h>
 #include <FeatureInterface.h>
-
+#include <yarp/conf/environment.h>
 
 #include <yarp/os/LogStream.h>
 
@@ -253,7 +253,7 @@ embObjMotionControl::embObjMotionControl() :
     behFlags.useRawEncoderData = false;
     behFlags.pwmIsLimited     = false;
 
-    std::string tmp = NetworkBase::getEnvironment("ETH_VERBOSEWHENOK");
+    std::string tmp = yarp::conf::environment::getEnvironment("ETH_VERBOSEWHENOK");
     if (tmp != "")
     {
         behFlags.verbosewhenok = (bool)NetType::toInt(tmp);

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -603,7 +603,12 @@ bool embObjMotionControl::saveCouplingsData(void)
             jc_dest = &(serviceConfig.ethservice.configuration.data.mc.mc2pluspsc.jomocoupling);
 
         } break;
-         case eomn_serv_MC_mc4:
+        case eomn_serv_MC_mc4plusfaps:
+        {
+            jc_dest = &(serviceConfig.ethservice.configuration.data.mc.mc4plusfaps.jomocoupling);
+
+        } break;
+        case eomn_serv_MC_mc4:
         {
             return true;
         } break;
@@ -4726,7 +4731,8 @@ bool embObjMotionControl::iNeedCouplingsInfo(void)
     if( (mc_serv_type == eomn_serv_MC_foc) ||
         (mc_serv_type == eomn_serv_MC_mc4plus) ||
         (mc_serv_type == eomn_serv_MC_mc4plusmais) ||
-        (mc_serv_type == eomn_serv_MC_mc2pluspsc)
+        (mc_serv_type == eomn_serv_MC_mc2pluspsc) ||
+        (mc_serv_type == eomn_serv_MC_mc4plusfaps)
       )
         return true;
     else


### PR DESCRIPTION
This PR allows `embObjMotionControl` to move the fingers of the new hand in open close mode.


![image](https://user-images.githubusercontent.com/7148284/105490923-d22e0780-5cb5-11eb-9d8e-76ec19c7ba95.png)

As such, we can now parse xml files which have the field `SERVICE.type`  equal `eo_motcon_mode_mc4plusfaps`.

This service type needs a mc4plus board of which uses the standard pwm actuators on ports `CONN:P2`, `CONN:P3`, `CONN:P4` and `CONN:P5`. 

The novelty in here is that the encoders at joint are described as `POS:hand_thumb`, `POS:hand_index`, `POS:hand_medium` and `POS:hand_pinky` and are associated to absolute magnetic encoders placed on the `fap` boards which are managed by CAN board `pmc` of which we specify CAN address in the field `POS.location`.

So we needed the parsing of the xml to be able to get the new parameters and to send then to a `mc4plus` board and then down to the `pmc` board.

The code in the PR has demonstrated to be effective in moving the fingers of the new hand and is fully compatible with the other service types used on the iCub platform. 

The firmware used for the `mc4plus` is already in `robotology:devel` since this [PR](https://github.com/robotology/icub-firmware/pull/157).

Compatibility test have been done with the standard `eo_motcon_mode_foc` service type which uses an `ems` two `2foc` boards and AEA encoders to move three brushless motors.

 