### PR TITLE
Fix net performance tool in embObjLib

### DIFF
--- a/src/libraries/icubmod/embObjLib/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjLib/CMakeLists.txt
@@ -58,6 +58,8 @@ mark_as_advanced(NETWORK_PERFORMANCE_BENCHMARK)
 
 if(NETWORK_PERFORMANCE_BENCHMARK)
 
+add_definitions(-DNETWORK_PERFORMANCE_BENCHMARK)
+
 set(TOOLS_FOLDER    ${CMAKE_CURRENT_SOURCE_DIR}/tools)
 set(TOOLS_HEADER    ${TOOLS_FOLDER}/include/PeriodicEventsVerifier.h)
 set(TOOLS_SOURCE    ${TOOLS_FOLDER}/src/PeriodicEventsVerifier.cpp 

--- a/src/libraries/icubmod/embObjLib/ethReceiver.cpp
+++ b/src/libraries/icubmod/embObjLib/ethReceiver.cpp
@@ -82,7 +82,7 @@ EthReceiver::EthReceiver(int raterx): PeriodicThread((double)raterx/1000.0)
        the m_perEvtVerifier object after 1 second, prints an istogram with values from 4 to 6 millisec with a step of 0.1 millisec
      */
     double raterx_sec = (double)raterx/1000;//raterx is in milliseconds
-    m_perEvtVerifier.init(raterx_sec, (raterx_sec/100), raterx_sec-0.001, raterx_sec+0.001, 0.0001, 1);
+    m_perEvtVerifier.init(raterx_sec, (raterx_sec/100), raterx_sec-0.001, raterx_sec+0.001, 0.0001, 1, "Receiver");
 #endif
 }
 

--- a/src/libraries/icubmod/embObjLib/ethReceiver.cpp
+++ b/src/libraries/icubmod/embObjLib/ethReceiver.cpp
@@ -81,8 +81,8 @@ EthReceiver::EthReceiver(int raterx): PeriodicThread((double)raterx/1000.0)
     /* We would like to verify if the receiver thread is ticked(running) every 5 millisecond, with a tollerance of 0.05 millisec.
        the m_perEvtVerifier object after 1 second, prints an istogram with values from 4 to 6 millisec with a step of 0.1 millisec
      */
-    //m_perEvtVerifier.init(0.005, 0.00005, 0.004, 0.006, 0.0001, 1);
-    m_perEvtVerifier.init(raterx, (raterx/100), raterx-0.001, raterx+0.001, 0.0001, 1);
+    double raterx_sec = (double)raterx/1000;//raterx is in milliseconds
+    m_perEvtVerifier.init(raterx_sec, (raterx_sec/100), raterx_sec-0.001, raterx_sec+0.001, 0.0001, 1);
 #endif
 }
 

--- a/src/libraries/icubmod/embObjLib/ethSender.cpp
+++ b/src/libraries/icubmod/embObjLib/ethSender.cpp
@@ -71,7 +71,7 @@ EthSender::EthSender(int txrate) : PeriodicThread((double)txrate/1000.0)
     */
 
     double txrate_sec=(double)txrate/1000; //txrate is in milliseconds
-    m_perEvtVerifier.init(txrate_sec, 5*txrate_sec/100, 0.0, txrate_sec+0.002, 0.0001, 1);
+    m_perEvtVerifier.init(txrate_sec, 5*txrate_sec/100, 0.0, txrate_sec+0.002, 0.0001, 1, "Sender");
 #endif
 }
 

--- a/src/libraries/icubmod/embObjLib/ethSender.cpp
+++ b/src/libraries/icubmod/embObjLib/ethSender.cpp
@@ -69,8 +69,9 @@ EthSender::EthSender(int txrate) : PeriodicThread((double)txrate/1000.0)
     /* We would like to verify if the receiver thread is ticked(running) every 1 millisecond, with a tollerance of 0.05 millisec.
        The m_perEvtVerifier object after 1 second, prints an istogram with values from 0 to 3 millisec with a step of 0.1 millisec
     */
-    //m_perEvtVerifier.init(0.001, 0.00005, 0.0, 0.003, 0.0001, 1);
-    m_perEvtVerifier.init(txrate, 5*txrate/100, 0.0, txrate+0.002, 0.0001, 1);
+
+    double txrate_sec=(double)txrate/1000; //txrate is in milliseconds
+    m_perEvtVerifier.init(txrate_sec, 5*txrate_sec/100, 0.0, txrate_sec+0.002, 0.0001, 1);
 #endif
 }
 

--- a/src/libraries/icubmod/embObjLib/tools/include/PeriodicEventsVerifier.h
+++ b/src/libraries/icubmod/embObjLib/tools/include/PeriodicEventsVerifier.h
@@ -16,6 +16,8 @@
 #ifndef _PERIODIC_EVENTS_VERIFIER_H_
 #define _PERIODIC_EVENTS_VERIFIER_H_
 
