### PR TITLE
iCubGui: Remove use of legacy OpenGL_LIBRARIES CMake variable

### DIFF
--- a/src/tools/iCubGui/src/CMakeLists.txt
+++ b/src/tools/iCubGui/src/CMakeLists.txt
@@ -53,8 +53,7 @@ source_group("Generated Files" FILES ${iCubGui_QRC_GEN_SRCS}
                                      ${iCubGui_UI_GEN_SRCS})
 
 
-include_directories(${OpenGL_INCLUDE_DIRS}
-                    ${Qt5_INCLUDE_DIRS})
+include_directories(${Qt5_INCLUDE_DIRS})
 
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
@@ -68,7 +67,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE ${QT_DEFINITIONS}
                                                    GLUT_NO_LIB_PRAGMA)
 
 target_link_libraries(iCubGui GLUT::GLUT
-                              ${OpenGL_LIBRARIES}
+                              OpenGL::GL
                               ${YARP_LIBRARIES}
                               skinDynLib)
 


### PR DESCRIPTION
The `OpenGL_LIBRARIES` variable is not provided by the official CMake OpenGL module, see https://cmake.org/cmake/help/latest/module/FindOpenGL.html . That variable was provided by the YCM's `FindOpenGL` module, that was removed in https://github.com/robotology/ycm/pull/401 . 

To avoid problems in linking OpenGL, this PR switches to use the CMake target `OpenGL::GL` as suggested in CMake docs.