### PR TITLE
Configuration of `threshold` and `subcomponent` of the message downsampler

### DIFF
--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.cpp
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.cpp
@@ -6,9 +6,7 @@
 
 namespace mced {
     
-
-    YARP_LOG_COMPONENT(MC_EVENT_DOWNSAMPLER, "mc.msgdownsampler.skipped-cmd-wrong-mode")
-
+    YARP_LOG_COMPONENT(MC_EVENT_DOWNSAMPLER, "msg-downsampler")
 
     mcEventDownsampler::mcEventDownsampler() 
     {
@@ -89,7 +87,7 @@ namespace mced {
         {
             expire_time = yarp::os::Time::now();
             
-            isdownsampling = (counter - latch_1 > 5);
+            isdownsampling = (counter - latch_1 > config.threshold);
 
             if (isdownsampling)
             {
@@ -103,7 +101,8 @@ namespace mced {
 
     void mcEventDownsampler::printreport()
     {
-        yCError(MC_EVENT_DOWNSAMPLER) << config.info << "detected" << counter - latch_2 << "events on aggregate since the last message";
+        yCError(MC_EVENT_DOWNSAMPLER) << config.subcomponent << config.info << "-"
+                                      << "detected" << counter - latch_2 << "events on aggregate since the last message";
     }
             
 } // mced

--- a/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
+++ b/src/libraries/icubmod/embObjLib/mcEventDownsampler.h
@@ -25,6 +25,8 @@ namespace mced {
         struct Config
         {
             double period {.01};
+            size_t threshold {10};
+            std::string subcomponent {""};
             std::string info {""};
         };
       

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -403,6 +403,8 @@ bool embObjMotionControl::open(yarp::os::Searchable &config)
     
     event_downsampler = new mced::mcEventDownsampler();
     event_downsampler->config.period = 0.01;
+    event_downsampler->config.threshold = 5;
+    event_downsampler->config.subcomponent = "[mc.skipped-cmd-wrong-mode]";
     event_downsampler->config.info = getBoardInfo();
     event_downsampler->start();
 


### PR DESCRIPTION
This PR follows up on #771 and allows for configuring the `threshold` and the `subcomponent` name.

The latter might be required as the downsampler is in the library and could be utilized in the future also for different goals other than the MC.