### PR TITLE
Improvements on the BCB battery module

### DIFF
--- a/src/libraries/icubmod/bcbBattery/README.md
+++ b/src/libraries/icubmod/bcbBattery/README.md
@@ -1,0 +1,40 @@
+# bcbBattery
+
+
+
+This module implements the [``IBattery``](http://www.yarp.it/git-master/classyarp_1_1dev_1_1IBattery.html) interface to retrieve the status of the battery in the iCub backpack.
+
+
+
+## Dependencies
+
+In order for this module to be compiled, it needs to be enabled with the option ``ENABLE_icubmod_bcbBattery`` set to ``ON``. In addition, ``yarp`` needs to be compiled with the following options set to ``ON``:
+
+- ``ENABLE_yarpmod_batteryWrapper``
+- ``ENABLE_yarpmod_serial``
+- ``ENABLE_yarpmod_serialport``
+
+In addition, in order to have a GUI representation of the battery status, enable the following in ``yarp``
+
+- ``ENABLE_yarpmod_batteryClient``
+- ``YARP_COMPILE_yarpbatterygui``
+
+## How to use
+
+This module can be used by resorting to the configuration files already available in the [``battery`` folder](https://github.com/robotology/robots-configuration/tree/master/experimentalSetups/battery) in the ``experimentalSetups`` of ``robots-configuration``. From that folder, it is sufficient to run ``yarprobotinterface``.
+
+
+
+## Configuration parameters
+
+The configuration file of this module needs two groups. A group named ``SERIAL_PORT`` with all the parameters relative to the serial port connection. For the meaning of these parameters refer to the ``serialPort`` [header file](https://github.com/robotology/yarp/blob/ab488c74e37de629af207b83be2fd90ae7412b1b/src/devices/serialport/SerialDeviceDriver.h#L34-L70). Their setup depends on the serial configuration done on the hardware side.
+
+
+
+The second group should be named ``GENERAL`` and should contain the following:
+
+- ``thread_period``:    the thread period in milliseconds 
+- ``screen``: when equal to 1, it enables an info print in the terminal showing the battery status
+- ``verbose``: when equal to 1, it prints on the terminal the raw value coming from the terminal.
+- ``silence_sync_warnings``: when 1 it avoids printing warning messages relative to syncing.
+

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
@@ -71,6 +71,7 @@ bool BcbBattery::open(yarp::os::Searchable& config)
     this->verboseEnable = group_general.check("verbose", Value(0), "enable/disable the verbose mode").asBool();
     this->screenEnable = group_general.check("screen", Value(0), "enable/disable the screen output").asBool();
     this->debugEnable = group_general.check("debug", Value(0), "enable/disable the debug mode").asBool();
+    this->silenceSyncWarnings = group_general.check("silence_sync_warnings", Value(0), "enable/disable the print of warnings in case of sync errors.").asBool();
 
     PeriodicThread::start();
     return true;
@@ -157,8 +158,8 @@ void BcbBattery::run()
             output[5] = pSerial->receiveChar(serial_buff[5]); //charge
             output[6] = pSerial->receiveChar(serial_buff[6]); //charge
             output[7] = pSerial->receiveChar(serial_buff[7]); //status
-            output[8] = pSerial->receiveChar(serial_buff[8]); if (serial_buff[8] != '\r') { yWarning("BcbBattery sync error r");}
-            output[9] = pSerial->receiveChar(serial_buff[9]); if (serial_buff[9] != '\n') { yWarning("BcbBattery sync error n");}
+            output[8] = pSerial->receiveChar(serial_buff[8]); if (serial_buff[8] != '\r' && !silenceSyncWarnings) { yWarning("BcbBattery sync error r");}
+            output[9] = pSerial->receiveChar(serial_buff[9]); if (serial_buff[9] != '\n' && !silenceSyncWarnings) { yWarning("BcbBattery sync error n");}
         }
 
         serial_buff[10] = 0;

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
@@ -305,14 +305,14 @@ bool BcbBattery::getBatteryCharge(double &charge)
 
 bool BcbBattery::getBatteryStatus(Battery_status &status)
 {
-    //yError("Not yet implemented");
+    //The BCB battery indicator does not provide this info, so we simply return BATTERY_OK_IN_USE
     status=Battery_status::BATTERY_OK_IN_USE;
     return true;
 }
 
 bool BcbBattery::getBatteryTemperature(double &)
 {
-    //yError("Not yet implemented");
+    //The BCB battery indicator does not provide this info, so we simply return true
     return true;
 }
 

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
@@ -68,7 +68,6 @@ bool BcbBattery::open(yarp::os::Searchable& config)
     // Other options
     this->verboseEnable = group_general.check("verbose", Value(0), "enable/disable the verbose mode").asBool();
     this->screenEnable = group_general.check("screen", Value(0), "enable/disable the screen output").asBool();
-    this->debugEnable = group_general.check("debug", Value(0), "enable/disable the debug mode").asBool();
     this->silenceSyncWarnings = group_general.check("silence_sync_warnings", Value(0), "enable/disable the print of warnings in case of sync errors.").asBool();
 
     this->isClosing = false;
@@ -106,7 +105,6 @@ bool BcbBattery::threadInit()
     battery_voltage     = 0.0;
     battery_current     = 0.0;
     battery_charge      = 0.0;
-    battery_temperature = 0.0;
     timeStamp = yarp::os::Time::now();
 
     //start the transmission

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
@@ -86,6 +86,13 @@ bool BcbBattery::close()
         //stop the thread
         PeriodicThread::stop();
 
+        char c = 0x00;
+        if (pSerial)
+        {
+            bool ret = pSerial->send(&c, 1);
+            if (ret == false) { yError("BcbBattery problems while stopping the transmission");}
+        }
+
         //stop the driver
         driver.close();
     }

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.h
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.h
@@ -37,6 +37,7 @@ protected:
     bool verboseEnable;
     bool screenEnable;
     bool debugEnable;
+    bool silenceSyncWarnings;
 
     ResourceFinder      rf;
     PolyDriver          driver;

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.h
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.h
@@ -8,6 +8,7 @@
 #define __BCBBATTERY_H__
 
 #include <mutex>
+#include <atomic>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/IBattery.h>
 #include <yarp/dev/PolyDriver.h>
@@ -45,6 +46,8 @@ protected:
     char                serial_buff[255];
     std::string         remoteName;
     std::string         localName;
+
+    std::atomic<bool> isClosing;
 
 public:
     BcbBattery(int period = 20) : PeriodicThread((double)period/1000.0)

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.h
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.h
@@ -24,28 +24,21 @@ class BcbBattery : public PeriodicThread, public yarp::dev::IBattery, public Dev
 protected:
     std::mutex mtx;
 
-    unsigned short     batteryId;
-    short              status;
     double             timeStamp;
-    yarp::sig::Vector  data;
     double             battery_charge;
     double             battery_voltage;
     double             battery_current;
-    double             battery_temperature;
     std::string        battery_info;
     unsigned char      backpack_status;
 
     bool verboseEnable;
     bool screenEnable;
-    bool debugEnable;
     bool silenceSyncWarnings;
 
     ResourceFinder      rf;
     PolyDriver          driver;
     ISerialDevice       *pSerial;
     char                serial_buff[255];
-    std::string         remoteName;
-    std::string         localName;
 
     std::atomic<bool> isClosing;
 


### PR DESCRIPTION
## Intro
This PR attempts at improving the ``bcbBattery`` module, fixing the following issues:
- ``thread_period`` was not found in the conf file and most probably assumed to be zero.
- A mutex was missing in the close method causing data races on the use of the serial device.
- The voltage and current values were not divided by 1000 (the board sends the values in mV and mA)
- It was not properly checked if the char were read correctly or not. Most of the times, the read values were from uninitialized memory.
- The sync mechanism seemed to have issues
- The methods returning the battery status and temperature were always returning false, avoiding the BatteryWrapper to stream the values.
- The print of the received buffer was not readable.

In addition, I added the following:
-  A parameter to avoid printing the messages relative to sync issues (in case it will be ever added to the robot main ``yarprobotinterface``).
- Improved the closing logic, aborting any while loop in the run method when closing.
- Stop the BCB transmission when closing the device
- Added a simple README.

## How to test it on the robot head

(I will move these lines to a proper place afterward, this is just for reference)
<details>
<summary><b>Bluetooth setup</b></summary>
<p>

First, it is necessary to understand the Bluetooth ID relative to the BCB board installed on the robot. For example, in ``iCubGenova04`` this is named ``RNBT-8223`` (in general it should be ``RNBT-``something) and has the address ``00:06:66:E7:82:23``.

First, you need to pair it. In order to do so, you can use ``bluetoothctl``. In particular, after running ``bluetoothctl``, you can trust the device with 
```
scan on
trust 00:06:66:E7:82:23
```
and then 
```
pair  00:06:66:E7:82:23
```
It may ask you to enter ``yes`` just to check that the passcode is correct.

After that, it is not possible to connect since the board is not compatible with ``BlueZ``. In order to use it as a serial device, it is possible to use [``rfcomm``](https://linux.die.net/man/1/rfcomm):
```
sudo rfcomm -r connect 0 00:06:66:E7:82:23
```
This connects to the Bluetooth and creates a serial device named ``/dev/rfcomm0`` in ``raw`` mode. The problem with ``rfcomm connect`` is that it keeps the connection with the Bluetooth board even when not necessary. Alternatively, it is possible to use 
```
sudo rfcomm bind 0 00:06:66:E7:82:23
```
This connects to the Bluetooth only when the port ``/dev/rfcomm0`` is opened. The drawback is that this interprets the serial communication as TTY. This causes the ``\r`` chars to be changed into ``\n``, hence messing up with the communication protocol of the BCB board. This can be fixed by using
```
sudo stty -F /dev/rfcomm0 raw
```

On the robot side, whenever we connect to the BCB board, a blue LED should light up between the "Motors" and "CPU" button. .

Unfortunately, it seems that the LED to notify that a connection is done is not installed in the BCB currently on ``iCubGenova04``. Still, there is a blue LED visible from inside the backpack. This gets constant blue when connected to the Bluetooth (i.e. when opening the file ``/dev/rfcomm0``).

![image](https://user-images.githubusercontent.com/18591940/108092204-c0edd600-707c-11eb-98be-c2d37080d7e9.png)

When nothing is connected, it blinks:

https://user-images.githubusercontent.com/18591940/108092398-fbf00980-707c-11eb-8ad6-2d014a2004b4.mp4

</p>
</details>

<details>
<summary><b>How to run the connection automatically at startup</b></summary>

The connections made via ``rfcomm`` get reset when shutting down. In order to have them working at startup, I created a system service as follows. First I created the file ``battery_bluetooth.service`` in the folder ``/etc/systemd/system/`` as follows
<details>
<summary><code>battery_bluetooth.service</code> content</summary>
<p>

```
[Unit]
Description=Connect to the BCB board via bluetooth using rfcomm
After=bluetooth.service

[Service]
Type=oneshot
ExecStart=/bin/bash /home/icub/battery_bluetooth.sh

[Install]
WantedBy=multi-user.target
```
</p>

</details>

This service runs once the ``battery_bluetooth.sh`` script once at startup after running the ``bluetooth`` service.

<details>
<summary><code>battery_bluetooth.sh</code> content</summary>
<p>

```bash
#!/bin/bash

address=00:06:66:E7:82:23

connected=0
i=0

echo Started

while (( connected == 0 && i < 10 ))
do
    echo Attempt $i
    rfcomm release 0 # Close eventual previous connections
    rfcomm -r connect 0 $address > /tmp/connect_out 2>&1 & #executes rfcomm in background to check that bluetooth is working
    sleep 5
    pid=$! #stores executed process id in pid
    count=$(ps -A| grep $pid |wc -l) #check whether process is still running
    if [[ $count -eq 0 ]] #if process is already terminated, then there were issues in connecting
    then
        cat /tmp/connect_out
        echo Connect failed
    else
        rfcomm release 0
        echo Released connection
        sleep 1
        cat /tmp/connect_out
        if grep -q "$address" /tmp/connect_out; then # If the connection was successfull, the address should be displayed in the output
            echo Connect successfull
            rfcomm bind 0 $address > /tmp/bind_out 2>&1
            cat /tmp/bind_out
            if [[ -s /tmp/bind_out ]]; then #if bind is successfull does not print anything
                echo  Bind returned error
            else
                echo Bind successfull
                sleep 1
                echo Calling stty
                stty -F /dev/rfcomm0 raw
                stty_return=$?
                if [[ $stty_return -eq 0 ]]
                then
                    echo stty successfull
                    connected=1
                else
                    echo stty failed
                fi
            fi
        else
            echo Connect failed
        fi
    fi
    i=$((i+1))
done

```
</p>

</details>

The scripts first tries to connect using ``rfcomm connect``. If it works (hence ``rfcomm connect`` is still alive), releases the connection. Then it tries running ``rfcomm bind`` and ``stty`` checking the outputs in case of errors. If there is any error, it tries again at most 10 times.

This service can be enabled at startup with 
```
sudo systemctl enable battery_bluetooth.service
```
and started with 
```
sudo systemctl enable battery_bluetooth.service
```
In case there were errors starting the service, it is possible to inspect the output of the script with 
```
systemctl status battery_bluetooth.service
```
This script can also be run after startup in case the connection is not working, with 
```
sudo bash ~/battery_bluetooth.sh
```

</details>

<details>

<summary><b>Running the module</b></summary>

In  case of ``iCubGenova04``, I already added the configuration files and they are installed. Hence, to run the module it is sufficient to run
```
yarprobotinterface --config battery/icub_battery.xml
```
otherwise, it is possible to go to the [``battery`` folder](https://github.com/robotology/robots-configuration/tree/master/experimentalSetups/battery) in the ``experimentalSetups`` of ``robots-configuration`` and run
```
yarprobotinterface
```
Once it is running, it is possible to visualize the battery status from anywhere in ``yarp`` network by running
```
yarpbatterygui --remote /icub/battery
```
</details>