+#include <string>
+
 //!  In the Tools namespace there are classes useful to check some kinds of performance on robot. 
 /*!
   Currently, the available classes are Emb_PeriodicEventVerifier and Emb_RensponseTimingVerifier: 
@@ -62,11 +64,12 @@ class Tools::Emb_PeriodicEventVerifier
      * \param max is the maximum period you expected [expressed in seconds].
      * \param step is the step of the histogram. [expressed in seconds].
      * \param reportPeriod the class prints the histogram every @reportPeriod seconds. [expressed in seconds].
+     * \param name used in the print of histogram
      * \return true/false on success/failure.
      *
      * \note the number of histogram columns are: ((@max-@min)/@step ) +2 
      */
-        bool init(double period, double tolerance, double min, double max, double step, double reportPeriod);
+        bool init(double period, double tolerance, double min, double max, double step, double reportPeriod, const std::string& name = {});
         
         
     /*!
@@ -112,11 +115,12 @@ class Tools::Emb_RensponseTimingVerifier
         * \param max is the maximum response period you expected [expressed in seconds].
         * \param step is the step of the histogram. [expressed in seconds].
         * \param reportPeriod the class prints the histogram every @reportPeriod seconds. [expressed in seconds].
+        * \param name used in the print of histogram
         * \return true/false on success/failure.
         *
         * \note the number of histogram columns are: ((@max-@min)/@step ) +2 
         */    
