### PR TITLE
Added CLI options for change CAN ID and IP address

### DIFF
--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -71,7 +71,7 @@ int saveDatFileStrain2(FirmwareUpdaterCore *core,QString device,QString id,QStri
 int setStrainSn(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canId, QString serialNumber);
 int setStrainGainsOffsets(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canId);
 int getCanBoardVersion(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canId,bool save);
-int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString oldCanId,QString newCanId);
+int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canIds);
 
 
 int main(int argc, char *argv[])
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
     QCommandLineOption setStrainGainsOffsetOption(QStringList() << "j" << "set-strain-gains", "Sets on STRAIN2 default gains to (8,24,24,10,10,24) , adjust the offset and check if some channel saturates","","");
     QCommandLineOption getCanBoardVersionOption(QStringList() << "b" << "get-canboard-version", "Gets Bootloader or Application version (<saveFile> must be y or n to save or not a file containing fw info)","saveFile","");
     QCommandLineOption saveDatFileOption(QStringList() << "u" << "save-dat-file", "Saves the calibration .dat file from STRAIN2 eeprom","","");
-    QCommandLineOption changeCanIdOption(QStringList() << "ci" << "change-can-id", "changes CAN ID","id-old","id-new");
+    QCommandLineOption changeCanIdOption(QStringList() << "k" << "change-can-id", "changes CAN ID","id-old,id-new","");
 
 
     parser.addOption(noGuiOption);
@@ -234,8 +234,9 @@ int main(int argc, char *argv[])
         bool setGains = parser.isSet(setStrainGainsOffsetOption);
         QString saveVersion = parser.value(getCanBoardVersionOption);
         bool getVersion = parser.isSet(getCanBoardVersionOption);
-        QString oldCanId = parser.value(changeCanIdOption);
-        QString newCanId = parser.value(changeCanIdOption);
+                bool changeCanID = parser.isSet(changeCanIdOption);
+
+        QString canIdOldNew = parser.value(changeCanIdOption);
 
 
         core.setVerbosity(verbosity);
@@ -377,7 +378,8 @@ int main(int argc, char *argv[])
             }
         }
 
