### PR TITLE
AMO data to YARP ports

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -34,7 +34,7 @@ message(STATUS "CMake modules directory: ${CMAKE_MODULE_PATH}")
 find_package(icub_firmware_shared QUIET)
 if(icub_firmware_shared_FOUND)
   # icub-firmware-shared 4.0.7 was actually a wrong version exported by icub-firmware-shared <= 1.15
-  if(icub_firmware_shared_VERSION VERSION_GREATER 4 OR icub_firmware_shared_VERSION VERSION_LESS 1.20.1)
+  if(icub_firmware_shared_VERSION VERSION_GREATER 4 OR icub_firmware_shared_VERSION VERSION_LESS 1.20.2)
     message(FATAL_ERROR "An old version of icub-firmware-shared has been detected, but at least 1.20.1 is required")
   endif()
 endif()

--- a/src/libraries/icubmod/embObjLib/hostTransceiver.cpp
+++ b/src/libraries/icubmod/embObjLib/hostTransceiver.cpp
@@ -834,6 +834,13 @@ void HostTransceiver::eoprot_override_mc(void)
             EO_INIT(.init)          NULL,
             EO_INIT(.update)        eoprot_fun_UPDT_mc_joint_status_core
         },
+        {   // joint_status_debug:
+            EO_INIT(.endpoint)      eoprot_endpoint_motioncontrol,
+            EO_INIT(.entity)        eoprot_entity_mc_joint,
+            EO_INIT(.tag)           eoprot_tag_mc_joint_status_debug,
+            EO_INIT(.init)          NULL,
+            EO_INIT(.update)        eoprot_fun_UPDT_mc_joint_status_debug
+        },
         {   // joint_status_basic: used to inform the motioncontrol device that a sig<> ROP about joint status has arrived. for .. updating the same timestamps as above
             EO_INIT(.endpoint)      eoprot_endpoint_motioncontrol,
             EO_INIT(.entity)        eoprot_entity_mc_joint,

--- a/src/libraries/icubmod/embObjLib/protocolCallbacks/EoProtocolMC_fun_userdef.c
+++ b/src/libraries/icubmod/embObjLib/protocolCallbacks/EoProtocolMC_fun_userdef.c
@@ -76,6 +76,10 @@ extern void eoprot_fun_UPDT_mc_joint_status_core(const EOnv* nv, const eOropdesc
     feat_manage_motioncontrol_data(eo_nv_GetIP(nv), rd->id32, (void *)rd->data);
 }
 
+extern void eoprot_fun_UPDT_mc_joint_status_debug(const EOnv* nv, const eOropdescriptor_t* rd)
+{
+    feat_manage_motioncontrol_data(eo_nv_GetIP(nv), rd->id32, (void *)rd->data);
+}
 
 extern void eoprot_fun_UPDT_mc_motor_status_basic(const EOnv* nv, const eOropdescriptor_t* rd)
 {

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -1508,16 +1508,22 @@ bool embObjMotionControl::update(eOprotID32_t id32, double timestamp, void *rxda
         if((eoprot_entity_mc_joint == ent) && (eoprot_tag_mc_joint_status_debug == tag) && (joint < mcdiagnostics.ports.size()))
         {
 
+            eOprotID32_t id32 = eoprot_ID_get(eoprot_endpoint_motioncontrol, eoprot_entity_mc_joint, joint, eoprot_tag_mc_joint_status_core);
+            eOmc_joint_status_core_t  jcore = {};
+
+            res->getLocalValue(id32, &jcore);
+
             int32_t *debug32 = reinterpret_cast<int32_t*>(rxdata);
             // write into relevant port
 
             Bottle& output = mcdiagnostics.ports[joint]->prepare();
             output.clear();
-            //output.addString("[yt, amo, reg, pos, pwm, cur]"); // but we must get the joint and the motor as well
-            output.addString("[yt, amo, reg]");
+            //output.addString("[yt, amo, reg, pos]"); // but we must get the joint and the motor as well
+            output.addString("[yt, amo, reg, pos]");
             output.addDouble(timestamp);
             output.addInt32(debug32[0]);
             output.addInt32(debug32[1]);
+            output.addInt32(jcore.measures.meas_position);
             mcdiagnostics.ports[joint]->write();
         }
     }

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -34,6 +34,7 @@ using namespace std;
 #include <mutex>
 //  Yarp stuff
 #include <yarp/os/Bottle.h>
+#include <yarp/os/BufferedPort.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/ControlBoardHelper.h>
@@ -109,6 +110,11 @@ namespace yarp {
 }
 
 
+struct MCdiagnostics
+{
+    eOmn_serv_diagn_cfg_t config;
+    std::vector<BufferedPort<Bottle>*> ports;
+};
 
 using namespace yarp::dev;
 
@@ -184,6 +190,9 @@ private:
     std::mutex                 _mutex;
     
     bool opened; //internal state
+
+    MCdiagnostics mcdiagnostics;
+
 
 
      /////configuartion info (read from xml files)


### PR DESCRIPTION
## Description
This PR belongs to a set of PRs which enable to stream AMO data towards YARP ports.

See robotology/icub-firmware#188 for details.

## Requirements of this PR

To enable the features of this PR we also need similar PRs. They are:
- in [`icub-firmware-shared`](https://github.com/robotology/icub-firmware-shared/pull/49) which contains the data structures,
-  in  [`icub-firmware`](https://github.com/robotology/icub-firmware/pull/188) we have the code for the ETH boards
- in [`icub-main`](https://github.com/robotology/icub-main/pull/753) which contains code to publish on the YARP port.
- in [`icub-firmware-build`](https://github.com/robotology/icub-firmware-build/pull/30) to give the new binaries for the `ems`, `mc4plus`, `mc2plus`.