-        bool init(double desiredResponseTime, double tolerance, double min, double max, double step, double reportPeriod);
+        bool init(double desiredResponseTime, double tolerance, double min, double max, double step, double reportPeriod, const std::string& name = {});
         
         /*!
         * Adds the current response time to the collection of data of the object.

--- a/src/libraries/icubmod/embObjLib/tools/src/PeriodicEventsVerifier.cpp
+++ b/src/libraries/icubmod/embObjLib/tools/src/PeriodicEventsVerifier.cpp
@@ -56,7 +56,7 @@ struct Tools::Emb_PeriodicEventVerifier::Impl
     void tick(double currentTime)
     {
         
-        uint64_t tnow = static_cast<std::uint64_t>(currentTime);
+        uint64_t tnow = static_cast<std::uint64_t>(currentTime * 1000000);
         uint64_t delta = 0;
         m_perVal.tick(tnow, delta);
         if(true == m_perVal.report())
@@ -151,16 +151,7 @@ Tools::Emb_PeriodicEventVerifier::~Emb_PeriodicEventVerifier()
 
 bool Tools::Emb_PeriodicEventVerifier::init(double period, double tolerance, double min, double max, double step, double reportPeriod)
 {
-    // now transform each parameter expressed in seconds to microseconds
-    uint64_t period_us=period*1000000;
-    uint64_t tolerance_us=tolerance*1000000;
-    uint64_t min_us=min*1000000;
-    uint64_t max_us=max*1000000;
-    uint64_t step_us=step*1000000;
-    uint64_t reportPeriod_us=reportPeriod*1000000;
-    
-    
-    return pImpl->init(period_us, tolerance_us, min_us, max_us, step_us, reportPeriod_us);
+   return pImpl->init(period, tolerance, min, max, step, reportPeriod);
 }
 
 void Tools::Emb_PeriodicEventVerifier::tick(double currentTime)

--- a/src/libraries/icubmod/embObjLib/tools/src/PeriodicEventsVerifier.cpp
+++ b/src/libraries/icubmod/embObjLib/tools/src/PeriodicEventsVerifier.cpp
@@ -30,14 +30,14 @@ struct Tools::Emb_PeriodicEventVerifier::Impl
 {
 
     embot::tools::PeriodValidator m_perVal;
-
+    std::string name;
 
     Impl()
     {
 
     }
 
-    bool init(double period, double tolerance, double min, double max, double step, double reportPeriod)
+    bool init(double period, double tolerance, double min, double max, double step, double reportPeriod, const std::string& name = {})
     {
         // now transform each parameter expressed in seconds to microseconds
         uint64_t period_us=period*1000000;
@@ -46,7 +46,7 @@ struct Tools::Emb_PeriodicEventVerifier::Impl
         uint64_t max_us=max*1000000;
         uint32_t step_us=step*1000000;
         uint64_t reportPeriod_us=reportPeriod*1000000;
-        
+        this->name=name;
         
         return m_perVal.init({period_us, period_us+tolerance_us,  reportPeriod_us, 
                         {min_us, max_us, step_us}});
@@ -65,15 +65,15 @@ struct Tools::Emb_PeriodicEventVerifier::Impl
             m_perVal.histogram()->probabilitydensityfunction(vect_prob);
             uint32_t min = m_perVal.histogram()->getconfig()->min;
             uint32_t step = m_perVal.histogram()->getconfig()->step;
-            yWarning() << "---------- PRINT HISTO RECEIVER ---------------";
+            yWarning() << "---------- PRINT HISTO" << name << "---------------";
             for(int i=0; i<vect_prob.size(); i++)
             {
                 if(vect_prob[i]==0)
                     continue;
 
-                yWarning() << "-- histo RX [" << min+step*i << "]="<< vect_prob[i];
+                yWarning() << "-- histo" << name << "[" << min+step*i << "]="<< vect_prob[i];
             }
-            yWarning() << "---------- END PRINT HISTO RECEIVER ---------------";
+            yWarning() << "---------- END PRINT HISTO" << name << "---------------";
             m_perVal.reset();
         }
 
@@ -84,13 +84,13 @@ struct Tools::Emb_PeriodicEventVerifier::Impl
 struct Tools::Emb_RensponseTimingVerifier::Impl
 {
     embot::tools::RoundTripValidator m_roundTripVal;
-
+    std::string name;
 
     Impl()
     {
     }
 
-    bool init(double desiredResponseTime, double tolerance, double min, double max, double step, double reportPeriod)
+    bool init(double desiredResponseTime, double tolerance, double min, double max, double step, double reportPeriod, const std::string& name = {})
     {
 
         // now transform each parameter expressed in seconds to microseconds
@@ -100,7 +100,7 @@ struct Tools::Emb_RensponseTimingVerifier::Impl
         uint64_t max_us=max*1000000;
         uint32_t step_us=step*1000000;
         uint64_t reportPeriod_us=reportPeriod*1000000;
-        
+        this->name = name;
         return m_roundTripVal.init({desiredResponseTime_us, desiredResponseTime_us+tolerance_us, reportPeriod_us,  
                                    {min_us, max_us, step_us}}); 
     }
@@ -120,14 +120,14 @@ struct Tools::Emb_RensponseTimingVerifier::Impl
             m_roundTripVal.histogram()->probabilitydensityfunction(vect_prob);
             uint32_t min = m_roundTripVal.histogram()->getconfig()->min;
             uint32_t step = m_roundTripVal.histogram()->getconfig()->step;
-            yInfo() << "---------- PRINT HISTO GETPID ---------------";
+            yInfo() << "---------- PRINT HISTO" << name << "---------------";
             for(int i=0; i<vect_prob.size(); i++)
             {
                 if(vect_prob[i]==0)
                     continue;
                 yInfo() << "-- histo PID [" << min+step*i << "]="<< vect_prob[i];
             }
-            yInfo() << "---------- END PRINT HISTO GETPID ---------------";
+            yInfo() << "---------- END PRINT HISTO" << name << "---------------";
             m_roundTripVal.reset();
         }
     }
@@ -149,9 +149,9 @@ Tools::Emb_PeriodicEventVerifier::~Emb_PeriodicEventVerifier()
 }
 
 
-bool Tools::Emb_PeriodicEventVerifier::init(double period, double tolerance, double min, double max, double step, double reportPeriod)
+bool Tools::Emb_PeriodicEventVerifier::init(double period, double tolerance, double min, double max, double step, double reportPeriod, const std::string& name)
 {
-   return pImpl->init(period, tolerance, min, max, step, reportPeriod);
+   return pImpl->init(period, tolerance, min, max, step, reportPeriod, name);
 }
 
 void Tools::Emb_PeriodicEventVerifier::tick(double currentTime)
@@ -169,9 +169,9 @@ Tools::Emb_RensponseTimingVerifier::~Emb_RensponseTimingVerifier()
 }
 
 
-bool Tools::Emb_RensponseTimingVerifier::init(double desiredResponseTime, double tolerance, double min, double max, double step, double reportPeriod)
+bool Tools::Emb_RensponseTimingVerifier::init(double desiredResponseTime, double tolerance, double min, double max, double step, double reportPeriod, const std::string& name)
 {
-    return pImpl->init(desiredResponseTime, tolerance, min, max, step, reportPeriod);
+    return pImpl->init(desiredResponseTime, tolerance, min, max, step, reportPeriod, name);
 }
 
 


### PR DESCRIPTION
Alongside with @vvasco, we fixed the tools inside the embObjLib for test network performance.

In details:
- we updated the cmake file: now the option `NETWORK_PERFORMANCE_BENCHMARK`, that enables the tool, works properly.
- we fixed `Emb_PeriodicEventVerifier`: now it uses the correct measure units.
- we fixed a bug about the casting from int to double.
- we updated the print histogram function.

We already used these changes to test the network performance on a robot. All is fine.