### PR TITLE
BcbBattery

### DIFF
--- a/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
@@ -156,15 +156,15 @@ void batteryReaderThread::run()
     }
 
     //parse battery data
-    std::smatch match;
-    string stringbuf((char*)tmp_buff, recb);
-    bool b = std::regex_search(stringbuf, match, r_exp);
+    std::cmatch cmatch;
+    bool b = std::regex_search((const char*)tmp_buff, (const char*)tmp_buff+recb, cmatch, r_exp);
+
     if (b)
     {
         //get the data
         for (size_t i=0; i< packet_len; i++)
         {
-            packet[i] = match.str().c_str()[i];
+            packet[i] = cmatch.str().c_str()[i];
         }
 
         //add checksum verification.

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
@@ -13,9 +13,25 @@
 #include <string.h>
 #include <time.h>
 #include <stdlib.h>
+#include <cmath>
 
 using namespace std;
+
 //#define DEBUG_TEST 1
+
+#ifdef DEBUG_TEST
+int test_buffer(unsigned char* tmp_buff, int buff_len)
+{
+    //          012345678901234567890123456789
+    //          567890123456789012345678901234
+    string s = "MMN...AABBCCD...EEFFGGH...IILL";
+    strcpy((char*)(tmp_buff), s.c_str());
+    (tmp_buff)[03] = '\r';  (tmp_buff)[04] = '\n';  (tmp_buff)[05] = '\0';
+    (tmp_buff)[13] = '\r';  (tmp_buff)[14] = '\n';  (tmp_buff)[15] = '\0';
+    (tmp_buff)[23] = '\r';  (tmp_buff)[24] = '\n';  (tmp_buff)[25] = '\0';
+    return s.size();
+}
+#endif
 
 bool BcbBattery::open(yarp::os::Searchable& config)
 {
@@ -38,7 +54,6 @@ bool BcbBattery::open(yarp::os::Searchable& config)
     }
 
     int period=group_general.find("thread_period").asInt();
-    setPeriod((double)period/1000.0);
 
     Property prop;
     std::string ps = group_serial.toString();
@@ -65,213 +80,110 @@ bool BcbBattery::open(yarp::os::Searchable& config)
 #endif
     }
 
+    //create the thread
+    batteryReader = new batteryReaderThread(pSerial, (double)period / 1000.0);
     // Other options
-    this->verboseEnable = group_general.check("verbose", Value(0), "enable/disable the verbose mode").asBool();
-    this->screenEnable = group_general.check("screen", Value(0), "enable/disable the screen output").asBool();
-    this->silenceSyncWarnings = group_general.check("silence_sync_warnings", Value(0), "enable/disable the print of warnings in case of sync errors.").asBool();
+    batteryReader->verboseEnable = group_general.check("verbose", Value(0), "enable/disable the verbose mode").asBool();
+    batteryReader->screenEnable = group_general.check("screen", Value(0), "enable/disable the screen output").asBool();
+    batteryReader->silenceSyncWarnings = group_general.check("silence_sync_warnings", Value(0), "enable/disable the print of warnings in case of sync errors.").asBool();
 
-    this->isClosing = false;
-    PeriodicThread::start();
+    //start the thread
+    batteryReader->start();
     return true;
 }
 
 bool BcbBattery::close()
 {
-    isClosing = true;
+    //stop the thread
+    batteryReader->stop();
 
-    {
-        lock_guard<mutex> lck(mtx);
-
-        //stop the thread
-        PeriodicThread::stop();
-
-        char c = 0x00;
-        if (pSerial)
-        {
-            bool ret = pSerial->send(&c, 1);
-            if (ret == false) { yError("BcbBattery problems while stopping the transmission");}
-        }
-
-        //stop the driver
-        driver.close();
-    }
+    //stop the driver
+    driver.close();
 
     return true;
 }
 
