### PR TITLE
Update right upperarm v3 skingui config file

### DIFF
--- a/app/skinGui/conf/skinGui/right_upperarm_V3.ini
+++ b/app/skinGui/conf/skinGui/right_upperarm_V3.ini
@@ -7,9 +7,9 @@ height 600
 
 #             x     y     th   gain
 [SENSORS]
-triangle_10pad	8	52	-4.574374158		4	
+triangle_10pad	8	52	-4.574374158	0	        4
 triangle_10pad	9	36	4.663230149	59.99985969	4	
-triangle_10pad	6	36	23.13843876		4	
+triangle_10pad	6	36	23.13843876	0	        4
 triangle_10pad	7	52	32.37604307	-59.99985969	4	
 triangle_10pad	3	20	32.37604307	59.99985969	4	
 triangle_10pad	4	4	23.13843876	119.9997194	4	


### PR DESCRIPTION
This patch fixes the skinGui visualization for right upperarm on v3. This is following the support ticket https://github.com/robotology/icub-tech-support/issues/1134 for checking if the right upperarm skin triangle patches numbered `6` and `8` are not working. Thanks to @simeonedussoni who pointed that it is the configuration file problem.


https://user-images.githubusercontent.com/6505998/118624359-6114e180-b7c9-11eb-93d2-1e7ea8482d93.mp4


https://user-images.githubusercontent.com/6505998/118624367-62460e80-b7c9-11eb-87af-79fb5204a158.mp4

CC @S-Dafarra @DanielePucci 

