### PR TITLE
Update Denavit-Hartenberg parameters of left and right iCubArm v2.x

### DIFF
--- a/src/libraries/iKin/src/iKinFwd.cpp
+++ b/src/libraries/iKin/src/iKinFwd.cpp
@@ -1576,7 +1576,7 @@ void iCubTorso::allocate(const string &_type)
     H0.zero();
     H0(3,3)=1.0;
 
-    if (version<3.0)
+    if (version<2.0) // version 1.x
     {
         H0(0,1)=-1.0;
         H0(1,2)=-1.0;
@@ -1587,7 +1587,19 @@ void iCubTorso::allocate(const string &_type)
         pushLink(new iKinLink(    0.0, -0.0055,  M_PI/2.0, -M_PI/2.0, -39.0*CTRL_DEG2RAD, 39.0*CTRL_DEG2RAD));
         pushLink(new iKinLink(0.00231, -0.1933, -M_PI/2.0, -M_PI/2.0, -59.0*CTRL_DEG2RAD, 59.0*CTRL_DEG2RAD));
     }
-    else
+    else if ((version>=2.0) && (version<3.0)) // version 2.x 
+    {
+        H0(0,0)=1.0;
+        H0(1,2)=-1.0;
+        H0(1,3)=0.026935;
+        H0(2,1)=1.0;
+        setH0(H0);
+
+        pushLink(new iKinLink(0.032,0.026935,  M_PI/2.0,  M_PI/2.0, -22.0*CTRL_DEG2RAD, 84.0*CTRL_DEG2RAD)); 
+        pushLink(new iKinLink(  0.0, -0.0055, -M_PI/2.0,  M_PI/2.0, -39.0*CTRL_DEG2RAD, 39.0*CTRL_DEG2RAD));
+        pushLink(new iKinLink(  0.0,   -0.05, -M_PI/2.0,       0.0, -59.0*CTRL_DEG2RAD, 59.0*CTRL_DEG2RAD));
+    }
+    else // version 3.0
     {
         H0(0,2)=1.0;
         H0(1,1)=-1.0;
@@ -1666,11 +1678,18 @@ void iCubArm::allocate(const string &_type)
     Matrix H0(4,4);
     H0.zero();
 
-    if (version<3.0)
+    if (version<2.0) 
     {
         H0(0,1)=-1.0;
         H0(1,2)=-1.0;
         H0(2,0)=1.0;
+    }
+    else if ((version>=2.0) && (version<3.0))
+    {
+        H0(0,0)=1.0;
+        H0(1,2)=-1.0;
+        H0(1,3)=0.026935;
+        H0(2,1)=1.0;
     }
     else
     {
@@ -1682,10 +1701,30 @@ void iCubArm::allocate(const string &_type)
     H0(3,3)=1.0;
     setH0(H0);
 
+    Matrix HN(4,4);
+    HN.zero();
+
+    if ((version>=2.0) && (version<3.0))
+    {
+        HN(0,0)=0.9996;
+        HN(0,1)=0.0286;
+        HN(1,0)=-0.0286;
+        HN(1,1)=0.9996;
+        HN(2,2)=1;
+    }
+    else
+    {
+        HN(0,0)=1.0;
+        HN(1,1)=1.0;
+        HN(2,2)=1.0;
+    }
+    HN(3,3)=1.0;
+    setHN(HN);
+
     if (arm=="right")
     {
-        if (version<3.0)
-        {
+	    if (version<2.0) // version 1.x
+	    {
             pushLink(new iKinLink(     0.032,      0.0,  M_PI/2.0,                 0.0, -22.0*CTRL_DEG2RAD,  84.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(       0.0,  -0.0055,  M_PI/2.0,           -M_PI/2.0, -39.0*CTRL_DEG2RAD,  39.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(-0.0233647,  -0.1433,  M_PI/2.0, -105.0*CTRL_DEG2RAD, -59.0*CTRL_DEG2RAD,  59.0*CTRL_DEG2RAD));
@@ -1693,17 +1732,27 @@ void iCubArm::allocate(const string &_type)
             pushLink(new iKinLink(       0.0,      0.0, -M_PI/2.0,           -M_PI/2.0,   0.0*CTRL_DEG2RAD, 160.8*CTRL_DEG2RAD));
             pushLink(new iKinLink(    -0.015, -0.15228, -M_PI/2.0, -105.0*CTRL_DEG2RAD, -37.0*CTRL_DEG2RAD, 100.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(     0.015,      0.0,  M_PI/2.0,                 0.0,   5.5*CTRL_DEG2RAD, 106.0*CTRL_DEG2RAD));
-        if (version<1.7)
-            pushLink(new iKinLink(       0.0,  -0.1373,  M_PI/2.0,           -M_PI/2.0, -50.0*CTRL_DEG2RAD,  50.0*CTRL_DEG2RAD));
-        else
-            pushLink(new iKinLink(       0.0,  -0.1413,  M_PI/2.0,           -M_PI/2.0, -50.0*CTRL_DEG2RAD,  50.0*CTRL_DEG2RAD));
-            pushLink(new iKinLink(       0.0,      0.0,  M_PI/2.0,            M_PI/2.0, -65.0*CTRL_DEG2RAD,  10.0*CTRL_DEG2RAD));
-        if (version<2.0)
+            if (version<1.7)
+                pushLink(new iKinLink(       0.0,  -0.1373,  M_PI/2.0,           -M_PI/2.0, -50.0*CTRL_DEG2RAD,  50.0*CTRL_DEG2RAD));
+	        else
+                pushLink(new iKinLink(       0.0,  -0.1413,  M_PI/2.0,           -M_PI/2.0, -50.0*CTRL_DEG2RAD,  50.0*CTRL_DEG2RAD));          
+            pushLink(new iKinLink(       0.0,      0.0,  M_PI/2.0,            M_PI/2.0, -65.0*CTRL_DEG2RAD,  10.0*CTRL_DEG2RAD));            
             pushLink(new iKinLink(    0.0625,    0.016,       0.0,                M_PI, -25.0*CTRL_DEG2RAD,  25.0*CTRL_DEG2RAD));
-        else
-            pushLink(new iKinLink(    0.0625,  0.02598,       0.0,                M_PI, -25.0*CTRL_DEG2RAD,  25.0*CTRL_DEG2RAD));
         }
-        else
+        else if (version>=2.0 && version<3.0) // version 2.x
+        {
+            pushLink(new iKinLink(     0.032,  0.026935,  M_PI/2.0,              M_PI/2.0, -22.0*CTRL_DEG2RAD,  84.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink(       0.0,   -0.0055, -M_PI/2.0,              M_PI/2.0, -39.0*CTRL_DEG2RAD,  39.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink( 0.0233647,   -0.1428, -M_PI/2.0,   -105.0*CTRL_DEG2RAD, -59.0*CTRL_DEG2RAD,  59.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink(       0.0, -0.106989,  M_PI/2.0,              M_PI/2.0, -95.5*CTRL_DEG2RAD,   5.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink(       0.0,       0.0,  M_PI/2.0,              M_PI/2.0,   0.0*CTRL_DEG2RAD, 160.8*CTRL_DEG2RAD));
+            pushLink(new iKinLink(     0.015,  -0.15906,  M_PI/2.0,   -105.0*CTRL_DEG2RAD, -37.0*CTRL_DEG2RAD, 100.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink(     0.015,       0.0,  M_PI/2.0,                 -M_PI,   5.5*CTRL_DEG2RAD, 106.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink(       0.0,   -0.1423, -M_PI/2.0,              M_PI/2.0, -50.0*CTRL_DEG2RAD,  50.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink(       0.0,       0.0, -M_PI/2.0,             -M_PI/2.0, -65.0*CTRL_DEG2RAD,  10.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink(   0.05926, -0.025057,     -M_PI, 178.3611*CTRL_DEG2RAD, -25.0*CTRL_DEG2RAD,  25.0*CTRL_DEG2RAD));
+        }
+        else // version 3.0
         {
             pushLink(new iKinLink(    0.0725,        0.0,              -M_PI/2.0,                 0.0, -20.0*CTRL_DEG2RAD,  20.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(       0.0,        0.0,               M_PI/2.0,           -M_PI/2.0, -15.0*CTRL_DEG2RAD,  40.0*CTRL_DEG2RAD));
@@ -1721,8 +1770,8 @@ void iCubArm::allocate(const string &_type)
     {
         if (arm!="left")
             type.replace(0,underscore,"left");
-
-        if (version<3.0)
+            
+	    if (version<2.0) // version 1.x
         {
             pushLink(new iKinLink(     0.032,      0.0,  M_PI/2.0,                 0.0, -22.0*CTRL_DEG2RAD,  84.0*CTRL_DEG2RAD)); 
             pushLink(new iKinLink(       0.0,  -0.0055,  M_PI/2.0,           -M_PI/2.0, -39.0*CTRL_DEG2RAD,  39.0*CTRL_DEG2RAD));
@@ -1731,17 +1780,27 @@ void iCubArm::allocate(const string &_type)
             pushLink(new iKinLink(       0.0,      0.0,  M_PI/2.0,           -M_PI/2.0,   0.0*CTRL_DEG2RAD, 160.8*CTRL_DEG2RAD));
             pushLink(new iKinLink(     0.015,  0.15228, -M_PI/2.0,   75.0*CTRL_DEG2RAD, -37.0*CTRL_DEG2RAD, 100.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(    -0.015,      0.0,  M_PI/2.0,                 0.0,   5.5*CTRL_DEG2RAD, 106.0*CTRL_DEG2RAD));
-        if (version<1.7)
-            pushLink(new iKinLink(       0.0,   0.1373,  M_PI/2.0,           -M_PI/2.0, -50.0*CTRL_DEG2RAD,  50.0*CTRL_DEG2RAD));
-        else
-            pushLink(new iKinLink(       0.0,   0.1413,  M_PI/2.0,           -M_PI/2.0, -50.0*CTRL_DEG2RAD,  50.0*CTRL_DEG2RAD));
+            if (version<1.7)
+                pushLink(new iKinLink(       0.0,   0.1373,  M_PI/2.0,           -M_PI/2.0, -50.0*CTRL_DEG2RAD,  50.0*CTRL_DEG2RAD));
+            else
+                pushLink(new iKinLink(       0.0,   0.1413,  M_PI/2.0,           -M_PI/2.0, -50.0*CTRL_DEG2RAD,  50.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(       0.0,      0.0,  M_PI/2.0,            M_PI/2.0, -65.0*CTRL_DEG2RAD,  10.0*CTRL_DEG2RAD));
-        if (version<2.0)
-            pushLink(new iKinLink(    0.0625,   -0.016,       0.0,                 0.0, -25.0*CTRL_DEG2RAD,  25.0*CTRL_DEG2RAD));
-        else
-            pushLink(new iKinLink(    0.0625, -0.02598,       0.0,                 0.0, -25.0*CTRL_DEG2RAD,  25.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink(    0.0625,   -0.016,       0.0,                 0.0, -25.0*CTRL_DEG2RAD,  25.0*CTRL_DEG2RAD));          
         }
-        else
+        else if (version>=2.0 && version<3.0) // version 2.x
+        {
+            pushLink(new iKinLink(     0.032, 0.026935,  M_PI/2.0,               M_PI/2.0, -22.0*CTRL_DEG2RAD,  84.0*CTRL_DEG2RAD)); 
+            pushLink(new iKinLink(       0.0,  -0.0055, -M_PI/2.0,               M_PI/2.0, -39.0*CTRL_DEG2RAD,  39.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink( 0.0233647,  -0.1428, -M_PI/2.0,     -75.0*CTRL_DEG2RAD, -59.0*CTRL_DEG2RAD,  59.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink(       0.0,    0.107, -M_PI/2.0,               M_PI/2.0, -95.5*CTRL_DEG2RAD,   5.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink(       0.0,      0.0, -M_PI/2.0,               M_PI/2.0,   0.0*CTRL_DEG2RAD, 160.8*CTRL_DEG2RAD));
+            pushLink(new iKinLink(     0.015,  0.15906, -M_PI/2.0,    -105.0*CTRL_DEG2RAD, -37.0*CTRL_DEG2RAD, 100.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink(     0.015,      0.0, -M_PI/2.0,                  -M_PI,   5.5*CTRL_DEG2RAD, 106.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink(       0.0,   0.1423,  M_PI/2.0,               M_PI/2.0, -50.0*CTRL_DEG2RAD,  50.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink(       0.0,  -0.0003, -M_PI/2.0,              -M_PI/2.0, -65.0*CTRL_DEG2RAD,  10.0*CTRL_DEG2RAD));
+            pushLink(new iKinLink(   0.05926,-0.025057,       0.0, -178.3611*CTRL_DEG2RAD, -25.0*CTRL_DEG2RAD,  25.0*CTRL_DEG2RAD));
+        }
+        else // version 3.0
         {
             pushLink(new iKinLink(    0.0725,         0.0,                -M_PI/2.0,               0.0, -20.0*CTRL_DEG2RAD,  20.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(       0.0,         0.0,                 M_PI/2.0,         -M_PI/2.0, -15.0*CTRL_DEG2RAD,  40.0*CTRL_DEG2RAD));


### PR DESCRIPTION
Copying it from https://github.com/robotology/icub-main/pull/758 since I accidentally closed that one.

----

The aim of this PR is to align the Denavit-Hartenberg parameters of left and right iCubArm v2.x with the values found in the CAD models.

## Motivation
While comparing the iKin forward kinematics with the iDynTree one extracted from the .urdf model, a significant misalignment was found in the left and right arm's end effector's position.

The comparison was made with a [task-specific application I developed](https://github.com/icub-tech-iit/icub-forward-kinematics-inspection), which instantiates an arm with iKin and iDynTree (which loads the .urdf file), and given a specific joints configuration, it prints out the forward kinematics transformation matrix. See the example below for the left arm.

|iKin | | | |
| --- | --- | --- | --- |
  | -1.0000 |  -0.0087   |      0 |  -0.2297|
  |       0     |    0     |   -1 | -0.08414|
  |  0.0087 |  -1.0000   |      0 | 0.009799|
|0      |   0       |  0       |  1|

|iDynTree | | | |
| --- | --- | --- | --- |
|-1.0000 |  -0.0087   |      0 |  -0.2273|
|         0     |    0      |  -1 | -0.08434|
|    0.0087 |  -1.0000    |     0 | 0.001105|
|0      |   0       |  0       |  1|

The difference of the translational component is: 
```
e_x = 0.00245053871179957
e_y = -0.000205222132508828
e_z = -0.00869452121972735
```

The misalignment was validated in MATLAB with Peter Corke's Robot toolbox
![123049020-5b7d6d80-d3ff-11eb-8431-52aaa7fa4196](https://user-images.githubusercontent.com/38140169/125923531-dcc9dc7b-af78-4023-8bd9-51b274828b4b.png)

and with other joints configurations:
|cfg|joint 1| joint 2| joint 3| joint4 | joint 5| joint 6| joint 7| joint 8 | joint 9 | joint 10|
|---|---|---|---|---|---|---|----|---|---|---|
|qdes5 |25 | 0| -9.6| 9.45| 160.80| 79.56 |19.005  |  0| 0| 0.6|
|qdes6 |25 | 10| -9.6| 9.45| 160.80| 79.56 |19.005  |  0| 0| 0.6|
|qdes7 |25 | -15| -9.6| 9.45| 160.80| 79.56 |19.005  |  0| 0| 0.6|
|qdes8 |-25 | 30| -9.6| 9.45| 160.80| 79.56 |19.005  |  0| 0| 0.6|


![123124806-48db5680-d448-11eb-9c78-205d53f8b80c](https://user-images.githubusercontent.com/38140169/125923795-ebe83daa-3f00-4b25-979d-614ae40b2a13.png)

Equivalent results were found for the right arm v2.x.

## Contribution
The PR's contribution changes the kinematic parameters of iCubArm v2.x left and right, specifically:
- base matrix H0
- Denavit-Hartenberg parameters
- end effector matrix Hn

If-else conditions are added to keep the parameters of v1.x and v3.0 unaltered.

## Result
The contribution was validated with the red ball test:


https://user-images.githubusercontent.com/38140169/125924817-4d17e057-79ca-408f-adda-437b7121ac67.mp4

