### PR TITLE
Bump version to 1.19.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.12)
 
 set(ROOT_PROJECT_NAME ICUB)
 project(${ROOT_PROJECT_NAME} LANGUAGES C CXX
-                             VERSION 1.19.0)
+                             VERSION 1.19.1)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
For some experiments I am doing with generation of conda binaries, it would be convenient to tag 1.19.1 that includes https://github.com/robotology/icub-main/pull/724, what do you think @Nicogene ? 