### PR TITLE
wholeBodyPlayer: fix limits/security checks

### DIFF
--- a/src/tools/wholeBodyPlayer/WholeBodyPlayerModule.h
+++ b/src/tools/wholeBodyPlayer/WholeBodyPlayerModule.h
@@ -112,13 +112,13 @@ public:
             m_mutex.lock();
             for (size_t i=0; i<datum.size(); i++) {
                 m_nextState[i] = datum.get(i).asDouble();
-                if ((m_nextState[i]<min[i] || m_nextState[i]> max[i]) && (i < 7)) { // 7 is for ignoring the hands in the limit check
+                if ((m_nextState[i]<min[i] || m_nextState[i]> max[i]) && (!m_isArm || i < 6)) { // 7 is for ignoring the hands in the limit check
                     yWarning()<<"ReplayPort: trying to move joint"<<i<<"of"<<m_partName<<" to "<<m_nextState[i]<<", it exceeds the limits, skipping...";
                     continue;
                 }
                 auto delta = std::fabs(m_nextState[i] - m_currState[i]);
                 ok &= delta < tolerance; // TODO improve the check calculating the distance between the 2 vector !!!
-                if (!ok && !m_simulator && (!m_isArm || i < 7)) { // 7 is for ignoring the hands in the security check
+                if (!ok && !m_simulator && (!m_isArm || i < 6)) { // 7 is for ignoring the hands in the security check
                     yWarning()<<"ReplayPort: joint"<<i<<"of"<<m_partName<<"is too far to the target position";
                     yWarning()<<"Desired: "<<datum.get(i).asDouble()<<"current: "<<m_currState[i]
                     <<"delta: "<<delta<<"Trying to reach "

--- a/src/tools/wholeBodyPlayer/WholeBodyPlayerModule.h
+++ b/src/tools/wholeBodyPlayer/WholeBodyPlayerModule.h
@@ -45,6 +45,8 @@
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/RFModule.h>
+#include <yarp/os/RpcClient.h>
+#include <yarp/os/Stamp.h>
 #include <yarp/dev/IPositionDirect.h>
 #include <yarp/dev/IPositionControl.h>
 #include <yarp/dev/IControlMode.h>
@@ -57,7 +59,6 @@
 #include <cmath>
 #include <memory>
 #include <mutex>
-#include <yarp/os/RpcClient.h>
 
 constexpr double tolerance = 5.0; //degrees
 
@@ -106,6 +107,9 @@ public:
     using yarp::os::TypedReaderCallback<yarp::os::Bottle>::onRead;
     void onRead(yarp::os::Bottle& datum) override
     {
+        yarp::os::Stamp ts;
+        this->getEnvelope(ts);
+        yDebug()<<"count"<<ts.getCount()<< "TS" << ts.getTime();
         if (m_state==state::ok && m_posDir && !datum.isNull()) {
 
             bool ok = m_enc->getEncoders(m_currState.data());

--- a/src/tools/wholeBodyPlayer/WholeBodyPlayerModule.h
+++ b/src/tools/wholeBodyPlayer/WholeBodyPlayerModule.h
@@ -112,13 +112,13 @@ public:
             m_mutex.lock();
             for (size_t i=0; i<datum.size(); i++) {
                 m_nextState[i] = datum.get(i).asDouble();
-                if (m_nextState[i]<min[i] || m_nextState[i]> max[i]) {
+                if ((m_nextState[i]<min[i] || m_nextState[i]> max[i]) && (i < 7)) { // 7 is for ignoring the hands in the limit check
                     yWarning()<<"ReplayPort: trying to move joint"<<i<<"of"<<m_partName<<" to "<<m_nextState[i]<<", it exceeds the limits, skipping...";
                     continue;
                 }
                 auto delta = std::fabs(m_nextState[i] - m_currState[i]);
                 ok &= delta < tolerance; // TODO improve the check calculating the distance between the 2 vector !!!
-                if (!ok && !m_simulator && (!m_isArm || i < 5)) { // 5 is for ignoring the hands in the security check
+                if (!ok && !m_simulator && (!m_isArm || i < 7)) { // 7 is for ignoring the hands in the security check
                     yWarning()<<"ReplayPort: joint"<<i<<"of"<<m_partName<<"is too far to the target position";
                     yWarning()<<"Desired: "<<datum.get(i).asDouble()<<"current: "<<m_currState[i]
                     <<"delta: "<<delta<<"Trying to reach "


### PR DESCRIPTION
The latest joint of the wrist is 6 not 4, and the check of the joint limits has to be skipped for the hands since the encoders are not reliable


TO BE TESTED