### PR TITLE
Add link on OpenGL::GLU for iCubGui

### DIFF
--- a/src/tools/iCubGui/src/CMakeLists.txt
+++ b/src/tools/iCubGui/src/CMakeLists.txt
@@ -68,6 +68,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE ${QT_DEFINITIONS}
 
 target_link_libraries(iCubGui GLUT::GLUT
                               OpenGL::GL
+                              OpenGL::GLU
                               ${YARP_LIBRARIES}
                               skinDynLib)
 


### PR DESCRIPTION
https://github.com/robotology/icub-main/pull/787 was incomplete, as `iCubGui` is also using GLU.