### PR TITLE
Forced use of icub_firmware_shared_VERSION 1.24.1

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -72,8 +72,8 @@ checkandset_dependency(Qt5)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
   # icub-firmware-shared 4.0.7 was actually a wrong version exported by icub-firmware-shared <= 1.15
-  if(icub_firmware_shared_VERSION VERSION_GREATER 4 OR icub_firmware_shared_VERSION VERSION_LESS 1.24.0)
-    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected, but at least 1.24.0 is required")
+  if(icub_firmware_shared_VERSION VERSION_GREATER 4 OR icub_firmware_shared_VERSION VERSION_LESS 1.24.1)
+    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected, but at least 1.24.1 is required")
   endif()
 endif()
 


### PR DESCRIPTION
This PR forces the use of the latest `icub-firmware-shared` version, now icub_firmware_shared_VERSION 1.24.1 as from [PR](https://github.com/robotology/icub-firmware-shared/pull/58).