-bool BcbBattery::threadInit()
+bool batteryReaderThread::threadInit()
 {
-    battery_info = "icub battery system v1.0";
-    battery_voltage     = 0.0;
-    battery_current     = 0.0;
-    battery_charge      = 0.0;
     timeStamp = yarp::os::Time::now();
 
-    //start the transmission
-    char c = 0x01;
     if (pSerial)
     {
-        bool ret = pSerial->send(&c, 1);
-        if (ret == false) { yError("BcbBattery problems starting the transmission"); return false; }
-
-        //empty the buffer
-        char c = 0;
-        int r = 0;
-        do
-        {
-            r = pSerial->receiveChar(c);
-        } while (r != 0);
+        yInfo("BcbBattery starting transmission");
+        startTransmission();
+        yInfo("BcbBattery started successfully");
     }
     else
     {
+#ifndef DEBUG_TEST
         yError("BcbBattery pSerial == NULL");
         return false;
+#endif
     }
-
 
     return true;
 }
 
-void BcbBattery::run()
+void batteryReaderThread::run()
 {
     double timeNow=yarp::os::Time::now();
-    lock_guard<mutex> lck(mtx);
-
-    //if 100ms have passed since the last received message
-    if (timeStamp+0.1<timeNow)
-    {
-        //status=IBattery::BATTERY_TIMEOUT;
-    }
+    int recb = 0;
 
     //read battery data.
-    serial_buff[0] = 0;
-
-    int output[10] = {0};
-    bool syncError = false;
-
+#ifndef DEBUG_TEST
     if (pSerial)
     {
-        size_t i = 0;
-        bool sync0 = false;
-        bool syncr = false;
-        bool syncn = false;
-        do
-        {
-            output[0] = pSerial->receiveChar(serial_buff[0]);
-            sync0 = output[0] && (serial_buff[0] == '\0');
-            ++i;
-        } while (!(sync0) && (i < 20) && !isClosing);
-
-        if (isClosing)
-        {
-            return;
-        }
-
-        if (sync0)
-        {
-            output[1] = pSerial->receiveChar(serial_buff[1]); //voltage
-            output[2] = pSerial->receiveChar(serial_buff[2]); //voltage
-            output[3] = pSerial->receiveChar(serial_buff[3]); //current
-            output[4] = pSerial->receiveChar(serial_buff[4]); //current
-            output[5] = pSerial->receiveChar(serial_buff[5]); //charge
-            output[6] = pSerial->receiveChar(serial_buff[6]); //charge
-            output[7] = pSerial->receiveChar(serial_buff[7]); //status
-        }
-
-        i = 0;
-        do
-        {
-            output[8] = pSerial->receiveChar(serial_buff[8]);
-            syncr = output[8] && (serial_buff[8] == '\r');
-            if (syncr)
-            {
-                output[9] = pSerial->receiveChar(serial_buff[9]);
-                syncn = output[9] && (serial_buff[9] == '\n');
-
-                if (!syncn)
-                {
-                    if (!syncError && !silenceSyncWarnings)
-                    {
-                        yDebug() << "Sync error (n)";
-                    }
-                    syncError = true;
-                }
-            }
-            else
-            {
-                if (!syncError && !silenceSyncWarnings)
-                {
-                    yDebug() << "Sync error (r)";
-                }
-                syncError = true;
-            }
-            ++i;
-        } while (!(syncn) && (i < 20) && !isClosing);
-
-        if (isClosing)
-        {
-            return;
-        }
-
-        serial_buff[10] = 0;
+        recb = pSerial->receiveBytes(tmp_buff, buff_len);
     }
     else
     {
         yError("BcbBattery pSerial == NULL");
     }
-
-#if DEBUG_TEST
-    battery_voltage     = 40.0;
-    battery_current = 5.0;
-    battery_charge = 72.0;
-    battery_temperature = 35.0;
 #else
+    recb = test_buffer((unsigned char*)(tmp_buff), buff_len);
+#endif
 
     if (verboseEnable)
     {
-        char hexBuffer[31];
-        char decBuffer[41];
-        for (size_t i = 0; i < 10; ++i)
+        printf("internal buffer:");
+        for (size_t i = 0; i < recb; i++)
+            printf("%02X ", (unsigned int)(tmp_buff[i] & 0xFF));
+        printf("\n");
+    }
+
+    //parse battery data
+    std::smatch match;
+    string stringbuf((char*)tmp_buff, recb);
+    bool b = std::regex_search(stringbuf, match, r_exp);
+    if (b)
+    {
+        //get the data
+        for (size_t i=0; i< packet_len; i++)
         {
-            if (output[i])
-            {
-                sprintf(hexBuffer + 3*i,"%02X ", (unsigned int)(serial_buff[i] & 0xFF));
-                sprintf(decBuffer + 4*i,"%03u ", (unsigned int)(serial_buff[i] & 0xFF));
-            }
-            else
-            {
-                sprintf(hexBuffer + 3*i,"-- ");
-                sprintf(decBuffer + 4*i,"--- ");
-            }
+            packet[i] = match.str().c_str()[i];
         }
 
-        yDebug("BcbBattery::run() serial_buffer is: (hex) %s, (dec) %s", hexBuffer, decBuffer);
-    }
+        //add checksum verification.
+        //...
 
-    if (output[1] && output[2] && !syncError)
+        if (verboseEnable)
+        {
+            printf("found:");
+            for (size_t i = 0; i < packet_len; i++)
+                printf("%02X ", (unsigned int)(packet[i] & 0xFF));
+            printf("\n");
+        }
+
+        battery_voltage = ((unsigned char)packet[1] * 256 + (unsigned char)packet[2]) / 1000.0;
+        battery_current = ((unsigned char)packet[3] * 256 + (unsigned char)packet[4]) / 1000.0;
+        battery_charge = ((unsigned char)packet[5] * 256 + (unsigned char)packet[6]);
+        backpack_status = (unsigned char)packet[7];
+        battery_status = IBattery::Battery_status::BATTERY_OK_IN_USE;
+    }
+    else
     {
-        battery_voltage = ((unsigned char) serial_buff[1] * 256 + (unsigned char) serial_buff[2])/1000.0;
+        //do nothing
     }
