### PR TITLE
Disable finding FFMPEG in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
         git clone https://github.com/robotology/yarp.git --depth 1 --branch master
         cd yarp && mkdir -p build && cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DYARP_COMPILE_GUIS:BOOL=OFF \
-              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
+              -DCMAKE_DISABLE_FIND_PACKAGE_FFMPEG=ON ..
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL
         # icub-firmware-shared
         cd ${GITHUB_WORKSPACE}
@@ -97,7 +98,8 @@ jobs:
         cd ${GITHUB_WORKSPACE}
         git clone https://github.com/robotology/yarp.git --depth 1 --branch master
         cd yarp && mkdir -p build && cd build
-        cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DYARP_COMPILE_GUIS:BOOL=OFF ..
+        cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DYARP_COMPILE_GUIS:BOOL=OFF \
+               -DCMAKE_DISABLE_FIND_PACKAGE_FFMPEG=ON ..
         cmake --build . --config ${{ matrix.build_type }} --target install
         # icub-firmware-shared
         cd ${GITHUB_WORKSPACE}


### PR DESCRIPTION
`FindFFMPEG.cmake` returns that the component is found even if not all libraries are installed (e.g. `libavdevice-dev`).

This is causing problems in CI: see for example https://github.com/robotology/icub-main/runs/2198575453?check_suite_focus=true.

cc @drdanz @Nicogene 