### PR TITLE
Add message downsampler to avoid logger flooding when changing control mode

### DIFF
--- a/src/libraries/icubmod/embObjLib/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjLib/CMakeLists.txt
@@ -40,7 +40,8 @@ set(EXTRA_SOURCE            ${CMAKE_CURRENT_SOURCE_DIR}/hostTransceiver.cpp
                             ${CMAKE_CURRENT_SOURCE_DIR}/serviceParser.cpp
                             ${CMAKE_CURRENT_SOURCE_DIR}/theNVmanager.cpp
                             ${CMAKE_CURRENT_SOURCE_DIR}/embObjGeneralDevPrivData.cpp
-                            )
+                            ${CMAKE_CURRENT_SOURCE_DIR}/mcEventDownsampler.cpp)
+                            
 set(NVS_CBK_SOURCE  ${CMAKE_CURRENT_SOURCE_DIR}/protocolCallbacks/EoProtocolMN_fun_userdef.c
                     ${CMAKE_CURRENT_SOURCE_DIR}/protocolCallbacks/EoProtocolMC_fun_userdef.c
                     ${CMAKE_CURRENT_SOURCE_DIR}/protocolCallbacks/EoProtocolAS_fun_userdef.c
@@ -99,4 +100,3 @@ icub_export_library(${PROJECT_NAME})
 endif(NOT ICUB_HAS_icub_firmware_shared)
 
 endif(ICUB_COMPILE_EMBOBJ_LIBRARY)
-

--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.cpp
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.cpp
@@ -6,6 +6,10 @@
 
 namespace mced {
     
+
+    YARP_LOG_COMPONENT(MC_EVENT_DOWNSAMPLER, "mc.downsampler")
+
+
     mcEventDownsampler::mcEventDownsampler() 
     {
         mutex = new std::mutex();
@@ -99,7 +103,7 @@ namespace mced {
 
     void mcEventDownsampler::printreport()
     {
-        yError() <<  "Detected " << (counter - latch_2) << " events on aggregate since the last message";
+        yCError(MC_EVENT_DOWNSAMPLER) <<  "Detected " << counter - latch_2 << " events on aggregate since the last message";
     }
             
 } // mced

--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.cpp
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.cpp
@@ -7,7 +7,7 @@
 namespace mced {
     
 
-    YARP_LOG_COMPONENT(MC_EVENT_DOWNSAMPLER, "mc.downsampler")
+    YARP_LOG_COMPONENT(MC_EVENT_DOWNSAMPLER, "mc.msgdownsampler.skipped-cmd-wrong-mode")
 
 
     mcEventDownsampler::mcEventDownsampler() 

--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.cpp
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.cpp
@@ -1,0 +1,116 @@
+// --------------------------------------------------------------------------------------------------------------------
+// - public interface
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "mcEventDownsampler.h"
+
+namespace mced {
+    
+    
+    mcEventDownsampler::mcEventDownsampler() 
+    {
+        // mutex ctor   
+    };
+    
+    mcEventDownsampler::~mcEventDownsampler()
+    {
+        
+        stop();
+        
+        if(nullptr != timer)
+        {
+            delete timer;
+            timer = nullptr;
+        }
+        // idem per le altre cose    
+        
+        // mutex dtor       
+    }
+    
+    bool mcEventDownsampler::canprint()
+    {
+        // mutex->lock(?);
+        // activate something.
+        counter++;
+        // boh
+        
+        bool cp = !isdownsampling;
+        // mutex->unlock();
+        
+        return cp;
+    }
+    
+    bool mcEventDownsampler::stop()
+    {
+        // controlli su valore di timer non null, se e'attivo etc....
+        
+        timer->stop();
+        return true;
+    }
+    
+    bool mcEventDownsampler::start(const Config &config)
+    {
+        if(nullptr != timer)
+        {
+            stop(); 
+            // delete timer
+        }
+        
+        yarp::os::TimerSettings ts(0.1);
+        timer = new yarp::os::Timer(ts, &mcEventDownsampler::step, this, true);
+
+
+        timer->start();
+        // decidere dove costruire mutex. di sicuro deve essere costruito prima di timer
+        // meglio nel ctor
+        // construct timer etc
+        
+        // assegnare step() come callback al timer ....
+        
+        return true;
+    }
+    
+    bool mcEventDownsampler::step(const yarp::os::YarpTimerEvent &event)
+    {
+        // qui dentro, deve esserci la logica della fsm e ci deve essere accesso ai dati privati della class Ticker
+        // mutex->lock(?);        
+        //fsmstep(fsm);
+        
+
+        if (counter < 5)
+            isdownsampling = false;
+        
+        if (counter >= 5 && !isdownsampling)
+            isdownsampling = true;
+
+        if (isdownsampling)
+        {
+            if (print_countdown > 0)
+            {
+                print_countdown--;
+            }
+            else
+            {
+                printreport();
+                print_countdown = 10;
+                counter = 0;
+            }
+        }
+
+        // genera ....
+        
+        // mutex->unlock();
+        return true;
+    }
+
+    void mcEventDownsampler::printreport()
+    {
+        yError() <<  "Detected " << counter << " events on aggregate since the last message";
+    }
+    
+    void mcEventDownsampler::fsmstep(void *fsm) {}
+        
+} // xxx
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
@@ -24,7 +24,7 @@ namespace mced {
          */
         struct Config
         {
-            double period {0};
+            double period {0.};
             Config() = default;
             constexpr Config(double c) : period(c) {} 
             bool isvalid() const { return 0 != period; }

--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
@@ -4,8 +4,6 @@
 #ifndef __TICKER_H_
 #define __TICKER_H_
 
-//#include <stdio.h>
-
 #include <string>
 #include <mutex>
 
@@ -13,7 +11,7 @@
 #include <stdint.h>
 #include <yarp/os/Timer.h>
 #include <yarp/os/Time.h>
-#include <yarp/os/all.h>
+#include <yarp/os/LogStream.h>
 
 namespace mced {
     

--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
@@ -20,9 +20,7 @@ namespace mced {
     class mcEventDownsampler
     {
     public:
-        
-        // enum class Message { tbd }; 
-        
+
         struct Config
         {
             double period {0};    // time between two ticks
@@ -39,24 +37,17 @@ namespace mced {
         Config config = 0.1;
         
     private: 
-        bool step(const yarp::os::YarpTimerEvent &event); // signature di yarp
+        bool step(const yarp::os::YarpTimerEvent &event); 
         void printreport();
         yarp::os::Timer* timer {nullptr};    
         double expire_time;
-        // varie
         bool isdownsampling {false};
         size_t counter {0};  // size_t should be enough for the next 5 billion years
         size_t latch_1{0};
         size_t latch_2{0};
-        size_t count_out{0};
-        // protezione
         std::mutex *mutex {nullptr};
-        void *fsm {nullptr};
-        void fsmstep(void *fsm);  
     };
     
-} // xxx
+} // mced
 
 #endif  // include-guard
-
-// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
@@ -1,0 +1,60 @@
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef __TICKER_H_
+#define __TICKER_H_
+
+//#include <stdio.h>
+
+#include <string>
+#include <mutex>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <yarp/os/Timer.h>
+#include <yarp/os/all.h>
+
+namespace mced {
+    
+    class mcEventDownsampler
+    {
+    public:
+        
+        // enum class Message { tbd }; 
+        
+        struct Config
+        {
+            double period {0};    // time between two ticks
+ 
+            Config() = default;
+            constexpr Config(double c) : period(c) {} 
+            bool isvalid() const { return 0 != period; }
+        };
+      
+        mcEventDownsampler();
+        ~mcEventDownsampler();            
+        bool start(const Config &config);              
+        bool stop(); 
+        bool canprint();
+        Config config = 0.1;
+        
+    private: 
+        bool step(const yarp::os::YarpTimerEvent &event); // signature di yarp
+        void printreport();
+        yarp::os::Timer* timer {nullptr};    
+
+        // varie
+        bool isdownsampling {false};
+        size_t counter {0};  
+        size_t print_countdown{10};
+        // protezione
+        void *mutex {nullptr};
+        void *fsm {nullptr};
+        void fsmstep(void *fsm);  
+    };
+    
+} // xxx
+
+#endif  // include-guard
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
@@ -12,6 +12,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <yarp/os/Timer.h>
+#include <yarp/os/Time.h>
 #include <yarp/os/all.h>
 
 namespace mced {
@@ -25,7 +26,6 @@ namespace mced {
         struct Config
         {
             double period {0};    // time between two ticks
- 
             Config() = default;
             constexpr Config(double c) : period(c) {} 
             bool isvalid() const { return 0 != period; }
@@ -42,13 +42,15 @@ namespace mced {
         bool step(const yarp::os::YarpTimerEvent &event); // signature di yarp
         void printreport();
         yarp::os::Timer* timer {nullptr};    
-
+        double expire_time;
         // varie
         bool isdownsampling {false};
-        size_t counter {0};  
-        size_t print_countdown{10};
+        size_t counter {0};  // size_t should be enough for the next 5 billion years
+        size_t latch_1{0};
+        size_t latch_2{0};
+        size_t count_out{0};
         // protezione
-        void *mutex {nullptr};
+        std::mutex *mutex {nullptr};
         void *fsm {nullptr};
         void fsmstep(void *fsm);  
     };

--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
@@ -27,7 +27,7 @@ namespace mced {
             double period {0.};
             Config() = default;
             constexpr Config(double c) : period(c) {} 
-            bool isvalid() const { return 0 != period; }
+            bool isvalid() const { return 0. != period; }
         };
       
         /**

--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
@@ -10,9 +10,10 @@
 #include <yarp/os/Timer.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/LogStream.h>
+#include <yarp/os/LogComponent.h>
 
 namespace mced {
-    
+
     class mcEventDownsampler
     {
     public:

--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
@@ -1,8 +1,6 @@
 
-// - include guard ----------------------------------------------------------------------------------------------------
-
-#ifndef __TICKER_H_
-#define __TICKER_H_
+#ifndef __EVENT_DOWNSAMPLER_H_
+#define __EVENT_DOWNSAMPLER_H_
 
 #include <string>
 #include <mutex>
@@ -19,33 +17,93 @@ namespace mced {
     {
     public:
 
+        /**
+         * @brief Contains the configurable parameters of the event downsampler
+         * @var Config::period the period of the timer
+         */
         struct Config
         {
-            double period {0};    // time between two ticks
+            double period {0};
             Config() = default;
             constexpr Config(double c) : period(c) {} 
             bool isvalid() const { return 0 != period; }
         };
       
+        /**
+         * @brief Construct a new Event Downsampler object and instantiates the mutex
+         *        needed by the timer
+         */
         mcEventDownsampler();
-        ~mcEventDownsampler();            
-        bool start(const Config &config);              
-        bool stop(); 
+
+        /**
+         * @brief Destroy the Event Downsampler object. It stops the timer then deletes it.
+         * 
+         */
+        ~mcEventDownsampler();      
+
+        /**
+         * @brief Instantiates the yarp::os::Timer object and starts it.
+         * @param config Structure containing the configuration parameters of the Event Downsampler
+         * @return true if the instantiation was successful, false otherwise.
+         */
+        bool start(const Config &config);   
+
+        /**
+         * @brief Stops the timer
+         * @return true if the operation was successful, false otherwise.
+         */
+        bool stop();
+
+        /**
+         * @brief Called by the object that implements the downsampler. Compares the difference between
+         *        counter and latch_1 is and the threshold.
+         * @return true if the difference is lower or equal to the threshold, false if it is higher. 
+         */
         bool canprint();
         Config config = 0.1;
         
     private: 
+        /**
+         * @brief Callback function called by the timer at each tick. Implements the downsampling logic:
+         *        the downsampling is activated if the number of events exceed a threshold, and a report
+         *        showing the number of events since the last report is printed.
+         *        The mutex is locked before entering the function, and unlocked right after returning.
+         *        
+         * @param event Structure containing data regarding the callback.
+         * @return true 
+         */
         bool step(const yarp::os::YarpTimerEvent &event); 
+
+        /**
+         * @brief Prints an error message in the logger with a cumulative number of events occurred since the
+         *        last call.
+         */
         void printreport();
-        yarp::os::Timer* timer {nullptr};    
+
+        /** @brief Pointer to the timer object. */
+        yarp::os::Timer* timer {nullptr};
+
+        /**  @brief Number of seconds since epoch. Used to check when one second has elapsed. */
         double expire_time;
+        
+        /**  @brief Indicates when the downsampling is active. It is set to true when the number of events
+         * exceeds a threshold
+         */
         bool isdownsampling {false};
-        size_t counter {0};  // size_t should be enough for the next 5 billion years
+
+        /**  @brief Events counter. size_t should be enough for the next 5 billion years. */
+        size_t counter {0};
+
+        /**  @brief Support variable used to evaluate the difference with the counter. */
         size_t latch_1{0};
+
+        /**  @brief Support variable used to evaluate the difference with the counter. */
         size_t latch_2{0};
+
+        /**  @brief Mutex needed by the timer. */
         std::mutex *mutex {nullptr};
     };
     
 } // mced
 
-#endif  // include-guard
+#endif  // __EVENT_DOWNSAMPLER_H_

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -212,8 +212,9 @@ embObjMotionControl::embObjMotionControl() :
     _impedance_params(0),
     _axesInfo(0),
     _jointEncs(0),
-    _motorEncs(0)
-{
+    _motorEncs(0),
+    timer_count(0)
+    {
     _gearbox_M2J  = 0;
     _gearbox_E2J  = 0;
     _deadzone     = 0;
@@ -399,6 +400,12 @@ bool embObjMotionControl::open(yarp::os::Searchable &config)
         }
     }
 
+    // Initialize the downsampler timer
+    yarp::os::TimerSettings downsampler_timer_data(1);
+    yarp::os::YarpTimerEvent downsampler_timer_event;
+    tm = new yarp::os::Timer(downsampler_timer_data, &embObjMotionControl::downsamplerCallback, this, true);
+
+    tm->start();
 
     if(false == res->serviceVerifyActivate(eomn_serv_category_mc, servparam))
     {
@@ -5233,6 +5240,13 @@ bool embObjMotionControl::getMotorEncTolerance(int axis, double *mEncTolerance_p
         return false;
     }
     *mEncTolerance_ptr = motorCfg.rotEncTolerance;
+    return true;
+}
+
+bool embObjMotionControl::downsamplerCallback(const yarp::os::YarpTimerEvent& event)
+{
+    timer_count++;
+    yInfo() << "This is the downsampler debug print n. " << timer_count;
     return true;
 }
 

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -402,7 +402,7 @@ bool embObjMotionControl::open(yarp::os::Searchable &config)
     // Initialize the downsampler timer
     
     event_downsampler = new mced::mcEventDownsampler();
-    event_downsampler->config.period = 0.1;
+    event_downsampler->config.period = 0.01;
     event_downsampler->start(event_downsampler->config);
 
     if(false == res->serviceVerifyActivate(eomn_serv_category_mc, servparam))
@@ -1899,7 +1899,10 @@ bool embObjMotionControl::velocityMoveRaw(int j, double sp)
         (mode != VOCAB_CM_IMPEDANCE_VEL) &&
         (mode != VOCAB_CM_IDLE))
     {
-        yError() << "velocityMoveRaw: skipping command because " << getBoardInfo() << " joint " << j << " is not in VOCAB_CM_VELOCITY mode";
+        if(event_downsampler->canprint())
+        {
+            yError() << "velocityMoveRaw: skipping command because " << getBoardInfo() << " joint " << j << " is not in VOCAB_CM_VELOCITY mode";
+        }
         return true;
     }
 
@@ -4111,7 +4114,10 @@ bool embObjMotionControl::setPositionRaw(int j, double ref)
     if (mode != VOCAB_CM_POSITION_DIRECT &&
         mode != VOCAB_CM_IDLE)
     {
-        yError() << "setReferenceRaw: skipping command because" << getBoardInfo() << " joint " << j << " is not in VOCAB_CM_POSITION_DIRECT mode";
+        if(event_downsampler->canprint())
+        {
+            yError() << "setReferenceRaw: skipping command because" << getBoardInfo() << " joint " << j << " is not in VOCAB_CM_POSITION_DIRECT mode";
+        }
         return true;
     }
 

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -261,7 +261,7 @@ private:
     double  *_ref_accs;         // for velocity control, in position min jerk eq is used.
     double  *_encodersStamp;                    /** keep information about acquisition time for encoders read */
     bool  *checking_motiondone;                 /* flag telling if I'm already waiting for motion done */
-    #define MAX_POSITION_MOVE_INTERVAL 0.0001
+    #define MAX_POSITION_MOVE_INTERVAL 0.080
     double *_last_position_move_time;           /** time stamp for last received position move command*/    
     eOmc_impedance_t *_cacheImpedance;    /* cache impedance value to split up the 2 sets */
     

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -35,6 +35,7 @@ using namespace std;
 //  Yarp stuff
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
+#include <yarp/os/Timer.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/ControlBoardHelper.h>
@@ -177,7 +178,7 @@ class yarp::dev::embObjMotionControl:   public DeviceDriver,
     public ICurrentControlRaw,
     public ImplementCurrentControl,
     public eth::IethResource
-{
+    {
 
 
 private:
@@ -260,7 +261,9 @@ private:
     double *_last_position_move_time;           /** time stamp for last received position move command*/    
     eOmc_impedance_t *_cacheImpedance;    /* cache impedance value to split up the 2 sets */
     
-
+    // downsampler timer
+    yarp::os::Timer* tm;
+    int timer_count;
 #ifdef NETWORK_PERFORMANCE_BENCHMARK 
     Tools:Emb_RensponseTimingVerifier m_responseTimingVerifier;
 #endif
@@ -608,8 +611,8 @@ public:
     virtual bool getRefCurrentsRaw(double *t) override;
     virtual bool getRefCurrentRaw(int j, double *t) override;
 
+    bool downsamplerCallback(const yarp::os::YarpTimerEvent& event);
     
 };
 
 #endif // include guard
-

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -53,6 +53,8 @@ using namespace std;
 #include "eomcParser.h"
 #include "measuresConverter.h"
 
+#include "mcEventDownsampler.h"
+
 #ifdef NETWORK_PERFORMANCE_BENCHMARK 
 #include <PeriodicEventsVerifier.h>
 #endif
@@ -230,12 +232,9 @@ private:
     int *                                   _axisMap;   /** axies map*/
     std::vector<eomc::axisInfo_t>           _axesInfo;
     /////// end configuration info
-    // downsampler timer
-    yarp::os::Timer* tm;
-    bool error_position_raw_triggered;
-    uint32_t timer_count_epr_trigger;
-    int downsampler_threshold;
-    std::map<std::string, uint32_t> downsampled_errors;
+    
+    // event downsampler
+    mced::mcEventDownsampler* event_downsampler;
 
 #ifdef VERIFY_ROP_SETIMPEDANCE
     uint32_t *impedanceSignature;
@@ -262,7 +261,7 @@ private:
     double  *_ref_accs;         // for velocity control, in position min jerk eq is used.
     double  *_encodersStamp;                    /** keep information about acquisition time for encoders read */
     bool  *checking_motiondone;                 /* flag telling if I'm already waiting for motion done */
-    #define MAX_POSITION_MOVE_INTERVAL 0.080
+    #define MAX_POSITION_MOVE_INTERVAL 0.0001
     double *_last_position_move_time;           /** time stamp for last received position move command*/    
     eOmc_impedance_t *_cacheImpedance;    /* cache impedance value to split up the 2 sets */
     
@@ -613,9 +612,6 @@ public:
     virtual bool setRefCurrentsRaw(const int n_joint, const int *joints, const double *t) override;
     virtual bool getRefCurrentsRaw(double *t) override;
     virtual bool getRefCurrentRaw(int j, double *t) override;
-
-    bool downsamplerCallback(const yarp::os::YarpTimerEvent& event);
-    
 };
 
 #endif // include guard

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -230,7 +230,12 @@ private:
     int *                                   _axisMap;   /** axies map*/
     std::vector<eomc::axisInfo_t>           _axesInfo;
     /////// end configuration info
-
+    // downsampler timer
+    yarp::os::Timer* tm;
+    bool error_position_raw_triggered;
+    uint32_t timer_count_epr_trigger;
+    int downsampler_threshold;
+    std::map<std::string, uint32_t> downsampled_errors;
 
 #ifdef VERIFY_ROP_SETIMPEDANCE
     uint32_t *impedanceSignature;
@@ -261,9 +266,7 @@ private:
     double *_last_position_move_time;           /** time stamp for last received position move command*/    
     eOmc_impedance_t *_cacheImpedance;    /* cache impedance value to split up the 2 sets */
     
-    // downsampler timer
-    yarp::os::Timer* tm;
-    int timer_count;
+
 #ifdef NETWORK_PERFORMANCE_BENCHMARK 
     Tools:Emb_RensponseTimingVerifier m_responseTimingVerifier;
 #endif


### PR DESCRIPTION
This PR aims to fix the issue: https://github.com/robotology/icub-main/issues/768
To downsample the error messages rate, the logic of a simple Finite State Machine is implemented inside a `yarp::os::Timer`. The timer runs at 100Hz. If they exceed a threshold of 5 events, the FSM prints the number of error events occurred each second. 
The proposed solution was tested on a desk setup with one joint, addressing the three  types of error events mentioned in the issue.

The videos below show the results on the setup.

On the top left there's the `Yarpmotorgui`, where I change the control mode. On the top right there's the program `tutorial_arm` that sends the requests, and triggers the errors in the `yarprobotinterface` if the control mode is not the expected one. On the bottom there is the `yarprobotinterface`.
 - From Position to Velocity

https://user-images.githubusercontent.com/38140169/141956329-92ffd840-57a6-4640-8e18-a4eefabee91f.mp4

- From Velocity to Position

https://user-images.githubusercontent.com/38140169/141957102-11277cc6-3883-4173-be1c-03c068cf45db.mp4

- From Position Direct to Velocity

https://user-images.githubusercontent.com/38140169/141957131-3839e8ea-926c-4463-b2c2-63228d5edaa4.mp4

 