### PR TITLE
Remove references to deprecated YARP interfaces

### DIFF
--- a/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.cpp
+++ b/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.cpp
@@ -2993,8 +2993,8 @@ bool CanBusMotionControl::close (void)
 
         PeriodicThread::stop ();/// stops the thread first (joins too).
 
-        ImplementPositionControl2::uninitialize();
-        ImplementVelocityControl2::uninitialize();
+        ImplementPositionControl::uninitialize();
+        ImplementVelocityControl::uninitialize();
 
 //        ImplementPositionControl<CanBusMotionControl, IPositionControl>::uninitialize ();
 //        ImplementVelocityControl<CanBusMotionControl, IVelocityControl>::uninitialize();
@@ -3006,7 +3006,7 @@ bool CanBusMotionControl::close (void)
         ImplementAmplifierControl::uninitialize();
         ImplementControlLimits::uninitialize();
 
-        ImplementControlMode2::uninitialize();
+        ImplementControlMode::uninitialize();
         ImplementTorqueControl::uninitialize();
         ImplementImpedanceControl::uninitialize();
         ImplementPositionDirect::uninitialize();

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -1348,10 +1348,10 @@ bool embObjMotionControl::close()
 {
     yTrace() << " embObjMotionControl::close()";
 
-    ImplementControlMode2::uninitialize();
+    ImplementControlMode::uninitialize();
     ImplementEncodersTimed::uninitialize();
     ImplementMotorEncoders::uninitialize();
-    ImplementPositionControl2::uninitialize();
+    ImplementPositionControl::uninitialize();
     ImplementVelocityControl::uninitialize();
     ImplementPidControl::uninitialize();
     ImplementControlCalibration::uninitialize();

--- a/src/simulators/iCubSimulation/wrapper/iCubSimulationControl.cpp
+++ b/src/simulators/iCubSimulation/wrapper/iCubSimulationControl.cpp
@@ -303,8 +303,8 @@ bool iCubSimulationControl::open(yarp::os::Searchable& config) {
         interactionMode[axis] = VOCAB_IM_STIFF;
    }
 
-    ImplementPositionControl2::initialize(njoints, axisMap, angleToEncoder, zeros);
-    ImplementVelocityControl2::initialize(njoints, axisMap, angleToEncoder, zeros);
+    ImplementPositionControl::initialize(njoints, axisMap, angleToEncoder, zeros);
+    ImplementVelocityControl::initialize(njoints, axisMap, angleToEncoder, zeros);
     ImplementPidControl::initialize(njoints, axisMap, angleToEncoder, zeros,newtonsToSensor,ampsToSensor, dutycycleToPwm);
     ImplementEncodersTimed::initialize(njoints, axisMap, angleToEncoder, zeros);
     ImplementMotorEncoders::initialize(njoints, axisMap, angleToEncoder, zeros);
@@ -312,7 +312,7 @@ bool iCubSimulationControl::open(yarp::os::Searchable& config) {
     ImplementAmplifierControl::initialize(njoints, axisMap, angleToEncoder, zeros);
     ImplementControlLimits::initialize(njoints, axisMap, angleToEncoder, zeros);
     ImplementTorqueControl::initialize(njoints, axisMap, angleToEncoder, zeros, newtonsToSensor, ampsToSensor, dutycycleToPwm,nullptr,nullptr);
-    ImplementControlMode2::initialize(njoints, axisMap);
+    ImplementControlMode::initialize(njoints, axisMap);
     ImplementInteractionMode::initialize(njoints, axisMap);
     ImplementPositionDirect::initialize(njoints, axisMap, angleToEncoder, zeros);
     ImplementRemoteVariables::initialize(njoints, axisMap);


### PR DESCRIPTION
`ImplementPositionControl2`, `ImplementVelocityControl2` were deprecated in YARP 3.0 (see https://github.com/robotology/yarp/blob/v3.0.0/doc/release/v3_0_0.md#yarp_dev). At some point there was a cleanup (in https://github.com/robotology/icub-main/pull/538 and probably other PRs) but some uses were still missing. This PR removes the remaining uses, and ensure that icub-main compiles fine with the upcoming YARP 3.5 .

Fix part of https://github.com/robotology/robotology-superbuild/issues/794 .