-
-    if (output[3] && output[4] && !syncError)
-    {
-        battery_current = ((unsigned char) serial_buff[3] * 256 + (unsigned char) serial_buff[4])/1000.0;
-    }
-
-    if (output[5] && output[6] && !syncError)
-    {
-        battery_charge =  (unsigned char) serial_buff[5] * 256 + (unsigned char) serial_buff[6];
-    }
-
-    if (output[7] && !syncError)
-    {
-        backpack_status = (unsigned char) serial_buff[7];
-    }
-
-#endif
-
-    //add checksum verification
-    //...
 
     // print data to screen
     if (screenEnable)
@@ -285,50 +197,74 @@ void BcbBattery::run()
         sprintf(buff, "battery status: %+6.1fA   % 6.1fV   charge:% 6.1f%%    time: %s", battery_current, battery_voltage, battery_charge, battery_timestamp);
         yDebug("BcbBattery::run() log_buffer is: %s", buff);
     }
+
+    //flush the buffer
+    pSerial->flush();
 }
 
 bool BcbBattery::getBatteryVoltage(double &voltage)
 {
-    lock_guard<mutex> lck(mtx);
-    voltage = battery_voltage;
+    voltage = batteryReader->battery_voltage;
     return true;
 }
 
 bool BcbBattery::getBatteryCurrent(double &current)
 {
-    lock_guard<mutex> lck(mtx);
-    current = battery_current;
+    current = batteryReader->battery_current;
     return true;
 }
 
 bool BcbBattery::getBatteryCharge(double &charge)
 {
-    lock_guard<mutex> lck(mtx);
-    charge = battery_charge;
+    charge = batteryReader->battery_charge;
     return true;
 }
 
 bool BcbBattery::getBatteryStatus(Battery_status &status)
 {
-    //The BCB battery indicator does not provide this info, so we simply return BATTERY_OK_IN_USE
-    status=Battery_status::BATTERY_OK_IN_USE;
+    status= batteryReader->battery_status;
     return true;
 }
 
