### PR TITLE
CanBusMotionControl: corrected compilation warnings + potential bugs

### DIFF
--- a/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.cpp
+++ b/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.cpp
@@ -3583,9 +3583,11 @@ void CanBusMotionControl:: run()
 
             int j=0;
             /// reports board errors
-            char tmp[255];
-            char message[255];
-            sprintf(message, "%s [%d] printing boards infos:\n", canDevName.c_str(), r._networkN);
+            std::string stringmessage {};
+            char tmp[255] = {0};
+
+            snprintf(tmp, sizeof(tmp), "%s [%d] printing boards infos:\n", canDevName.c_str(), r._networkN);
+            stringmessage += std::string(tmp);
 
             bool errorF=false;
             for (j=0; j<r._njoints ;j++)
@@ -3610,8 +3612,9 @@ void CanBusMotionControl:: run()
                     if ( (r._bcastRecvBuffer[j]._canTxError>0)||(r._bcastRecvBuffer[j]._canRxError>0))
                         {
                             errorF=true;
-                            sprintf(tmp, "Id:%d T:%u R:%u ", addr, r._bcastRecvBuffer[j]._canTxError, r._bcastRecvBuffer[j]._canRxError);
-                            sprintf(message, "%s%s", message, tmp);
+                            snprintf(tmp, sizeof(tmp), "Id:%d T:%u R:%u ", addr, r._bcastRecvBuffer[j]._canTxError, r._bcastRecvBuffer[j]._canRxError);
+                            stringmessage += std::string(tmp);
+
 
                             logJointData(canDevName.c_str(),r._networkN,j,14,yarp::os::Value((int)r._bcastRecvBuffer[j]._canTxError));
                             logJointData(canDevName.c_str(),r._networkN,j,15,yarp::os::Value((int)r._bcastRecvBuffer[j]._canRxError));
@@ -3624,11 +3627,11 @@ void CanBusMotionControl:: run()
                 }
             if (!errorF)
                 {
-                    sprintf(tmp, "None");
-                    sprintf(message, "%s%s", message, tmp);
+                    snprintf(tmp, sizeof(tmp), "None");
+                    stringmessage += std::string(tmp);
                 }
 
-            yDebug("%s\n", message);
+            yDebug("%s\n", stringmessage.c_str());
 
             //Check statistics on boards
             for (j=0; j<r._njoints ;j++)
@@ -3899,7 +3902,7 @@ int CanBusMotionControl::from_interactionint_to_interactionvocab (unsigned char 
 }
 
 
