### PR TITLE
Add board info to the downsampler

### DIFF
--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.cpp
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.cpp
@@ -61,7 +61,7 @@ namespace mced {
         return false;
     }
     
-    bool mcEventDownsampler::start(const Config &config)
+    bool mcEventDownsampler::start()
     {
         if(nullptr != timer)
         {
@@ -103,7 +103,7 @@ namespace mced {
 
     void mcEventDownsampler::printreport()
     {
-        yCError(MC_EVENT_DOWNSAMPLER) <<  "Detected " << counter - latch_2 << " events on aggregate since the last message";
+        yCError(MC_EVENT_DOWNSAMPLER) << config.info << "detected" << counter - latch_2 << "events on aggregate since the last message";
     }
             
 } // mced

--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
@@ -24,10 +24,8 @@ namespace mced {
          */
         struct Config
         {
-            double period {0.};
-            Config() = default;
-            constexpr Config(double c) : period(c) {} 
-            bool isvalid() const { return 0. != period; }
+            double period {.01};
+            std::string info {""};
         };
       
         /**
@@ -44,10 +42,9 @@ namespace mced {
 
         /**
          * @brief Instantiates the yarp::os::Timer object and starts it.
-         * @param config Structure containing the configuration parameters of the Event Downsampler
          * @return true if the instantiation was successful, false otherwise.
          */
-        bool start(const Config &config);   
+        bool start();   
 
         /**
          * @brief Stops the timer
@@ -61,7 +58,7 @@ namespace mced {
          * @return true if the difference is lower or equal to the threshold, false if it is higher. 
          */
         bool canprint();
-        Config config = 0.1;
+        Config config;
         
     private: 
         /**

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -403,7 +403,8 @@ bool embObjMotionControl::open(yarp::os::Searchable &config)
     
     event_downsampler = new mced::mcEventDownsampler();
     event_downsampler->config.period = 0.01;
-    event_downsampler->start(event_downsampler->config);
+    event_downsampler->config.info = getBoardInfo();
+    event_downsampler->start();
 
     if(false == res->serviceVerifyActivate(eomn_serv_category_mc, servparam))
     {


### PR DESCRIPTION
This PR follows up on #770 and lets the downsampler print out info about the board as well.
I've also streamlined the code here and there where/when possible.