### PR TITLE
Added support for amcbldc and pmc boards in FirmwareUpdater

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -72,8 +72,8 @@ checkandset_dependency(Qt5)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
   # icub-firmware-shared 4.0.7 was actually a wrong version exported by icub-firmware-shared <= 1.15
-  if(icub_firmware_shared_VERSION VERSION_GREATER 4 OR icub_firmware_shared_VERSION VERSION_LESS 1.21.0)
-    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected, but at least 1.21.0 is required")
+  if(icub_firmware_shared_VERSION VERSION_GREATER 4 OR icub_firmware_shared_VERSION VERSION_LESS 1.22.1)
+    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected, but at least 1.22.1 is required")
   endif()
 endif()
 

--- a/src/tools/canLoader/canLoaderLib/downloader.cpp
+++ b/src/tools/canLoader/canLoaderLib/downloader.cpp
@@ -2201,6 +2201,8 @@ int cDownloader::get_firmware_version(int bus, int target_id, eObrd_cantype_t bo
         case eobrd_cantype_sg3:
         case eobrd_cantype_psc:
         case eobrd_cantype_mtb4w:
+        case eobrd_cantype_pmc:
+        case eobrd_cantype_amcbldc:
         {
             boardisMC = false;
             txBuffer[0].setId(EOCANPROT_D_CREATE_CANID(ICUBCANPROTO_CLASS_POLLING_ANALOGSENSOR, 0, target_id));
@@ -2424,6 +2426,8 @@ int cDownloader::change_card_address(int bus, int target_id, int new_id, int boa
         case icubCanProto_boardType__sg3:
         case icubCanProto_boardType__psc:
         case icubCanProto_boardType__mtb4w:
+        case eobrd_cantype_pmc:
+        case eobrd_cantype_amcbldc:
             txBuffer[0].setId((0x02 << 8) + (ID_MASTER << 4) + target_id);
             txBuffer[0].setLen(2);
             txBuffer[0].getData()[0]= ICUBCANPROTO_POL_MC_CMD__SET_BOARD_ID;
@@ -2768,6 +2772,8 @@ int cDownloader::startscheda(int bus, int board_pid, bool board_eeprom, int boar
     case icubCanProto_boardType__sg3:
     case icubCanProto_boardType__psc:
     case icubCanProto_boardType__mtb4w:
+    case eobrd_cantype_pmc:
+    case eobrd_cantype_amcbldc:
     case icubCanProto_boardType__unknown:
     {
         // Send command
@@ -2792,9 +2798,8 @@ int cDownloader::startscheda(int bus, int board_pid, bool board_eeprom, int boar
             if(_verbose) yError ("START_CMD: Unable to send message\n");
             return -1;
         }
-
-    //pause
-     drv_sleep(500);
+     // marco.accame: wait some more time (it was 500 ms) to wait amcbldc and pmc boards to erase their flash 
+     drv_sleep(2000); 
 
     // riceve la risposta
     int read_messages = m_idriver->receive_message(rxBuffer);
@@ -3245,7 +3250,9 @@ int cDownloader::download_hexintel_line(char* line, int len, int bus, int board_
                 {   // only mtb4, strain2, rfe, sg3, psc, mtb4w are allowed to use such a code space.
                     if((icubCanProto_boardType__mtb4 == board_type) || (icubCanProto_boardType__strain2 == board_type) ||
                        (icubCanProto_boardType__rfe == board_type) || (icubCanProto_boardType__sg3 == board_type) ||
-                       (icubCanProto_boardType__psc == board_type) || (icubCanProto_boardType__mtb4w == board_type)
+                       (icubCanProto_boardType__psc == board_type) || (icubCanProto_boardType__mtb4w == board_type) ||
+                       (icubCanProto_boardType__pmc == board_type) 
+                       || (icubCanProto_boardType__amcbldc == board_type)
                       )
                     {   // it is ok
                     }
@@ -3486,6 +3493,8 @@ int cDownloader::download_file(int bus, int board_pid, int download_type, bool b
                         case icubCanProto_boardType__sg3:
                         case icubCanProto_boardType__psc:
                         case icubCanProto_boardType__mtb4w:
+                        case icubCanProto_boardType__pmc:
+                        case icubCanProto_boardType__amcbldc:
                              ret = download_hexintel_line(buffer, strlen(buffer), bus, board_pid, board_eeprom, download_type);
 
                         break;


### PR DESCRIPTION
This PR allows the program `FirmwareUpdater` to recognize the boards `pmc` and `amcbldc` for its operativity.

For this purpose, we need to define some enum values in `icub-firmware-shared` (see the relevant [PR](https://github.com/robotology/icub-firmware-shared/pull/51)) and to avoid compilation failure we also need to update the required version of icub-firmware-shared to be 1.22.1.

A small but important change was to increase the timeout with which the `canloader` library waits for a reply from the `amcbldc` and `pmc` after it has sent them a `BOOTLOADER:board` message. The reason is that these two new boards require longer time to perform their FLASH erase.

For further details see also the following joint PR in [icub-firmware](https://github.com/robotology/icub-firmware/pull/222), where we also document about the performed tests.

      
**NOTE**: The CI will fail because we need first to merge the PR on [icub-firmware-shared](https://github.com/robotology/icub-firmware-shared/pull/51). 