### PR TITLE
Fix unittest for Windows

### DIFF
--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -40,12 +40,14 @@ PRIVATE
   embObjMultipleFTsensorsUT
   YARP::YARP_init
 )
-TARGET_LINK_LIBRARIES(ethResources)
 
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-include(GoogleTest)
-gtest_discover_tests(${PROJECT_NAME})
+#
+# Auto test execution during the build
+#
+#include(GoogleTest)
+#gtest_discover_tests(${PROJECT_NAME})
 
 #add_custom_target(run_unit_test ALL
 #    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure


### PR DESCRIPTION
On a local Windows PC this fix works. The UTs now are correctly compiled