### PR TITLE
Warning message for position control PID when config not consistent

### DIFF
--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -2327,7 +2327,7 @@ void JointsSet::dumpdata(void)
 
 }
 
-bool Parser::checkJointTypes(PidInfo *pids, std::string pid_type)
+bool Parser::checkJointTypes(PidInfo *pids, const std::string pid_type)
 {
     //Here i would check that all joints have same type units in order to create pid_type helper with correct factor.
 

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -2362,3 +2362,4 @@ bool Parser::checkJointTypes(PidInfo *pids, std::string pid_type)
     }
     return true;
 }
+

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -242,39 +242,7 @@ bool Parser::parseSelectedCurrentPid(yarp::os::Searchable &config, bool pidisMan
         }
     }
 
-    //Here i would check that all joints have same type units in order to create current helper with correct factor.
-
-    //get first joint with enabled current
-    int firstjoint = -1;
-    for(int i=0; i<_njoints; i++)
-    {
-        if(pids[i].enabled)
-        {
-            firstjoint = i;
-            break;
-        }
-    }
-
-    if(firstjoint==-1)
-    {
-        // no joint has current enabed
-        return true;
-    }
-
-    for(int i=firstjoint+1; i<_njoints; i++)
-    {
-        if(pids[i].enabled)
-        {
-            if(pids[firstjoint].fbk_PidUnits != pids[i].fbk_PidUnits ||
-               pids[firstjoint].out_PidUnits != pids[i].out_PidUnits)
-            {
-                yError() << "embObjMC BOARD " << _boardname << "all joints with CURRENT enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
-                return false;
-            }
-        }
-    }
-
-    return true;
+    return checkJointTypes(pids, "CURRENT");
 }
 
 bool Parser::parseSelectedSpeedPid(yarp::os::Searchable &config, bool pidisMandatory, PidInfo *pids) // OK
@@ -339,39 +307,7 @@ bool Parser::parseSelectedSpeedPid(yarp::os::Searchable &config, bool pidisManda
         }
     }
 
-    //Here i would check that all joints have same type units in order to create speed helper with correct factor.
-
-    //get first joint with enabled speed
-    int firstjoint = -1;
-    for(int i=0; i<_njoints; i++)
-    {
-        if(pids[i].enabled)
-        {
-            firstjoint = i;
-            break;
-        }
-    }
-
-    if(firstjoint==-1)
-    {
-        // no joint has speed enabed
-        return true;
-    }
-
-    for(int i=firstjoint+1; i<_njoints; i++)
-    {
-        if(pids[i].enabled)
-        {
-            if(pids[firstjoint].fbk_PidUnits != pids[i].fbk_PidUnits ||
-               pids[firstjoint].out_PidUnits != pids[i].out_PidUnits)
-            {
-                yError() << "embObjMC BOARD " << _boardname << "all joints with SPEED enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
-                return false;
-            }
-        }
-    }
-
-    return true;
+    return checkJointTypes(pids, "SPEED");
 }
 
 bool Parser::parseSelectedPositionControl(yarp::os::Searchable &config) // OK
@@ -1197,9 +1133,6 @@ bool Parser::parsePid_torque_outVel(Bottle &b_pid, string controlLaw)
     return true;
 }
 
