### PR TITLE
Do not use deprecated IFrameGrabberControls2 interface

### DIFF
--- a/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.h
+++ b/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.h
@@ -287,7 +287,7 @@ class yarp::dev::DragonflyDeviceDriver2 :
     public IPreciselyTimed,
     public IFrameGrabber,
     public IFrameGrabberRgb,
-    public IFrameGrabberControls2,
+    public IFrameGrabberControls,
     public IFrameGrabberControlsDC1394,
     public IRgbVisualParams
 {


### PR DESCRIPTION
Fix https://github.com/robotology/icub-main/issues/794 . As `IFrameGrabberControls2` was a typedef for `IFrameGrabberControls` since YARP 3.0 it is safe to do this change in master branch.