### PR TITLE
Fix placing of shared libraries in Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,6 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }}
 
     - name: Test
-      if: matrix.os == 'ubuntu-latest'
       shell: bash
       run: |
         cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+
 option(ICUB_COMPILE_BINDINGS "Compile optional language bindings"  FALSE)
 
 set(YCM_REQUIRED_VERSION 0.13.0)
@@ -41,7 +45,6 @@ set_property(GLOBAL PROPERTY ICUB_DEPENDENCIES_FLAGS) # this is populated iCubFi
 # Pick up our scripts - they are all in the conf subdirectory
 set(ICUB_MODULE_PATH ${PROJECT_SOURCE_DIR}/conf)
 set(CMAKE_MODULE_PATH ${ICUB_MODULE_PATH} ${CMAKE_MODULE_PATH})
-
 
 # add functionalities like icub_add_library/icub_add_executable
 include(${PROJECT_SOURCE_DIR}/conf/iCubHelpers.cmake)


### PR DESCRIPTION
This PR fixes #784.

@sgiraz narrowed down the reason why part of the libraries was ok and part not. See below.

I've also reinstated the test stage of the CI on Windows.

---

After a quick comparison between commit [87cd0a1][1] and commit [b6e0f7b][2] I found the difference that caused the "fix".

In particular in [`src/libraries/icubmod/embObjLib/CMakeLists.txt`][3] we have the following difference:
```diff
- add_library(${PROJECT_NAME} SHARED ${embobj_source} ${embobj_header})
+ add_library(${PROJECT_NAME} ${embobj_source} ${embobj_header})
```

As we can see, the SHARED keyword has been removed in [b6e0f7b][2].

[1]: https://github.com/robotology/icub-main/commit/87cd0a1df4c6b52c5876a5c7e7969cd60299d408
[2]: https://github.com/robotology/icub-main/commit/b6e0f7b471437efa82172ee757db116fb210b924
[3]: https://github.com/robotology/icub-main/blob/ad4870c4a54b6512bc009a064534aadb4a8c0576/src/libraries/icubmod/embObjLib/CMakeLists.txt#L86