-unsigned char CanBusMotionControl::from_modevocab_to_modeint (int modevocab)
+icubCanProto_controlmode_t CanBusMotionControl::from_modevocab_to_modeint (int modevocab)
 {
     switch (modevocab)
     {
@@ -3931,16 +3934,16 @@ unsigned char CanBusMotionControl::from_modevocab_to_modeint (int modevocab)
         return  icubCanProto_controlmode_openloop;
         break;
     case VOCAB_CM_CURRENT:
-        return  VOCAB_CM_UNKNOWN;
+        return  icubCanProto_controlmode_unknownError;
         yError("'VOCAB_CM_CURRENT' error condition detected");
         break;
 
-    case VOCAB_CM_FORCE_IDLE: 
+    case VOCAB_CM_FORCE_IDLE:
         return icubCanProto_controlmode_forceIdle;
         break;
 
     default:
-        return VOCAB_CM_UNKNOWN;
+        return icubCanProto_controlmode_unknownError;
         yError ("'VOCAB_CM_UNKNOWN' error condition detected");
         break;
     }
@@ -4060,8 +4063,8 @@ bool CanBusMotionControl::setControlModeRaw(const int j, const int mode)
     DEBUG_FUNC("Calling SET_CONTROL_MODE_RAW SINGLE JOINT\n");
     bool ret = true;
 
-    int v = from_modevocab_to_modeint(mode);
-    if (v==VOCAB_CM_UNKNOWN) return false;
+    icubCanProto_controlmode_t v = from_modevocab_to_modeint(mode);
+    if (v==icubCanProto_controlmode_unknownError) return false;
     _writeByte8(ICUBCANPROTO_POL_MC_CMD__SET_CONTROL_MODE,j,v);
 
     int current_mode = VOCAB_CM_UNKNOWN;
@@ -4101,8 +4104,8 @@ bool CanBusMotionControl::setControlModesRaw(const int n_joints, const int *join
     {
         if (modes[i] == VOCAB_CM_TORQUE && _MCtorqueControlEnabled == false) {yError()<<"Torque control is disabled. Check your configuration parameters"; continue;}
 
-        int v = from_modevocab_to_modeint(modes[i]);
-        if (v==VOCAB_CM_UNKNOWN) ret = false;
+        icubCanProto_controlmode_t v = from_modevocab_to_modeint(modes[i]);
+        if (v==icubCanProto_controlmode_unknownError) ret = false;
         _writeByte8(ICUBCANPROTO_POL_MC_CMD__SET_CONTROL_MODE,joints[i],v);
 
         int current_mode = VOCAB_CM_UNKNOWN;
@@ -4231,8 +4234,8 @@ bool CanBusMotionControl::setControlModesRaw(int *modes)
     {
         if (modes[i] == VOCAB_CM_TORQUE && _MCtorqueControlEnabled == false) {yError()<<"Torque control is disabled. Check your configuration parameters"; continue;}
 
-        int v = from_modevocab_to_modeint(modes[i]);
-        if (v==VOCAB_CM_UNKNOWN) return false;
+        icubCanProto_controlmode_t v = from_modevocab_to_modeint(modes[i]);
+        if (v==icubCanProto_controlmode_unknownError) return false;
         _writeByte8(ICUBCANPROTO_POL_MC_CMD__SET_CONTROL_MODE,i,v);
 
         int current_mode = VOCAB_CM_UNKNOWN;

--- a/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.cpp
+++ b/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.cpp
@@ -3456,6 +3456,7 @@ bool CanBusMotionControl::threadInit()
 
     r._error_status = true;
 
+    errorstring.reserve(errorstringsize);
     previousRun=0;
     averagePeriod=0;
     averageThreadTime=0;
@@ -3583,11 +3584,11 @@ void CanBusMotionControl:: run()
 
             int j=0;
             /// reports board errors
-            std::string stringmessage {};
             char tmp[255] = {0};
+            errorstring.clear();
 
             snprintf(tmp, sizeof(tmp), "%s [%d] printing boards infos:\n", canDevName.c_str(), r._networkN);
-            stringmessage += std::string(tmp);
+            errorstring.append(tmp);
 
             bool errorF=false;
             for (j=0; j<r._njoints ;j++)
@@ -3613,7 +3614,7 @@ void CanBusMotionControl:: run()
                         {
                             errorF=true;
                             snprintf(tmp, sizeof(tmp), "Id:%d T:%u R:%u ", addr, r._bcastRecvBuffer[j]._canTxError, r._bcastRecvBuffer[j]._canRxError);
-                            stringmessage += std::string(tmp);
+                            errorstring.append(tmp);
 
 
                             logJointData(canDevName.c_str(),r._networkN,j,14,yarp::os::Value((int)r._bcastRecvBuffer[j]._canTxError));
@@ -3628,10 +3629,10 @@ void CanBusMotionControl:: run()
             if (!errorF)
                 {
                     snprintf(tmp, sizeof(tmp), "None");
-                    stringmessage += std::string(tmp);
+                    errorstring.append(tmp);
                 }
 
-            yDebug("%s\n", stringmessage.c_str());
+            yDebug("%s\n", errorstring.c_str());
 
             //Check statistics on boards
             for (j=0; j<r._njoints ;j++)

--- a/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.h
+++ b/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.h
@@ -1158,7 +1158,7 @@ protected:
     speedEstimationHelper *_speedEstimationHelper;
     axisPositionDirectHelper  *_axisPositionDirectHelper;
 
-    inline unsigned char from_modevocab_to_modeint (int modevocab);
+    inline icubCanProto_controlmode_t from_modevocab_to_modeint (int modevocab);
     inline int from_modeint_to_modevocab (unsigned char modeint);
     inline unsigned char from_interactionvocab_to_interactionint (int interactionvocab);
     inline int from_interactionint_to_interactionvocab (unsigned char interactionint);

--- a/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.h
+++ b/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.h
@@ -739,6 +739,8 @@ private:
     os::Stamp stampEncoders;
 
     char _buff[256];
+    std::string errorstring;
+    static constexpr size_t errorstringsize = 512;
 
     std::list<TBR_AnalogSensor *> analogSensors;
 


### PR DESCRIPTION

## Purpose of the PR
This PR addresses what in issue https://github.com/robotology/icub-main/issues/754 and fixes:
- compilation warnings
- potential bugs
  - `CanBusMotionControl::setControlModeRaw()` and similar methods did not return false when they receive an invalid control mode.
  - in some c-string manipulation there was the danger to write out of memory in case the string is very long.

## Details of the changes

There are two changes:
- fix of the behaviour / use of function `CanBusMotionControl::from_modevocab_to_modeint()` used inside `::setControlModeRaw()` to transform a `yarp::conf::vocab32_t` into a `icubCanProto_controlmode_t`.
- fix of the creation of a string to be printed with yDebug() inside method `void CanBusMotionControl::run()` 

In the first case, the return value of `from_modevocab_to_modeint()` was compared vs `VOCAB_CM_UNKNOWN` which was never returned because the function truncated its value (the warning was just saying that).
Solved by returning `icubCanProto_controlmode_unknownError` instead.

In the second case, some `sprintf()` did not have check vs writing out of memory in the case of particularly long strings. Solved by using a `std::string` which gets the memory it needs.


## Tests
The changes are trivial and for this reason I did not test them on the robot. 