-bool BcbBattery::getBatteryTemperature(double &)
+bool BcbBattery::getBatteryTemperature(double &temperature)
 {
-    //The BCB battery indicator does not provide this info, so we simply return true
-    return true;
+    //yError("Not yet implemented");
+    temperature = std::nan("");
+    return false;
 }
 
 bool BcbBattery::getBatteryInfo(string &info)
 {
-    lock_guard<mutex> lck(mtx);
-    info = battery_info;
+    info = batteryReader->battery_info;
     return true;
 }
 
-void BcbBattery::threadRelease()
+void batteryReaderThread::threadRelease()
 {
-    yTrace("BcbBattery Thread released\n");
+    stopTransmission();
+}
+
+void batteryReaderThread::startTransmission()
+{
+    //start the transmission
+    char cmd = 0x01;
+    bool ret = pSerial->send(&cmd, 1);
+    if (ret == false)
+    {
+        yError("BcbBattery problems starting the transmission");
+        return;
+    }
+
+    //empty the buffer
+    pSerial->flush();
+}
+
+void batteryReaderThread::stopTransmission()
+{
+    if (pSerial)
+    {
+        char c = 0x00;
+        bool ret = pSerial->send(&c, 1);
+        if (ret == false) { yError("BcbBattery problems while stopping the transmission"); }
+    }
 }

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
@@ -85,7 +85,6 @@ bool BcbBattery::open(yarp::os::Searchable& config)
     // Other options
     batteryReader->verboseEnable = group_general.check("verbose", Value(0), "enable/disable the verbose mode").asBool();
     batteryReader->screenEnable = group_general.check("screen", Value(0), "enable/disable the screen output").asBool();
-    batteryReader->silenceSyncWarnings = group_general.check("silence_sync_warnings", Value(0), "enable/disable the print of warnings in case of sync errors.").asBool();
 
     //start the thread
     batteryReader->start();

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.h
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.h
@@ -35,7 +35,7 @@ class batteryReaderThread : public PeriodicThread
     static const int   buff_len = 10000;
     unsigned char      tmp_buff[buff_len];
     static const int   packet_len =10;
-    char               packet[packet_len];
+    unsigned char      packet[packet_len];
     std::regex         r_exp;
 
     ISerialDevice*     iSerial = nullptr;

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.h
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.h
@@ -8,61 +8,83 @@
 #define __BCBBATTERY_H__
 
 #include <mutex>
-#include <atomic>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/IBattery.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/SerialInterfaces.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/sig/Vector.h>
+#include <regex>
 
 using namespace yarp::os;
 using namespace yarp::dev;
 
