### PR TITLE
deadlock fix

### DIFF
--- a/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.h
+++ b/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.h
@@ -1116,7 +1116,7 @@ protected:
 
 protected:
     void *system_resources;
-    std::mutex _mutex;
+    std::recursive_mutex _mutex;
     ICanBus *canController;
 
     bool _writerequested;


### PR DESCRIPTION
Fixed a deadlock issue caused by a non-recursive mutex used by recursive function calls.

The bug was affecting several multi-joint methods, e.g. `getControlModesRaw(const int n_joints, const int *joints, int *modes)`. If those methods are called once, the robot gets frozen.

The `std::mutex` has been changed to `std::rescursive_mutex`.
