### PR TITLE
Fix imuFilter sampling of incoming data

### DIFF
--- a/src/libraries/icubmod/imuFilter/ImuFilter.cpp
+++ b/src/libraries/icubmod/imuFilter/ImuFilter.cpp
@@ -136,13 +136,13 @@ bool ImuFilter::open(yarp::os::Searchable& config)
     gyroBias.resize(3,0.0);
     adaptGyroBias=false;
 
-    m_period=config.check("period",Value(0.01)).asDouble()/1000.0;
+    m_period_ms=config.check("period",Value(20)).asInt();
 
     if (name.at(0) != '/')
         name = "/" +name;
     ok &= bPort.open(name+"/bias:o");
 
-    this->setPeriod(m_period);
+    this->setPeriod(m_period_ms / 1000.0);
 
     if (!ok) {
         yError()<<"imuFilter: failed to open the bias port";

--- a/src/libraries/icubmod/imuFilter/ImuFilter.h
+++ b/src/libraries/icubmod/imuFilter/ImuFilter.h
@@ -174,7 +174,7 @@ class yarp::dev::ImuFilter :  public yarp::os::PeriodicThread,
     double bias_gain{0.0};
     bool verbose{false};
     bool adaptGyroBias{false};
-    double m_period{0.01};
+    int m_period_ms{20};
     double gyroTs{0.0};
     mutable std::mutex m_mutex;
     yarp::os::Stamp stampBias;


### PR DESCRIPTION
This PR aims to fix #728.

To this end, the option `period` is handled in `ms` instead of `s`, plus the default value is brought to 20 ms instead of 10 ms in order to prevent the generation of continuous warning: we take a sampling margin wrt the rate of the incoming data, which is 10 ms.