### PR TITLE
AMO diagnostics

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -34,8 +34,8 @@ message(STATUS "CMake modules directory: ${CMAKE_MODULE_PATH}")
 find_package(icub_firmware_shared QUIET)
 if(icub_firmware_shared_FOUND)
   # icub-firmware-shared 4.0.7 was actually a wrong version exported by icub-firmware-shared <= 1.15
-  if(icub_firmware_shared_VERSION VERSION_GREATER 4 OR icub_firmware_shared_VERSION VERSION_LESS 1.19.2)
-    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected, but at least 1.18.100 is required")
+  if(icub_firmware_shared_VERSION VERSION_GREATER 4 OR icub_firmware_shared_VERSION VERSION_LESS 1.20.1)
+    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected, but at least 1.20.1 is required")
   endif()
 endif()
 

--- a/src/libraries/icubmod/embObjLib/serviceParser.cpp
+++ b/src/libraries/icubmod/embObjLib/serviceParser.cpp
@@ -80,6 +80,23 @@ bool ServiceParser::convert(std::string const &fromstring, eOmn_serv_type_t& tos
 
 }
 
+bool ServiceParser::convert(std::string const &fromstring, eOmn_serv_diagn_mode_t &todiagnmode, bool &formaterror)
+{
+    const char *t = fromstring.c_str();
+
+    todiagnmode = eomn_string2servicediagnmode(t);
+
+    if(eOmn_serv_diagn_mode_UNKNOWN == todiagnmode)
+    {
+        yWarning() << "ServiceParser::convert():" << t << "is not a legal string for eOmn_serv_diagn_mode_t";
+        formaterror = true;
+        return false;
+    }
+
+    return true;
+}
+
+
 
 // bool ServiceParser::convert(std::string const &fromstring, eOmc_ctrlboard_t &controllerboard, bool &formaterror)
 // {
@@ -2510,6 +2527,11 @@ bool ServiceParser::check_motion(Searchable &config)
     Bottle b_PROPERTIES_JOINTMAPPING = Bottle(b_PROPERTIES.findGroup("JOINTMAPPING"));
     bool has_PROPERTIES_JOINTMAPPING = !b_PROPERTIES_JOINTMAPPING.isNull();
 
+    Bottle b_PROPERTIES_DIAGNOSTICS = Bottle(b_PROPERTIES.findGroup("DIAGNOSTICS"));
+    bool has_PROPERTIES_DIAGNOSTICS = !b_PROPERTIES_DIAGNOSTICS.isNull();
+
+
+
 
 
     bool itisoksofar = false;
@@ -3499,6 +3521,49 @@ bool ServiceParser::check_motion(Searchable &config)
         }
 
     } // has_PROPERTIES_JOINTMAPPING
+
+
+    // add default values. then we may change tem
+    mc_service.diagconfig.mode = eOmn_serv_diagn_mode_NONE;
+    mc_service.diagconfig.par16 = 0;
+
+    if(true == has_PROPERTIES_DIAGNOSTICS)
+    {
+        Bottle b_PROPERTIES_DIAGNOSTICS_mode = b_PROPERTIES_DIAGNOSTICS.findGroup("mode");
+        Bottle b_PROPERTIES_DIAGNOSTICS_par16 = b_PROPERTIES_DIAGNOSTICS.findGroup("par16");
+        if(!b_PROPERTIES_DIAGNOSTICS_mode.isNull() && !b_PROPERTIES_DIAGNOSTICS_par16.isNull())
+        {
+            // if we have both of them ... and they contain at least (only) one we get the values
+            int n_type = b_PROPERTIES_DIAGNOSTICS_mode.size() - 1;
+            int n_par16 = b_PROPERTIES_DIAGNOSTICS_par16.size() - 1;
+            if((1 == n_type) && (1 == n_par16))
+            {
+                eOmn_serv_diagn_mode_t dm = eOmn_serv_diagn_mode_NONE;
+                int par16 = 0;
+                if(false == convert(b_PROPERTIES_DIAGNOSTICS_mode.get(1).asString(), dm, formaterror))
+                {
+                    yWarning() << "ServiceParser::check_motion() has detected an illegal format for SERVICE.PROPERTIES.DIAGNOSTICS.mode. Using {eOmn_serv_diagn_mode_NONE, 0}";
+                }
+                else if(!b_PROPERTIES_DIAGNOSTICS_par16.get(1).isInt())
+                {
+                    yWarning() << "ServiceParser::check_motion() has detected an illegal format for SERVICE.PROPERTIES.DIAGNOSTICS.par16. Using {eOmn_serv_diagn_mode_NONE, 0}";
+                }
+                else
+                {
+                    par16 = b_PROPERTIES_DIAGNOSTICS_par16.get(1).asInt();
+                }
+
+                mc_service.diagconfig.mode = dm;
+                mc_service.diagconfig.par16 = static_cast<uint16_t>(par16);
+
+                yWarning() << "ServiceParser::check_motion() has detected some DIAGNOSTICS config for this MC service: mode = " << eomn_servicediagnmode2string(dm) << ", par16 = " << mc_service.diagconfig.par16;
+
+            }
+
+        }
+
+    } // has_PROPERTIES_DIAGNOSTICS
+
 
     return true;
 }