-        if((saveDatFile) && (action_impossible != action))
+       
+        if((changeCanID) && (action_impossible != action))
         {
             if(action == action_none)
             {
@@ -713,7 +715,7 @@ int main(int argc, char *argv[])
             case action_changeCanId:
             {
                 ret = 1;
-
+  qDebug() << "AEIOU";
                 if(device.isEmpty()){
                     if(verbosity >= 1) qDebug() << "Need a device to be set";
                 }else if(id.isEmpty()){
@@ -724,7 +726,8 @@ int main(int argc, char *argv[])
                     } else if(!device.contains("ETH") && canId.isEmpty()){
                         if(verbosity >= 1) qDebug() << "Need a can id to be set";
                     }else{
-                      ret = changeCanId(&core,device,id,board,canLine,oldCanId,newCanId);
+                        qDebug() << "AAAAA";
+                      ret = changeCanId(&core,device,id,board,canLine,canIdOldNew);
                     }
                 }
 
@@ -836,16 +839,21 @@ int main(int argc, char *argv[])
         }
 
         */   
-int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString oldCanId,QString newCanId)
+int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canIds)
 {
     QList <sBoard> canBoards;
     QString retString;
     int ret;
     string msg;
-      
+    QStringList ids;
+
+    ids = canIds.split(",");
+
+    yInfo("AAAAAAAAAA\n");
     if(device.contains("SOCKETCAN"))
     {
-        if (oldCanId.toInt() <1 || oldCanId.toInt() >= 15){
+        
+        if (ids[0].toInt() <1 || ids[0].toInt() >= 15){
         yError("Invalid board address!\n");
         return false;
         }

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -843,9 +843,10 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
 
     QList <sBoard> canBoards;
     QString retString;
-    int ret;
+    bool ret;
     string msg;
     QStringList ids;
+    
 
     ids = canIds.split(",");
 
@@ -861,9 +862,10 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
         
         if(canBoards.count() > 0)
         {
-           
-            yInfo() << "BOARD FOUND!";
-            core->getDownloader()->change_card_address(0,ids[0].toInt(),1,canBoards[0].type);
+            ret = core->getDownloader()->change_card_address(0,ids[0].toInt(),1,canBoards[0].type);
+            if(ret) yInfo() << "Cahnge CAN ID Succeded !!!";
+            else yError() << "Cahnge CAN ID Failed !!!";
+
         } else {
             yError() << "No CAN board found, stopped!";
             return false;
@@ -873,7 +875,7 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
     {
         // FirmwareUpdater -g -e ETH -i 10.0.1.1 -c 1 -n 1 -k 1,2
 
-        QString result, ret;
+        QString result;
         ret = setBoardToMaintenance(core,device,id,board);
         if(!core->isBoardInMaintenanceMode(board)){
             yError("ETH board is not present or not in maintenace mode!!\n");
@@ -883,7 +885,9 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
         if(canBoards.count() > 0)
         {
             core->setSelectedCanBoards(canBoards,board,-1);
-            core->setCanBoardAddress(canLine.toInt(),ids[0].toInt(),canBoards[0].type,ids[1],board,-1,&result); 
+            ret = core->setCanBoardAddress(canLine.toInt(),ids[0].toInt(),canBoards[0].type,ids[1],board,-1,&result); 
+            if(ret) yInfo() << "Cahnge CAN ID Succeded !!!";
+            else yError() << "Cahnge CAN ID Failed !!!";
 
         } else {
             yError() << "No CAN board found, stopped!";

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -885,16 +885,18 @@ int changeBoardIp(FirmwareUpdaterCore *core,QString device,QString id,QString bo
     string msg;
 
     QString result;
+
     ret = setBoardToMaintenance(core,device,id,board);
     if(!core->isBoardInMaintenanceMode(board)){
         yError("ETH board is not present or not in maintenace mode!!\n");
         return false;
     }
-
+  
+   EthBoardList ethl = core->getEthBoardList();
+   yInfo() << ethl.size() << " " <<  ethl[0].getIPV4string();
     ret = core->setEthBoardAddress(0, newipaddr);
     if(ret) yInfo() << "Cahnge board IP Succeded !!!";
     else yError() << "Cahnge board IP Failed !!!";
-       
     return -1;
 }
 

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -839,6 +839,8 @@ int main(int argc, char *argv[])
         */   
 int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canIds)
 {
+    // FirmwareUpdater -g -e SOCKETCAN -i 0 -c 0 -n 1 -k 1,2
+
     QList <sBoard> canBoards;
     QString retString;
     int ret;
@@ -857,7 +859,15 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
 
         canBoards = core->getCanBoardsFromDriver(device,id.toInt(),&retString,true);
         
-        yInfo() << device.toInt();
+        if(canBoards.count() > 0)
+        {
+           
+            yInfo() << "BOARD FOUND!";
+            core->getDownloader()->change_card_address(0,ids[0].toInt(),1,canBoards[0].type);
+        } else {
+            yError() << "No CAN board found, stopped!";
+            return false;
+        }
     }
     else if(device.contains("ETH"))
     {
@@ -868,18 +878,19 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
             return false;
         }
         canBoards = core->getCanBoardsFromEth(board,&result,canLine.toInt(),true);
-    }
-
         if(canBoards.count() > 0)
         {
            
             yInfo() << "BOARD FOUND!";
-            core->getDownloader()->change_card_address(0,ids[0].toInt(),ids[1].toInt(),canBoards[0].type);
-            
+            core->setCanBoardAddress(1,ids[0].toInt(), canBoards[0].type, ids[1], "10.0.1.1", 0, &ret);
         } else {
             yError() << "No CAN board found, stopped!";
             return false;
         }
+    }
+
+        
+       
    
     return -1;
 }

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -839,7 +839,7 @@ int main(int argc, char *argv[])
         */   
 int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canIds)
 {
-    // FirmwareUpdater -g -e SOCKETCAN -i 0 -c 0 -n 1 -k 1,2
+    // FirmwareUpdater -g -e ETH -i eth1 -t 10.0.1.1 -c 1 -k 2,1
 
     QList <sBoard> canBoards;
     QString retString;
@@ -874,18 +874,16 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
         // FirmwareUpdater -g -e ETH -i 10.0.1.1 -c 1 -n 1 -k 1,2
 
         QString result, ret;
-        qDebug() << "AAAAAAAAAAAAAAAAAAAAA";
-        ret = setBoardToMaintenance(core,device,id,"10.0.1.1");
-        if(!core->isBoardInMaintenanceMode("10.0.1.1")){
+        ret = setBoardToMaintenance(core,device,id,board);
+        if(!core->isBoardInMaintenanceMode(board)){
             yError("ETH board is not present or not in maintenace mode!!\n");
             return false;
         }
-        canBoards = core->getCanBoardsFromEth("10.0.1.1",&result,canLine.toInt(),true);
+        canBoards = core->getCanBoardsFromEth(board,&result,canLine.toInt(),true);
         if(canBoards.count() > 0)
         {
-            qDebug() << "DEBUGGGGGGGGGGGGGGGGG " << canBoards[0].type << " " << ids[0] << " " << ids[1];
-            core->setSelectedCanBoards(canBoards,"10.0.1.1",-1);
-            core->setCanBoardAddress(1,ids[0].toInt(),canBoards[0].type,ids[1],"10.0.1.1",-1,&result); 
+            core->setSelectedCanBoards(canBoards,board,-1);
+            core->setCanBoardAddress(canLine.toInt(),ids[0].toInt(),canBoards[0].type,ids[1],board,-1,&result); 
 
         } else {
             yError() << "No CAN board found, stopped!";

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -71,7 +71,7 @@ int saveDatFileStrain2(FirmwareUpdaterCore *core,QString device,QString id,QStri
 int setStrainSn(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canId, QString serialNumber);
 int setStrainGainsOffsets(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canId);
 int getCanBoardVersion(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canId,bool save);
-int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString ipaddress,QString canIds);
+int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canIds);
 
 
 int main(int argc, char *argv[])
@@ -234,7 +234,7 @@ int main(int argc, char *argv[])
         bool setGains = parser.isSet(setStrainGainsOffsetOption);
         QString saveVersion = parser.value(getCanBoardVersionOption);
         bool getVersion = parser.isSet(getCanBoardVersionOption);
-        bool changeCanID = parser.isSet(changeCanIdOption);
+                bool changeCanID = parser.isSet(changeCanIdOption);
 
         QString canIdOldNew = parser.value(changeCanIdOption);
 
@@ -725,7 +725,7 @@ int main(int argc, char *argv[])
                     } else if(!device.contains("ETH") && canId.isEmpty()){
                         if(verbosity >= 1) qDebug() << "Need a can id to be set";
                     }else{
-                      ret = changeCanId(&core,device,id,board,canLine,board,canIdOldNew);
+                      ret = changeCanId(&core,device,id,board,canLine,canIdOldNew);
                     }
                 }
 
@@ -837,7 +837,7 @@ int main(int argc, char *argv[])
         }
 
         */   
-int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString ipaddress, QString canIds)
+int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canIds)
 {
     // FirmwareUpdater -g -e SOCKETCAN -i 0 -c 0 -n 1 -k 1,2
 
@@ -863,7 +863,7 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
         {
            
             yInfo() << "BOARD FOUND!";
-            core->getDownloader()->change_card_address(0,ids[0].toInt(),ids[1].toInt(),canBoards[0].type);
+            core->getDownloader()->change_card_address(0,ids[0].toInt(),1,canBoards[0].type);
         } else {
             yError() << "No CAN board found, stopped!";
             return false;
@@ -871,7 +871,7 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
     }
     else if(device.contains("ETH"))
     {
-        // FirmwareUpdater -g -e ETH -i eth1 -t 10.0.1.1 -c 1 -n 1 -k 1,2
+        // FirmwareUpdater -g -e ETH -i 10.0.1.1 -c 1 -n 1 -k 1,2
 
         QString result, ret;
         ret = setBoardToMaintenance(core,device,id,board);
@@ -882,8 +882,9 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
         canBoards = core->getCanBoardsFromEth(board,&result,canLine.toInt(),true);
         if(canBoards.count() > 0)
         {
+            qDebug() << "DEBUGGGGGGGGGGGGGGGGG " << canBoards[0].type << " " << ids[0] << " " << ids[1];
             core->setSelectedCanBoards(canBoards,"10.0.1.1",-1);
-            core->setCanBoardAddress(canLine.toInt(),ids[0].toInt(),canBoards[0].type,ids[1],ipaddress,-1,&result); 
+            core->setCanBoardAddress(1,ids[0].toInt(),canBoards[0].type,ids[1],"10.0.1.1",-1,&result); 
 
         } else {
             yError() << "No CAN board found, stopped!";

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -904,7 +904,7 @@ int changeBoardIp(FirmwareUpdaterCore *core,QString device,QString id,QString bo
 
 int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canId, QString canIdNew)
 {
-    // FirmwareUpdater -g -e SOCKETCAN -i 0 -c 0 -n 1 -k 2,1
+    // FirmwareUpdater -g -e SOCKETCAN -i 0 -c 0 -n 1 -k 2
     // FirmwareUpdater -g -e ETH -i eth1 -t 10.0.1.1 -c 1 -n 1 -k 2
 
     QList <sBoard> canBoards;

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -876,7 +876,7 @@ int main(int argc, char *argv[])
         */   
 int changeBoardIp(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString newipaddr)
 {
-    // FirmwareUpdater -g -e ETH -i eth1 -t 10.0.1.7 -2 10.0.1.1
+    // FirmwareUpdater -g -e ETH -i eth1 -t 10.0.1.1 -2 10.0.1.2
 
     QString retString;
     bool ret;
@@ -905,17 +905,13 @@ int changeBoardIp(FirmwareUpdaterCore *core,QString device,QString id,QString bo
 int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canId, QString canIdNew)
 {
     // FirmwareUpdater -g -e SOCKETCAN -i 0 -c 0 -n 1 -k 2,1
-    // FirmwareUpdater -g -e ETH -i eth1 -t 10.0.1.1 -c 1 -k 2,1
+    // FirmwareUpdater -g -e ETH -i eth1 -t 10.0.1.1 -c 1 -n 1 -k 2
 
     QList <sBoard> canBoards;
     QString retString;
     bool ret;
     int ret1;
     string msg;
-    QStringList ids;
-    
-
-    
 
     if(device.contains("SOCKETCAN"))
     {
@@ -939,7 +935,6 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
     }
     else if(device.contains("ETH"))
     {
-        // FirmwareUpdater -g -e ETH -i 10.0.1.1 -c 1 -n 1 -k 1,2
 
         QString result;
         ret = setBoardToMaintenance(core,device,id,board);
@@ -951,7 +946,7 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
         if(canBoards.count() > 0)
         {
             core->setSelectedCanBoards(canBoards,board,-1);
-            ret = core->setCanBoardAddress(canLine.toInt(),ids[0].toInt(),canBoards[0].type,ids[1],board,-1,&result); 
+            ret = core->setCanBoardAddress(canLine.toInt(),canId.toInt(),canBoards[0].type,canIdNew,board,-1,&result); 
             if(ret) yInfo() << "Cahnge CAN ID Succeded !!!";
             else yError() << "Cahnge CAN ID Failed !!!";
 

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -878,7 +878,7 @@ int main(int argc, char *argv[])
         */   
 int changeBoardIp(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString newipaddr)
 {
-    // FirmwareUpdater -g -e ETH -i eth1 -t 10.0.1.1 -c 1 -k 2,1
+    // FirmwareUpdater -g -e ETH -i eth1 -t 10.0.1.7 -2 10.0.1.1
 
     QString retString;
     bool ret;

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -71,7 +71,7 @@ int saveDatFileStrain2(FirmwareUpdaterCore *core,QString device,QString id,QStri
 int setStrainSn(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canId, QString serialNumber);
 int setStrainGainsOffsets(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canId);
 int getCanBoardVersion(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canId,bool save);
-int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canIds);
+int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString ipaddress,QString canIds);
 
 
 int main(int argc, char *argv[])
@@ -234,7 +234,7 @@ int main(int argc, char *argv[])
         bool setGains = parser.isSet(setStrainGainsOffsetOption);
         QString saveVersion = parser.value(getCanBoardVersionOption);
         bool getVersion = parser.isSet(getCanBoardVersionOption);
-                bool changeCanID = parser.isSet(changeCanIdOption);
+        bool changeCanID = parser.isSet(changeCanIdOption);
 
         QString canIdOldNew = parser.value(changeCanIdOption);
 
@@ -725,7 +725,7 @@ int main(int argc, char *argv[])
                     } else if(!device.contains("ETH") && canId.isEmpty()){
                         if(verbosity >= 1) qDebug() << "Need a can id to be set";
                     }else{
-                      ret = changeCanId(&core,device,id,board,canLine,canIdOldNew);
+                      ret = changeCanId(&core,device,id,board,canLine,board,canIdOldNew);
                     }
                 }
 
@@ -837,7 +837,7 @@ int main(int argc, char *argv[])
         }
 
         */   
-int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canIds)
+int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString ipaddress, QString canIds)
 {
     // FirmwareUpdater -g -e SOCKETCAN -i 0 -c 0 -n 1 -k 1,2
 
@@ -863,7 +863,7 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
         {
            
             yInfo() << "BOARD FOUND!";
-            core->getDownloader()->change_card_address(0,ids[0].toInt(),1,canBoards[0].type);
+            core->getDownloader()->change_card_address(0,ids[0].toInt(),ids[1].toInt(),canBoards[0].type);
         } else {
             yError() << "No CAN board found, stopped!";
             return false;
@@ -871,6 +871,8 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
     }
     else if(device.contains("ETH"))
     {
+        // FirmwareUpdater -g -e ETH -i eth1 -t 10.0.1.1 -c 1 -n 1 -k 1,2
+
         QString result, ret;
         ret = setBoardToMaintenance(core,device,id,board);
         if(!core->isBoardInMaintenanceMode(board)){
@@ -880,9 +882,9 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
         canBoards = core->getCanBoardsFromEth(board,&result,canLine.toInt(),true);
         if(canBoards.count() > 0)
         {
-           
-            yInfo() << "BOARD FOUND!";
-            core->setCanBoardAddress(1,ids[0].toInt(), canBoards[0].type, ids[1], "10.0.1.1", 0, &ret);
+            core->setSelectedCanBoards(canBoards,"10.0.1.1",-1);
+            core->setCanBoardAddress(canLine.toInt(),ids[0].toInt(),canBoards[0].type,ids[1],ipaddress,-1,&result); 
+
         } else {
             yError() << "No CAN board found, stopped!";
             return false;

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -884,12 +884,16 @@ int changeBoardIp(FirmwareUpdaterCore *core,QString device,QString id,QString bo
     bool ret;
     string msg;
 
-        QString result;
-        ret = setBoardToMaintenance(core,device,id,board);
-        if(!core->isBoardInMaintenanceMode(board)){
-            yError("ETH board is not present or not in maintenace mode!!\n");
-            return false;
-        }
+    QString result;
+    ret = setBoardToMaintenance(core,device,id,board);
+    if(!core->isBoardInMaintenanceMode(board)){
+        yError("ETH board is not present or not in maintenace mode!!\n");
+        return false;
+    }
+
+    ret = core->setEthBoardAddress(0, newipaddr);
+    if(ret) yInfo() << "Cahnge board IP Succeded !!!";
+    else yError() << "Cahnge board IP Failed !!!";
        
     return -1;
 }

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -715,7 +715,6 @@ int main(int argc, char *argv[])
             case action_changeCanId:
             {
                 ret = 1;
-  qDebug() << "AEIOU";
                 if(device.isEmpty()){
                     if(verbosity >= 1) qDebug() << "Need a device to be set";
                 }else if(id.isEmpty()){
@@ -726,7 +725,6 @@ int main(int argc, char *argv[])
                     } else if(!device.contains("ETH") && canId.isEmpty()){
                         if(verbosity >= 1) qDebug() << "Need a can id to be set";
                     }else{
-                        qDebug() << "AAAAA";
                       ret = changeCanId(&core,device,id,board,canLine,canIdOldNew);
                     }
                 }
@@ -849,7 +847,6 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
 
     ids = canIds.split(",");
 
-    yInfo("AAAAAAAAAA\n");
     if(device.contains("SOCKETCAN"))
     {
         
@@ -860,7 +857,7 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
 
         canBoards = core->getCanBoardsFromDriver(device,id.toInt(),&retString,true);
         
-        
+        yInfo() << device.toInt();
     }
     else if(device.contains("ETH"))
     {
@@ -877,7 +874,7 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
         {
            
             yInfo() << "BOARD FOUND!";
-
+            core->getDownloader()->change_card_address(0,ids[0].toInt(),ids[1].toInt(),canBoards[0].type);
             
         } else {
             yError() << "No CAN board found, stopped!";

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -874,12 +874,13 @@ int changeCanId(FirmwareUpdaterCore *core,QString device,QString id,QString boar
         // FirmwareUpdater -g -e ETH -i 10.0.1.1 -c 1 -n 1 -k 1,2
 
         QString result, ret;
-        ret = setBoardToMaintenance(core,device,id,board);
-        if(!core->isBoardInMaintenanceMode(board)){
+        qDebug() << "AAAAAAAAAAAAAAAAAAAAA";
+        ret = setBoardToMaintenance(core,device,id,"10.0.1.1");
+        if(!core->isBoardInMaintenanceMode("10.0.1.1")){
             yError("ETH board is not present or not in maintenace mode!!\n");
             return false;
         }
-        canBoards = core->getCanBoardsFromEth(board,&result,canLine.toInt(),true);
+        canBoards = core->getCanBoardsFromEth("10.0.1.1",&result,canLine.toInt(),true);
         if(canBoards.count() > 0)
         {
             qDebug() << "DEBUGGGGGGGGGGGGGGGGG " << canBoards[0].type << " " << ids[0] << " " << ids[1];

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
     QCommandLineOption getCanBoardVersionOption(QStringList() << "b" << "get-canboard-version", "Gets Bootloader or Application version (<saveFile> must be y or n to save or not a file containing fw info)","saveFile","");
     QCommandLineOption saveDatFileOption(QStringList() << "u" << "save-dat-file", "Saves the calibration .dat file from STRAIN2 eeprom","","");
     QCommandLineOption changeCanIdOption(QStringList() << "k" << "change-can-id", "changes CAN ID","id-old,id-new","");
-    QCommandLineOption changeBoardIpOption(QStringList() << "b" << "change-ip-addr", "changes board IP address","ip-new","");
+    QCommandLineOption changeBoardIpOption(QStringList() << "2" << "change-ip-addr", "changes board IP address","ip-new","");
 
 
     parser.addOption(noGuiOption);
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
         QString saveVersion = parser.value(getCanBoardVersionOption);
         bool getVersion = parser.isSet(getCanBoardVersionOption);
         bool changeCanID = parser.isSet(changeCanIdOption);
-        bool changeIp = parser.isSet(changeCanIdOption);
+        bool changeIp = parser.isSet(changeBoardIpOption);
 
 
         QString canIdOldNew = parser.value(changeCanIdOption);


### PR DESCRIPTION
# New FirmwareUpdater CLI options
This PR introduces the `FirmwareUpdater CLI` capability to change : 

- CAN board ID via `SOCKETCAN` device
- CAN board ID via `ETH` device  
- IP address of an ETH board

## Change CAN ID via SOCKETCAN
In this example, we change the `CAN ID` on an `mtb` board connected via `SOCKETCAN` from 1 to 2.
The syntax of the command is the following : 
```bash
FirmwareUpdater -g -e SOCKETCAN -i 0 -c 0 -n 1 -k 2
```
where : 
- `-g -e SOCKETCAN -i 0 -c 0` is need to use a `SOCKETCAN` device (i.e. `ESD CAN/USB`) with `ID=0` and `canline=0`
- `-n 1 -k 2` changes old id 1 (-n 1) to 2 (-k 2)

https://user-images.githubusercontent.com/6638215/143570541-aab0d7ac-a9c9-45e3-b3c9-195622be5d4e.mp4

## Change CAN ID via ETH
In this example, we change the `CAN ID` on an `mtb` board connected via `ETH ` through an `ems4` board w/ `IP address = 10.0.1.1` from 1 to 2.
The syntax of the command is the following : 
```bash
FirmwareUpdater -g -e ETH -i eth1 -t 10.0.1.1 -c 1 -n 1 -k 2
```
where : 
- `-g -e ETH -i eth1 -t 10.0.1.1 -c 1` is need to use a `ETH` device (i.e. `ems4`) with `ip address = 10.0.1.1` and `canline=1`
- `-n 1 -k 2` changes old id 1 (-n 1) to 2 (-k 2)

https://user-images.githubusercontent.com/6638215/143570871-71523cda-4d26-4433-823d-a89ba3fcaccc.mp4

## Change IP address of an ETH board
In this example, we change the `IP address on an `ems4` board from `10.0.1.1` to 110.0.1.21.
The syntax of the command is the following : 
```bash
 FirmwareUpdater -g -e ETH -i eth1 -t 10.0.1.1 -2 10.0.1.2
```
where : 
- ` -g -e ETH -i eth1` is need to use a `ETH` device (i.e. `ems4`) 
- `-t 10.0.1.1 -2 10.0.1.2` changes old i`IP address` 10.0.1.1 to 10.0.1.2

https://user-images.githubusercontent.com/6638215/143571478-c2be1fb2-f357-4bc5-b3dd-e5539df0f555.mp4

cc @pattacini @maggia80 @emilianob80 @Uboldi80 @gsisinna @marcoaccame 