-
-
-
 bool Parser::getCorrectPidForEachJoint(PidInfo *ppids/*, PidInfo *vpids*/, TrqPidInfo *tpids)
 {
     Pid_Algorithm *minjerkAlgo_ptr = NULL;
@@ -1310,74 +1243,8 @@ bool Parser::getCorrectPidForEachJoint(PidInfo *ppids/*, PidInfo *vpids*/, TrqPi
         //eomc_ctrl_out_type_vel = 2,
         //eomc_ctrl_out_type_cur = 3
 
-
-    //Here i would check that all joints have same type units in order to create torquehelper with correct factor.
-
-    //get first joint with enabled torque
-    int firstjoint = -1;
-    for(int i=0; i<_njoints; i++)
-    {
-        if(tpids[i].enabled)
-        {
-            firstjoint = i;
-            break;
-        }
-    }
-
-    if(firstjoint==-1)
-    {
-        // no joint has torque enabed
-        return true;
-    }
-
-    for(int i=firstjoint+1; i<_njoints; i++)
-    {
-        if(tpids[i].enabled)
-        {
-            if(tpids[firstjoint].fbk_PidUnits != tpids[i].fbk_PidUnits ||
-               tpids[firstjoint].out_PidUnits != tpids[i].out_PidUnits)
-            {
-                yError() << "embObjMC BOARD " << _boardname << "all joints with TORQUE enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
-                return false;
-            }
-        }
-    }
-
-    //Here i would check that all joints have same type units in order to create position helper with correct factor.
-
-    //get first joint with enabled position
-    firstjoint = -1;
-    for(int i=0; i<_njoints; i++)
-    {
-        if(ppids[i].enabled)
-        {
-            firstjoint = i;
-            break;
-        }
-    }
-
-    if(firstjoint==-1)
-    {
-        // no joint has position enabed
-        return true;
-    }
-
-    for(int i=firstjoint+1; i<_njoints; i++)
-    {
-        if(ppids[i].enabled)
-        {
-            if(ppids[firstjoint].fbk_PidUnits != ppids[i].fbk_PidUnits ||
-               ppids[firstjoint].out_PidUnits != ppids[i].out_PidUnits)
-            {
-                yError() << "embObjMC BOARD " << _boardname << "all joints with POSITION enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
-                return false;
-            }
-        }
-    }
-
-    return true;
+    return checkJointTypes(tpids, "TORQUE") && checkJointTypes(ppids, "POSITION");
 }
-
 
 bool Parser::parsePidUnitsType(Bottle &bPid, yarp::dev::PidFeedbackUnitsEnum  &fbk_pidunits, yarp::dev::PidOutputUnitsEnum& out_pidunits)
 {
@@ -1434,7 +1301,6 @@ bool Parser::parsePidUnitsType(Bottle &bPid, yarp::dev::PidFeedbackUnitsEnum  &f
     }
     return true;
 }
-
 
 bool Parser::parse2FocGroup(yarp::os::Searchable &config, eomc::twofocSpecificInfo_t *twofocinfo)
 {
@@ -1576,9 +1442,6 @@ bool Parser::parse2FocGroup(yarp::os::Searchable &config, eomc::twofocSpecificIn
     return true;
 
 }
-
-
-
 
 bool Parser::parseJointsetCfgGroup(yarp::os::Searchable &config, std::vector<JointsSet> &jsets, std::vector<int> &joint2set)
 {
@@ -1836,7 +1699,6 @@ bool Parser::parseJointsLimits(yarp::os::Searchable &config, std::vector<jointLi
     return true;
 }
 
-
 bool Parser::parseRotorsLimits(yarp::os::Searchable &config, std::vector<rotorLimits_t> &rotorsLimits)
 {
     Bottle &limits=config.findGroup("LIMITS");
@@ -1883,9 +1745,6 @@ bool Parser::parseRotorsLimits(yarp::os::Searchable &config, std::vector<rotorLi
     return true;
 
 }
-
-
-
 
 bool Parser::parseCouplingInfo(yarp::os::Searchable &config, couplingInfo_t &couplingInfo)
 {
@@ -1942,7 +1801,6 @@ bool Parser::parseCouplingInfo(yarp::os::Searchable &config, couplingInfo_t &cou
 
     return true;
 }
-
 
 bool Parser::parseMotioncontrolVersion(yarp::os::Searchable &config, int &version)
 {
@@ -2024,8 +1882,6 @@ bool Parser::parseBehaviourFalgs(yarp::os::Searchable &config, bool &useRawEncod
     return true;
 }
 
-
-
 bool Parser::parseAxisInfo(yarp::os::Searchable &config, int axisMap[], std::vector<axisInfo_t> &axisInfo)
 {
 
@@ -2086,9 +1942,6 @@ bool Parser::parseAxisInfo(yarp::os::Searchable &config, int axisMap[], std::vec
 
     return true;
 }
-
-
-
 
 bool Parser::parseEncoderFactor(yarp::os::Searchable &config, double encoderFactor[])
 {
@@ -2153,7 +2006,6 @@ bool Parser::parsefullscalePWM(yarp::os::Searchable &config, double dutycycleToP
 
     return true;
 }
-
 
 bool Parser::parseAmpsToSensor(yarp::os::Searchable &config, double ampsToSensor[])
 {
@@ -2274,7 +2126,6 @@ bool Parser::parseDeadzoneValue(yarp::os::Searchable &config, double deadzone[],
     return true;
 }
 
-
 bool Parser::parseMechanicalsFlags(yarp::os::Searchable &config, int useMotorSpeedFbk[])
 {
     Bottle general = config.findGroup("GENERAL");
@@ -2299,11 +2150,6 @@ bool Parser::parseMechanicalsFlags(yarp::os::Searchable &config, int useMotorSpe
     return true;
 
 }
-
-
-
-
-
 
 bool Parser::parseImpedanceGroup(yarp::os::Searchable &config,std::vector<impedanceParameters_t> &impedance)
 {
@@ -2371,8 +2217,6 @@ bool Parser::convert(std::string const &fromstring, eOmc_jsetconstraint_t &jsetc
 
     return true;
 }
-
-
 
 bool Parser::convert(Bottle &bottle, vector<double> &matrix, bool &formaterror, int targetsize)
 {
@@ -2481,4 +2325,40 @@ void JointsSet::dumpdata(void)
 
     cout << " param1="<< cfg.constraints.param1 << " param2=" << cfg.constraints.param2 << endl;
 
+}
+
+bool Parser::checkJointTypes(PidInfo *pids, std::string pid_type)
+{
+    //Here i would check that all joints have same type units in order to create pid_type helper with correct factor.
+
+    //get first joint with enabled pid_type
+    int firstjoint = -1;
+    for(int i=0; i<_njoints; i++)
+    {
+        if(pids[i].enabled)
+        {
+            firstjoint = i;
+            break;
+        }
+    }
+
+    if(firstjoint==-1)
+    {
+        // no joint has current enabed
+        return true;
+    }
+
+    for(int i=firstjoint+1; i<_njoints; i++)
+    {
+        if(pids[i].enabled)
+        {
+            if(pids[firstjoint].fbk_PidUnits != pids[i].fbk_PidUnits ||
+               pids[firstjoint].out_PidUnits != pids[i].out_PidUnits)
+            {
+                yError() << "embObjMC BOARD " << _boardname << "all joints with " << pid_type << " enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
+                return false;
+            }
+        }
+    }
+    return true;
 }

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -85,7 +85,7 @@ bool Parser::parsePids(yarp::os::Searchable &config, PidInfo *ppids/*, PidInfo *
     // come specificato in _currentControlLaw
     if(!parseSelectedCurrentPid(config, lowLevPidisMandatory, cpids)) // OK
         return false;
-    // legge i pid di velocita per ciascun motore 
+    // legge i pid di velocità per ciascun motore 
     // come specificato in _speedControlLaw
     if(!parseSelectedSpeedPid(config, lowLevPidisMandatory, spids)) // OK
         return false;
@@ -2482,4 +2482,3 @@ void JointsSet::dumpdata(void)
     cout << " param1="<< cfg.constraints.param1 << " param2=" << cfg.constraints.param2 << endl;
 
 }
-

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -242,6 +242,38 @@ bool Parser::parseSelectedCurrentPid(yarp::os::Searchable &config, bool pidisMan
         }
     }
 
+    //Here i would check that all joints have same type units in order to create current helper with correct factor.
+
+    //get first joint with enabled current
+    int firstjoint = -1;
+    for(int i=0; i<_njoints; i++)
+    {
+        if(pids[i].enabled)
+        {
+            firstjoint = i;
+            break;
+        }
+    }
+
+    if(firstjoint==-1)
+    {
+        // no joint has current enabed
+        return true;
+    }
+
+    for(int i=firstjoint+1; i<_njoints; i++)
+    {
+        if(pids[i].enabled)
+        {
+            if(pids[firstjoint].fbk_PidUnits != pids[i].fbk_PidUnits ||
+               pids[firstjoint].out_PidUnits != pids[i].out_PidUnits)
+            {
+                yError() << "embObjMC BOARD " << _boardname << "all joints with CURRENT enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
+                return false;
+            }
+        }
+    }
+
     return true;
 }
 
@@ -304,6 +336,38 @@ bool Parser::parseSelectedSpeedPid(yarp::os::Searchable &config, bool pidisManda
             pids[i].pid = mycpids[i];
 
             delete[] mycpids;
+        }
+    }
+
+    //Here i would check that all joints have same type units in order to create speed helper with correct factor.
+
+    //get first joint with enabled speed
+    int firstjoint = -1;
+    for(int i=0; i<_njoints; i++)
+    {
+        if(pids[i].enabled)
+        {
+            firstjoint = i;
+            break;
+        }
+    }
+
+    if(firstjoint==-1)
+    {
+        // no joint has speed enabed
+        return true;
+    }
+
+    for(int i=firstjoint+1; i<_njoints; i++)
+    {
+        if(pids[i].enabled)
+        {
+            if(pids[firstjoint].fbk_PidUnits != pids[i].fbk_PidUnits ||
+               pids[firstjoint].out_PidUnits != pids[i].out_PidUnits)
+            {
+                yError() << "embObjMC BOARD " << _boardname << "all joints with SPEED enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
+                return false;
+            }
         }
     }
 
@@ -1246,8 +1310,6 @@ bool Parser::getCorrectPidForEachJoint(PidInfo *ppids/*, PidInfo *vpids*/, TrqPi
         //eomc_ctrl_out_type_vel = 2,
         //eomc_ctrl_out_type_cur = 3
 
-    return true;
-
 
     //Here i would check that all joints have same type units in order to create torquehelper with correct factor.
 
@@ -1256,7 +1318,10 @@ bool Parser::getCorrectPidForEachJoint(PidInfo *ppids/*, PidInfo *vpids*/, TrqPi
     for(int i=0; i<_njoints; i++)
     {
         if(tpids[i].enabled)
+        {
             firstjoint = i;
+            break;
+        }
     }
 
     if(firstjoint==-1)
@@ -1285,7 +1350,10 @@ bool Parser::getCorrectPidForEachJoint(PidInfo *ppids/*, PidInfo *vpids*/, TrqPi
     for(int i=0; i<_njoints; i++)
     {
         if(ppids[i].enabled)
+        {
             firstjoint = i;
+            break;
+        }
     }
 
     if(firstjoint==-1)

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -1337,7 +1337,7 @@ bool Parser::getCorrectPidForEachJoint(PidInfo *ppids/*, PidInfo *vpids*/, TrqPi
             if(tpids[firstjoint].fbk_PidUnits != tpids[i].fbk_PidUnits ||
                tpids[firstjoint].out_PidUnits != tpids[i].out_PidUnits)
             {
-                yError() << "embObjMC BOARD " << _boardname << "all joints with torque enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
+                yError() << "embObjMC BOARD " << _boardname << "all joints with TORQUE enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
                 return false;
             }
         }
@@ -1369,7 +1369,7 @@ bool Parser::getCorrectPidForEachJoint(PidInfo *ppids/*, PidInfo *vpids*/, TrqPi
             if(ppids[firstjoint].fbk_PidUnits != ppids[i].fbk_PidUnits ||
                ppids[firstjoint].out_PidUnits != ppids[i].out_PidUnits)
             {
-                yError() << "embObjMC BOARD " << _boardname << "all joints with position enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
+                yError() << "embObjMC BOARD " << _boardname << "all joints with POSITION enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
                 return false;
             }
         }

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -2327,7 +2327,7 @@ void JointsSet::dumpdata(void)
 
 }
 
-bool Parser::checkJointTypes(PidInfo *pids, const std::string pid_type)
+bool Parser::checkJointTypes(PidInfo *pids, const std::string &pid_type)
 {
     //Here i would check that all joints have same type units in order to create pid_type helper with correct factor.
 

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -85,7 +85,7 @@ bool Parser::parsePids(yarp::os::Searchable &config, PidInfo *ppids/*, PidInfo *
     // come specificato in _currentControlLaw
     if(!parseSelectedCurrentPid(config, lowLevPidisMandatory, cpids)) // OK
         return false;
-    // legge i pid di velocità per ciascun motore 
+    // legge i pid di velocita per ciascun motore 
     // come specificato in _speedControlLaw
     if(!parseSelectedSpeedPid(config, lowLevPidisMandatory, spids)) // OK
         return false;
@@ -1273,6 +1273,35 @@ bool Parser::getCorrectPidForEachJoint(PidInfo *ppids/*, PidInfo *vpids*/, TrqPi
                tpids[firstjoint].out_PidUnits != tpids[i].out_PidUnits)
             {
                 yError() << "embObjMC BOARD " << _boardname << "all joints with torque enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
+                return false;
+            }
+        }
+    }
+
+    //Here i would check that all joints have same type units in order to create position helper with correct factor.
+
+    //get first joint with enabled position
+    firstjoint = -1;
+    for(int i=0; i<_njoints; i++)
+    {
+        if(ppids[i].enabled)
+            firstjoint = i;
+    }
+
+    if(firstjoint==-1)
+    {
+        // no joint has position enabed
+        return true;
+    }
+
+    for(int i=firstjoint+1; i<_njoints; i++)
+    {
+        if(ppids[i].enabled)
+        {
+            if(ppids[firstjoint].fbk_PidUnits != ppids[i].fbk_PidUnits ||
+               ppids[firstjoint].out_PidUnits != ppids[i].out_PidUnits)
+            {
+                yError() << "embObjMC BOARD " << _boardname << "all joints with position enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
                 return false;
             }
         }

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.h
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.h
@@ -370,7 +370,7 @@ private:
     bool getCorrectPidForEachJoint(PidInfo *ppids/*, PidInfo *vpids*/, TrqPidInfo *tpids);
     bool parsePidUnitsType(yarp::os::Bottle &bPid, yarp::dev::PidFeedbackUnitsEnum  &fbk_pidunits, yarp::dev::PidOutputUnitsEnum& out_pidunits);
 
-    bool checkJointTypes(PidInfo *pids, const std::string pid_type);
+    bool checkJointTypes(PidInfo *pids, const std::string &pid_type);
 
     bool convert(std::string const &fromstring, eOmc_jsetconstraint_t &jsetconstraint, bool& formaterror);
     bool convert(yarp::os::Bottle &bottle, std::vector<double> &matrix, bool &formaterror, int targetsize);

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.h
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.h
@@ -370,6 +370,7 @@ private:
     bool getCorrectPidForEachJoint(PidInfo *ppids/*, PidInfo *vpids*/, TrqPidInfo *tpids);
     bool parsePidUnitsType(yarp::os::Bottle &bPid, yarp::dev::PidFeedbackUnitsEnum  &fbk_pidunits, yarp::dev::PidOutputUnitsEnum& out_pidunits);
 
+    bool checkJointTypes(PidInfo *pids, std::string pid_type);
 
     bool convert(std::string const &fromstring, eOmc_jsetconstraint_t &jsetconstraint, bool& formaterror);
     bool convert(yarp::os::Bottle &bottle, std::vector<double> &matrix, bool &formaterror, int targetsize);

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.h
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.h
@@ -370,7 +370,7 @@ private:
     bool getCorrectPidForEachJoint(PidInfo *ppids/*, PidInfo *vpids*/, TrqPidInfo *tpids);
     bool parsePidUnitsType(yarp::os::Bottle &bPid, yarp::dev::PidFeedbackUnitsEnum  &fbk_pidunits, yarp::dev::PidOutputUnitsEnum& out_pidunits);
 
-    bool checkJointTypes(PidInfo *pids, std::string pid_type);
+    bool checkJointTypes(PidInfo *pids, const std::string pid_type);
 
     bool convert(std::string const &fromstring, eOmc_jsetconstraint_t &jsetconstraint, bool& formaterror);
     bool convert(yarp::os::Bottle &bottle, std::vector<double> &matrix, bool &formaterror, int targetsize);


### PR DESCRIPTION
This pull request introduces a warning message when the configuration of position control PID is not consistent across the different joints, resulting in wrong values for the PIDs (mismatching between `machine_units` and `metric_units`).

This PR addresses [this issue](https://github.com/robotology/icub-main/issues/712).


@randaz81 : This implementation covers **only position control**, since the configuration for other types of control is slightly different. Should this be implemented for all different types of control?