--- a/src/libraries/icubmod/embObjLib/serviceParser.cpp
+++ b/src/libraries/icubmod/embObjLib/serviceParser.cpp
@@ -3707,6 +3707,8 @@ bool ServiceParser::parseService(Searchable &config, servConfigMC_t &mcconfig)
     // ...
 
     mcconfig.ethservice.configuration.type = mc_service.type;
+    mcconfig.ethservice.configuration.diagnosticsmode = mc_service.diagconfig.mode;
+    mcconfig.ethservice.configuration.diagnosticsparam = mc_service.diagconfig.par16;
     
     switch(mc_service.type)
     {

--- a/src/libraries/icubmod/embObjLib/serviceParser.cpp
+++ b/src/libraries/icubmod/embObjLib/serviceParser.cpp
@@ -86,7 +86,7 @@ bool ServiceParser::convert(std::string const &fromstring, eOmn_serv_diagn_mode_
 
     todiagnmode = eomn_string2servicediagnmode(t);
 
-    if(eOmn_serv_diagn_mode_UNKNOWN == todiagnmode)
+    if(eomn_serv_diagn_mode_UNKNOWN == todiagnmode)
     {
         yWarning() << "ServiceParser::convert():" << t << "is not a legal string for eOmn_serv_diagn_mode_t";
         formaterror = true;
@@ -3524,7 +3524,7 @@ bool ServiceParser::check_motion(Searchable &config)
 
 
     // add default values. then we may change tem
-    mc_service.diagconfig.mode = eOmn_serv_diagn_mode_NONE;
+    mc_service.diagconfig.mode = eomn_serv_diagn_mode_NONE;
     mc_service.diagconfig.par16 = 0;
 
     if(true == has_PROPERTIES_DIAGNOSTICS)
@@ -3538,7 +3538,7 @@ bool ServiceParser::check_motion(Searchable &config)
             int n_par16 = b_PROPERTIES_DIAGNOSTICS_par16.size() - 1;
             if((1 == n_type) && (1 == n_par16))
             {
-                eOmn_serv_diagn_mode_t dm = eOmn_serv_diagn_mode_NONE;
+                eOmn_serv_diagn_mode_t dm = eomn_serv_diagn_mode_NONE;
                 int par16 = 0;
                 if(false == convert(b_PROPERTIES_DIAGNOSTICS_mode.get(1).asString(), dm, formaterror))
                 {

--- a/src/libraries/icubmod/embObjLib/serviceParser.h
+++ b/src/libraries/icubmod/embObjLib/serviceParser.h
@@ -238,6 +238,7 @@ typedef struct
 typedef struct
 {
     eOmn_serv_type_t            type;
+    eOmn_serv_diagn_cfg_t       diagconfig;
     servMCproperties_t          properties;
     servMCsettings_t            settings;
 } servMCcollector_t;
@@ -293,6 +294,7 @@ public:
 #endif
 
     bool convert(std::string const &fromstring, eOmn_serv_type_t &toservicetype, bool &formaterror);
+    bool convert(std::string const &fromstring, eOmn_serv_diagn_mode_t &todiagnmode, bool &formaterror);
     bool convert(std::string const &fromstring, eObrd_type_t& tobrdtype, bool& formaterror);
     bool convert(std::string const &fromstring, eObrd_cantype_t &tobrdcantype, bool &formaterror);
     bool convert(std::string const &fromstring, eObrd_ethtype_t& tobrdethtype, bool& formaterror);


### PR DESCRIPTION
## Description

This PR adds runtime configuration of additional diagnostics useful for debugging services on the robot. 

Runtime configuration means that yarprobotinterface collects some parameters from xml files and sends them to the ETH boards so that this one can use them to activate / tune some actions.

So far, only the AMO diagnostics in MC service is supported. 

## Details

See https://github.com/robotology/icub-firmware/pull/187

## Important

The CI test needs https://github.com/robotology/icub-firmware-shared/pull/48 to be merged first otherwise it will fail.