### PR TITLE
Make ctrlLib constants constexpr

### DIFF
--- a/src/libraries/ctrlLib/CMakeLists.txt
+++ b/src/libraries/ctrlLib/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 
 add_library(${PROJECT_NAME} ${folder_source} ${folder_header})
 add_library(ICUB::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-target_compile_definitions(${PROJECT_NAME} PRIVATE _USE_MATH_DEFINES)
+target_compile_definitions(${PROJECT_NAME} PUBLIC _USE_MATH_DEFINES)
 
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
                                                   "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")

--- a/src/libraries/ctrlLib/include/iCub/ctrl/math.h
+++ b/src/libraries/ctrlLib/include/iCub/ctrl/math.h
@@ -37,6 +37,8 @@
 #ifndef __CTRLMATH_H__
 #define __CTRLMATH_H__
 
+#include <cmath>
+
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/math/Math.h>
@@ -51,17 +53,17 @@ namespace ctrl
 /**
  * The PI constant.
  */
-extern const double CTRL_PI;
+constexpr double CTRL_PI = M_PI;
 
 /**
  * 180/PI.
  */
-extern const double CTRL_RAD2DEG;
+constexpr double CTRL_RAD2DEG = 180.0 / M_PI;
 
 /**
  * PI/180.
  */
-extern const double CTRL_DEG2RAD;
+constexpr double CTRL_DEG2RAD = M_PI / 180.0;
 
 /**
 * \ingroup Maths

--- a/src/libraries/ctrlLib/src/math.cpp
+++ b/src/libraries/ctrlLib/src/math.cpp
@@ -8,7 +8,6 @@
  * details.
 */
 
-#include <cmath>
 #include <string>
 
 #include <yarp/os/Log.h>
@@ -19,16 +18,6 @@ using namespace std;
 using namespace yarp::os;
 using namespace yarp::sig;
 using namespace yarp::math;
-
-
-/************************************************************************/
-namespace iCub {
-    namespace ctrl {
-        const double CTRL_PI=M_PI;
-        const double CTRL_RAD2DEG=180.0/M_PI;
-        const double CTRL_DEG2RAD=M_PI/180.0;
-    }
-}
 
 
 /************************************************************************/


### PR DESCRIPTION
This PR addresses #717.

Instead of resorting to the CMake infrastructure to export the constants, I've verified that declaring those identifiers as `constexpr` made the trick, both in shared and static building.

@traversaro I believe this way is simpler to be maintained.

What's your opinion?