-class BcbBattery : public PeriodicThread, public yarp::dev::IBattery, public DeviceDriver
+class batteryReaderThread : public PeriodicThread
+{
+    public:
+    //configuration options
+    bool               verboseEnable = false;
+    bool               screenEnable = true;
+    bool               silenceSyncWarnings = false;
+
+    //the buffer
+    double             timeStamp;
+    static const int   buff_len = 10000;
+    unsigned char      tmp_buff[buff_len];
+    static const int   packet_len =10;
+    char               packet[packet_len];
+    std::regex         r_exp;
+
+    ISerialDevice*     pSerial = nullptr;
+    double             battery_charge = 0;
+    double             battery_voltage = 0;
+    double             battery_current = 0;
+    std::string        battery_info = "icub battery system v1.0";
+    int                backpack_status = 0;
+    IBattery::Battery_status     battery_status = IBattery::Battery_status::BATTERY_OK_STANBY;
+
+    batteryReaderThread (ISerialDevice *_pSerial, double period) :
+    PeriodicThread((double)period),
+    pSerial(_pSerial)
+    {
+       //                         0   1   2   3   4   5   6   7   8    9
+       char c_exp[packet_len +5+ packet_len +1] =
+                               {'\0','.','.','.','.','.','.','.','\r','\n',
+                                 '(','?','!','.','*',
+                                '\0','.','.','.','.','.','.','.','\r','\n',
+                                 ')'};
+       r_exp=std::string(c_exp,26);
+    }
+
+    void startTransmission();
+    void stopTransmission();
+    virtual bool threadInit() override;
+    virtual void threadRelease() override;
+    virtual void run() override;
+};
+
+class BcbBattery: public yarp::dev::IBattery, public DeviceDriver
 {
 protected:
-    std::mutex mtx;
-
-    double             timeStamp;
-    double             battery_charge;
-    double             battery_voltage;
-    double             battery_current;
-    std::string        battery_info;
-    unsigned char      backpack_status;
-
-    bool verboseEnable;
-    bool screenEnable;
-    bool silenceSyncWarnings;
+    batteryReaderThread* batteryReader =nullptr;
 
     ResourceFinder      rf;
     PolyDriver          driver;
-    ISerialDevice       *pSerial;
-    char                serial_buff[255];
-
-    std::atomic<bool> isClosing;
+    ISerialDevice       *pSerial = nullptr;
 
 public:
-    BcbBattery(int period = 20) : PeriodicThread((double)period/1000.0)
-    {}
-
-    ~BcbBattery()
-    {
-    }
+    BcbBattery()  {}
+    ~BcbBattery()  {}
 
     virtual bool open(yarp::os::Searchable& config);
     virtual bool close();
 
-    virtual bool getBatteryVoltage     (double &voltage);
-    virtual bool getBatteryCurrent     (double &current);
-    virtual bool getBatteryCharge      (double &charge);
-    virtual bool getBatteryStatus      (Battery_status &status);
-    virtual bool getBatteryInfo        (std::string &info);
-    virtual bool getBatteryTemperature (double &temperature);
-
-    virtual bool threadInit();
-    virtual void threadRelease();
-    virtual void run();
+    virtual bool getBatteryVoltage     (double &voltage) override;
+    virtual bool getBatteryCurrent     (double &current) override;
+    virtual bool getBatteryCharge      (double &charge) override;
+    virtual bool getBatteryStatus      (Battery_status &status) override;
+    virtual bool getBatteryInfo        (std::string &info) override;
+    virtual bool getBatteryTemperature (double &temperature) override;
 };
 
 

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.h
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.h
@@ -55,13 +55,9 @@ class batteryReaderThread : public PeriodicThread
        // \0........\r\n which is not followed by any other occurrence of the same pattern.
        // See for example: https://docs.pexip.com/admin/regex_reference.htm
        //
-       //                         0   1   2   3   4   5   6   7   8    9
-       char c_exp[packet_len +5+ packet_len +1] =
-                               {'\0','.','.','.','.','.','.','.','\r','\n',
-                                 '(','?','!','.','*',
-                                '\0','.','.','.','.','.','.','.','\r','\n',
-                                 ')'};
-       r_exp=std::string(c_exp,26);
+       //                    01234567  8  9*****  01234567  8  9
+       std::string c_exp ("\\0.......\\r\\n(?!.*\\0.......\\r\\n)");
+       r_exp=c_exp;
     }
 
     void startTransmission();

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.h
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.h
@@ -29,7 +29,6 @@ class batteryReaderThread : public PeriodicThread
     //configuration options
     bool               verboseEnable = false;
     bool               screenEnable = true;
-    bool               silenceSyncWarnings = false;
 
     //the buffer
     double             timeStamp;


### PR DESCRIPTION
Some changes to: https://github.com/robotology/icub-main/pull/727

Main changes and explanation:
I did some experiments and I noticed that the previous implementation was too much dependent on the thread period: a wrong value could cause severe misbehavior.
- If the thread period was too small, not enough characters were received in the internal buffer. So all the receiver_character() calls become blocking for the number of milliseconds specified in the configuration file (default = 5ms)
- If the thread period was too large, many packets (i.e. blocks of 10 bytes) were placed in the buffer, but the parsing function was just getting the first (old) one. I added a flush() to avoid that the buffer increases in size indefinitely, however, I still was not happy with the solution.

So: this is the logic of the new version:
On every run() cycle I copy all the content of the serial buffer to a local buffer and I search for the last (most recent) valid packet occurrence. This solution works as long as the thread period is at least twice the size of the duration of a packet (but I think that keeping it large, i.e. 500-1000ms is still a good idea)








