### PR TITLE
Fix packets generation for debian buster

### DIFF
--- a/.ci/create_icub-main_deb.sh
+++ b/.ci/create_icub-main_deb.sh
@@ -287,6 +287,10 @@ install_deps()
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | $_SUDO apt-key add -
     $_SUDO apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
     DEBIAN_FRONTEND=noninteractive; $_SUDO apt-get install $APT_OPTIONS cmake
+  elif [ "$_PLATFORM_RELEASE" == "buster" ]; then
+    $_SUDO apt-add-repository 'deb http://deb.debian.org/debian buster-backports main'
+    DEBIAN_FRONTEND=noninteractive;
+    $_SUDO apt-get -y update && $_SUDO apt-get -y install -t buster-backports cmake
   else
     DEBIAN_FRONTEND=noninteractive; $_SUDO apt-get install $APT_OPTIONS cmake
   fi

--- a/.ci/packages_vars.sh
+++ b/.ci/packages_vars.sh
@@ -23,7 +23,7 @@ APT_OPTIONS="-q -y"
 
 SUPPORTED_DISTRO_LIST="buster bionic focal"
 SUPPORTED_TARGET_LIST="amd64"
-CMAKE_MIN_REQ_VER="3.12.0"
+CMAKE_MIN_REQ_VER="3.16.0"
 ICUB_DEPS_COMMON="libace-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libc6 python3 libgsl0-dev libncurses5-dev libsdl1.2-dev subversion git gfortran libxmu-dev libode-dev wget unzip qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev libqt5svg5 libqt5opengl5-dev libopencv-dev freeglut3-dev libtinyxml-dev libblas-dev coinor-libipopt-dev liblapack-dev libmumps-dev qml-module-qtmultimedia qml-module-qtquick-dialogs qml-module-qtquick-controls qml-module-qt-labs-settings libqcustomplot-dev qml-module-qt-labs-folderlistmodel libedit-dev libeigen3-dev libjpeg-dev libsimbody-dev libxml2-dev libjs-underscore portaudio19-dev libgtkmm-2.4-dev ${YCM_PACKAGE}"
 ICUB_DEPS_bionic="libode6"
 ICUB_DEPS_focal="libode8"


### PR DESCRIPTION
Since now yarp requires cmake 3.16.0 or higher, we had to install it on buster using the backports