### PR TITLE
fixed the checkJointTypes function for the case of TORQUE control

### DIFF
--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -2364,3 +2364,4 @@ bool Parser::checkJointTypes(PidInfo *pids, const std::string &pid_type)
     return true;
 }
 
+

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -2336,13 +2336,14 @@ bool Parser::checkJointTypes(PidInfo *pids, const std::string &pid_type)
     if(pid_type == "TORQUE")
     {
         // since we are working with a torque pid, we first cast it as such
-        TrqPidInfo* pids = dynamic_cast<TrqPidInfo*>(pids);
+        // this allows the loop to correctly point to the corresponding memory
+        TrqPidInfo* trq_pids = (TrqPidInfo*) pids;
 
         //get first joint with enabled pid_type
         int firstjoint = -1;
         for(int i=0; i<_njoints; i++)
         {
-            if(pids[i].enabled)
+            if(trq_pids[i].enabled)
             {
                 firstjoint = i;
                 break;
@@ -2357,10 +2358,10 @@ bool Parser::checkJointTypes(PidInfo *pids, const std::string &pid_type)
 
         for(int i=firstjoint+1; i<_njoints; i++)
         {
-            if(pids[i].enabled)
+            if(trq_pids[i].enabled)
             {
-                if(pids[firstjoint].fbk_PidUnits != pids[i].fbk_PidUnits ||
-                pids[firstjoint].out_PidUnits != pids[i].out_PidUnits)
+                if(trq_pids[firstjoint].fbk_PidUnits != trq_pids[i].fbk_PidUnits ||
+                trq_pids[firstjoint].out_PidUnits != trq_pids[i].out_PidUnits)
                 {
                     yError() << "embObjMC BOARD " << _boardname << "all joints with " << pid_type << " enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
                     return false;

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -2332,6 +2332,12 @@ bool Parser::checkJointTypes(PidInfo *pids, const std::string &pid_type)
 {
     //Here i would check that all joints have same type units in order to create pid_type helper with correct factor.
 
+    //parse verify if pid type is torque or some other
+    if(pid_type == "TORQUE")
+    {
+        dynamic_cast<TrqPidInfo*>(pids);
+    }
+
     //get first joint with enabled pid_type
     int firstjoint = -1;
     for(int i=0; i<_njoints; i++)

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -2335,38 +2335,72 @@ bool Parser::checkJointTypes(PidInfo *pids, const std::string &pid_type)
     //parse verify if pid type is torque or some other
     if(pid_type == "TORQUE")
     {
+        // since we are working with a torque pid, we first cast it as such
         TrqPidInfo* pids = dynamic_cast<TrqPidInfo*>(pids);
-    }
 
-    //get first joint with enabled pid_type
-    int firstjoint = -1;
-    for(int i=0; i<_njoints; i++)
-    {
-        if(pids[i].enabled)
+        //get first joint with enabled pid_type
+        int firstjoint = -1;
+        for(int i=0; i<_njoints; i++)
         {
-            firstjoint = i;
-            break;
-        }
-    }
-
-    if(firstjoint==-1)
-    {
-        // no joint has current enabed
-        return true;
-    }
-
-    for(int i=firstjoint+1; i<_njoints; i++)
-    {
-        if(pids[i].enabled)
-        {
-            if(pids[firstjoint].fbk_PidUnits != pids[i].fbk_PidUnits ||
-               pids[firstjoint].out_PidUnits != pids[i].out_PidUnits)
+            if(pids[i].enabled)
             {
-                yError() << "embObjMC BOARD " << _boardname << "all joints with " << pid_type << " enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
-                return false;
+                firstjoint = i;
+                break;
+            }
+        }
+
+        if(firstjoint==-1)
+        {
+            // no joint has current enabed
+            return true;
+        }
+
+        for(int i=firstjoint+1; i<_njoints; i++)
+        {
+            if(pids[i].enabled)
+            {
+                if(pids[firstjoint].fbk_PidUnits != pids[i].fbk_PidUnits ||
+                pids[firstjoint].out_PidUnits != pids[i].out_PidUnits)
+                {
+                    yError() << "embObjMC BOARD " << _boardname << "all joints with " << pid_type << " enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
+                    return false;
+                }
             }
         }
     }
+    else
+    {
+        //get first joint with enabled pid_type
+        int firstjoint = -1;
+        for(int i=0; i<_njoints; i++)
+        {
+            if(pids[i].enabled)
+            {
+                firstjoint = i;
+                break;
+            }
+        }
+
+        if(firstjoint==-1)
+        {
+            // no joint has current enabed
+            return true;
+        }
+
+        for(int i=firstjoint+1; i<_njoints; i++)
+        {
+            if(pids[i].enabled)
+            {
+                if(pids[firstjoint].fbk_PidUnits != pids[i].fbk_PidUnits ||
+                pids[firstjoint].out_PidUnits != pids[i].out_PidUnits)
+                {
+                    yError() << "embObjMC BOARD " << _boardname << "all joints with " << pid_type << " enabled should have same controlunits type. Joint " << firstjoint << " differs from joint " << i;
+                    return false;
+                }
+            }
+        }
+    }
+
     return true;
 }
 

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -2335,7 +2335,7 @@ bool Parser::checkJointTypes(PidInfo *pids, const std::string &pid_type)
     //parse verify if pid type is torque or some other
     if(pid_type == "TORQUE")
     {
-        dynamic_cast<TrqPidInfo*>(pids);
+        TrqPidInfo* pids = dynamic_cast<TrqPidInfo*>(pids);
     }
 
     //get first joint with enabled pid_type

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -85,6 +85,7 @@ bool Parser::parsePids(yarp::os::Searchable &config, PidInfo *ppids/*, PidInfo *
     // come specificato in _currentControlLaw
     if(!parseSelectedCurrentPid(config, lowLevPidisMandatory, cpids)) // OK
         return false;
+
     // legge i pid di velocità per ciascun motore 
     // come specificato in _speedControlLaw
     if(!parseSelectedSpeedPid(config, lowLevPidisMandatory, spids)) // OK

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.h
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.h
@@ -178,7 +178,7 @@ public:
         fbk_PidUnits = yarp::dev::PidFeedbackUnitsEnum::RAW_MACHINE_UNITS;
         out_PidUnits = yarp::dev::PidOutputUnitsEnum::RAW_MACHINE_UNITS;
     }
-    ~PidInfo()
+    virtual ~PidInfo()
     {
         //delete (usernamePidSelected);
     }

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.h
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.h
@@ -178,7 +178,7 @@ public:
         fbk_PidUnits = yarp::dev::PidFeedbackUnitsEnum::RAW_MACHINE_UNITS;
         out_PidUnits = yarp::dev::PidOutputUnitsEnum::RAW_MACHINE_UNITS;
     }
-    virtual ~PidInfo()
+    ~PidInfo()
     {
         //delete (usernamePidSelected);
     }

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.h
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.h
@@ -371,6 +371,7 @@ private:
     bool parsePidUnitsType(yarp::os::Bottle &bPid, yarp::dev::PidFeedbackUnitsEnum  &fbk_pidunits, yarp::dev::PidOutputUnitsEnum& out_pidunits);
 
     bool checkJointTypes(PidInfo *pids, const std::string &pid_type);
+    bool checkSinglePid(PidInfo &firstPid, PidInfo &currentPid, const int &firstjoint, const int &currentjoint, const std::string &pid_type);
 
     bool convert(std::string const &fromstring, eOmc_jsetconstraint_t &jsetconstraint, bool& formaterror);
     bool convert(yarp::os::Bottle &bottle, std::vector<double> &matrix, bool &formaterror, int targetsize);


### PR DESCRIPTION
This PR fixes issue #718 .

Since we have an array of PidInfo / TrqPidInfo, we can't rely on class inheritance to query the parameters of each PID ([an array of Derived is not a kind-of array of Base][1]). As such, we need to check if the PID type is torque and handle it differently.

[1]: https://www.cs.technion.ac.il/users/yechiel/c++-faq/array-derived-vs-base.html