### PR TITLE
Fix wholeBodyDynamics and gravityCompensator memory leaks

### DIFF
--- a/src/modules/gravityCompensator/gravityThread.cpp
+++ b/src/modules/gravityCompensator/gravityThread.cpp
@@ -84,7 +84,7 @@ void gravityCompensatorThread::init_upper()
     //---------------------PARTS-------------------------//
     // Left_arm variables
     allJnt = 0;
-    int jnt=7;
+    int jnt=16;
     encoders_arm_left.resize(jnt,0.0);
     F_LArm.resize(6,0.0);
     F_iDyn_LArm.resize(6,0.0);
@@ -95,7 +95,7 @@ void gravityCompensatorThread::init_upper()
     allJnt+=jnt;
 
     // Right_arm variables
-    jnt = 7;
+    jnt = 16;
     encoders_arm_right.resize(jnt,0.0);
     F_RArm.resize(6,0.0);
     F_iDyn_RArm.resize(6,0.0);
@@ -106,7 +106,7 @@ void gravityCompensatorThread::init_upper()
     allJnt+=jnt;
 
     // Head variables
-    jnt = 3;
+    jnt = 6;
     encoders_head.resize(jnt,0.0);
     q_head.resize(3,0.0);
     dq_head.resize(3,0.0);

--- a/src/modules/wholeBodyDynamics/observerThread.cpp
+++ b/src/modules/wholeBodyDynamics/observerThread.cpp
@@ -110,7 +110,7 @@ void inverseDynamics::init_upper()
     //---------------------PARTS-------------------------//
     // Left_arm variables
     allJnt = 0;
-    int jnt=7;
+    int jnt=16;
     encoders_arm_left.resize(jnt,0.0);
     F_LArm.resize(6,0.0);
     F_iDyn_LArm.resize(6,0.0);
@@ -118,7 +118,7 @@ void inverseDynamics::init_upper()
     allJnt+=jnt;
 
     // Right_arm variables
-    jnt = 7;
+    jnt = 16;
     encoders_arm_right.resize(jnt,0.0);
     F_RArm.resize(6,0.0);
     F_iDyn_RArm.resize(6,0.0);
@@ -126,7 +126,7 @@ void inverseDynamics::init_upper()
     allJnt+=jnt;
 
     // Head variables
-    jnt = 3;
+    jnt = 6;
     encoders_head.resize(jnt,0.0);
     allJnt+=jnt;
 


### PR DESCRIPTION
This bug was hidden by the fact in the past the `yarp::sig::Vector` by default preallocated 16 elements. Calling e.g. `getEncoders` with a smaller vector made this function call write in forbidden memory areas.

With these fixes they do not crash anymore, and they close gracefully

Please review code.

(I know that I should retrieve the number of joints and not hardcode them, but this executable will be replaced soon.)