### PR TITLE
Replace `controlboardwrapper2` w/ `controlBoard_nws_yarp`

### DIFF
--- a/app/simConfig/conf/Sim_head.ini
+++ b/app/simConfig/conf/Sim_head.ini
@@ -1,15 +1,14 @@
 /// initialization file for the head of the iCub Simulation
 
-device controlboardwrapper2
+device controlBoard_nws_yarp
 subdevice simulationcontrol
 name /head
-rate 100
+period 0.02
 
 [GENERAL]
 Type 3
 TotalJoints 6 //total number of joints....
 
-AxisMap 0 1 2 3 4 5   
 Vel 20.0
 Zeros 0.0 0.0 0.0 0.0 0.0 0.0 
 Encoder 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533

--- a/app/simConfig/conf/Sim_left_arm.ini
+++ b/app/simConfig/conf/Sim_left_arm.ini
@@ -1,15 +1,14 @@
 /// initialization file for the left arm of the iCub Simulation
 
-device controlboardwrapper2
+device controlBoard_nws_yarp
 subdevice simulationcontrol
 name /left_arm
-rate 100
+period 0.02
 
 [GENERAL]
 Type 1 /// 1 is for the left arm  ///2 is for the right....
 TotalJoints 16 //total number of joints....
 
-AxisMap 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 
 Vel 20.0
 Zeros 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
 Encoder 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533

--- a/app/simConfig/conf/Sim_left_leg.ini
+++ b/app/simConfig/conf/Sim_left_leg.ini
@@ -1,15 +1,14 @@
 /// initialization file for the head of the iCub Simulation
 
-device controlboardwrapper2
+device controlBoard_nws_yarp
 subdevice simulationcontrol
 name /left_leg
-rate 100
+period 0.02
 
 [GENERAL]
 Type 4
 TotalJoints 6 //total number of joints....
 
-AxisMap 0 1 2 3 4 5   
 Vel 20.0
 Zeros 0.0 0.0 0.0 0.0 0.0 0.0 
 Encoder 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533

--- a/app/simConfig/conf/Sim_right_arm.ini
+++ b/app/simConfig/conf/Sim_right_arm.ini
@@ -1,15 +1,14 @@
 /// initialization file for the right arm of the iCub Simulation
 
-device controlboardwrapper2
+device controlBoard_nws_yarp
 subdevice simulationcontrol
 name /right_arm
-rate 100
+period 0.02
 
 [GENERAL]
 Type 2 /// 1 is for the left arm  ///2 is for the right....
 TotalJoints 16 //total number of joints....
 
-AxisMap 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 
 Vel 20.0
 Zeros 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
 Encoder 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533

--- a/app/simConfig/conf/Sim_right_leg.ini
+++ b/app/simConfig/conf/Sim_right_leg.ini
@@ -1,15 +1,14 @@
 /// initialization file for the head of the iCub Simulation
 
-device controlboardwrapper2
+device controlBoard_nws_yarp
 subdevice simulationcontrol
 name /right_leg
-rate 100
+period 0.02
 
 [GENERAL]
 Type 5
 TotalJoints 6 //total number of joints....
 
-AxisMap 0 1 2 3 4 5   
 Vel 20.0
 Zeros 0.0 0.0 0.0 0.0 0.0 0.0 
 Encoder 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533 0.0174533

--- a/app/simConfig/conf/Sim_torso.ini
+++ b/app/simConfig/conf/Sim_torso.ini
@@ -1,15 +1,14 @@
 /// initialization file for the head of the iCub Simulation
 
-device controlboardwrapper2
+device controlBoard_nws_yarp
 subdevice simulationcontrol
 name /torso
-rate 100
+period 0.02
 
 [GENERAL]
 Type 6
 TotalJoints 3 //total number of joints....
 
-AxisMap 0 1 2    
 Vel 20.0
 Zeros 0.0 0.0 0.0 
 Encoder 0.0174533 0.0174533 0.0174533

--- a/src/libraries/icubmod/canBusMotionControl/CMakeLists.txt
+++ b/src/libraries/icubmod/canBusMotionControl/CMakeLists.txt
@@ -2,12 +2,11 @@
 # Authors: Lorenzo Natale
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-
 yarp_prepare_plugin(canmotioncontrol
     CATEGORY device
     TYPE yarp::dev::CanBusMotionControl
     INCLUDE CanBusMotionControl.h
-    EXTRA_CONFIG WRAPPER=controlboardwrapper2)
+    EXTRA_CONFIG WRAPPER=controlBoard_nws_yarp)
 
 if (ENABLE_icubmod_canmotioncontrol)
 

--- a/src/libraries/icubmod/embObjMotionControl/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjMotionControl/CMakeLists.txt
@@ -6,7 +6,7 @@ yarp_prepare_plugin(embObjMotionControl
     CATEGORY device
     TYPE yarp::dev::embObjMotionControl
     INCLUDE embObjMotionControl.h
-    EXTRA_CONFIG WRAPPER=controlboardwrapper2)
+    EXTRA_CONFIG WRAPPER=controlBoard_nws_yarp)
 
  IF (NOT SKIP_embObjMotionControl)
 

--- a/src/simulators/iCubSimulation/wrapper/SimulatorModule.cpp
+++ b/src/simulators/iCubSimulation/wrapper/SimulatorModule.cpp
@@ -436,7 +436,7 @@ bool SimulatorModule::initSimulatorModule()
         //start left arm device driver
         iCubLArm = createPart("left_arm");
         desc.device_name = moduleName+"/left_arm";
-        desc.device_type = "controlboardwrapper2";
+        desc.device_type = "controlBoard_nws_yarp";
         if (idesc) idesc->registerDevice(desc);
     }
 
@@ -444,7 +444,7 @@ bool SimulatorModule::initSimulatorModule()
         //start right arm device driver
         iCubRArm = createPart("right_arm");
         desc.device_name = moduleName + "/right_arm";
-        desc.device_type = "controlboardwrapper2";
+        desc.device_type = "controlBoard_nws_yarp";
         if (idesc) idesc->registerDevice(desc);
     }
 
@@ -452,7 +452,7 @@ bool SimulatorModule::initSimulatorModule()
         //start head device driver
         iCubHead = createPart("head");
         desc.device_name = moduleName + "/head";
-        desc.device_type = "controlboardwrapper2";
+        desc.device_type = "controlBoard_nws_yarp";
         if (idesc) idesc->registerDevice(desc);
     }
 
@@ -460,7 +460,7 @@ bool SimulatorModule::initSimulatorModule()
         //start left leg device driver
         iCubLLeg = createPart("left_leg");
         desc.device_name = moduleName + "/left_leg";
-        desc.device_type = "controlboardwrapper2";
+        desc.device_type = "controlBoard_nws_yarp";
         if (idesc) idesc->registerDevice(desc);
     }
 
@@ -468,14 +468,14 @@ bool SimulatorModule::initSimulatorModule()
         //start right leg device driver
         iCubRLeg = createPart("right_leg");
         desc.device_name = moduleName + "/right_leg";
-        desc.device_type = "controlboardwrapper2";
+        desc.device_type = "controlBoard_nws_yarp";
         if (idesc) idesc->registerDevice(desc);
     }
     if (robot_flags.actTorso) {
         //start torso device driver
         iCubTorso = createPart("torso");
         desc.device_name = moduleName + "/torso";
-        desc.device_type = "controlboardwrapper2";
+        desc.device_type = "controlBoard_nws_yarp";
         if (idesc) idesc->registerDevice(desc);
     }
 

--- a/src/simulators/iCubSimulation/wrapper/iCubSimulationControl.cpp
+++ b/src/simulators/iCubSimulation/wrapper/iCubSimulationControl.cpp
@@ -186,15 +186,9 @@ bool iCubSimulationControl::open(yarp::os::Searchable& config) {
     /*   GENERAL           */
     ///////////////////////// 
 
-    Bottle& xtmp = p.findGroup("GENERAL").findGroup("AxisMap","a list of reordered indices for the axes");
-    
-    if (xtmp.size() != njoints+1) {
-        yError("AxisMap does not have the right number of entries\n");
-        return false;
-    }
-    for (int i = 1; i < xtmp.size(); i++) axisMap[i-1] = xtmp.get(i).asInt32();
+    for (int i = 0; i < njoints; i++) axisMap[i] = i;
 
-    xtmp = p.findGroup("GENERAL").findGroup("Encoder","a list of scales for the encoders");
+    Bottle& xtmp = p.findGroup("GENERAL").findGroup("Encoder","a list of scales for the encoders");
     if (xtmp.size() != njoints+1) {
         yError("Encoder does not have the right number of entries\n");
         return false;


### PR DESCRIPTION
This PR aims to remove some leftovers after the `controlboardwrapper2` has been declared deprecated in https://github.com/robotology/yarp/pull/2834. The new intended device is thus`controlBoard_nws_yarp`.

In particular, `controlBoard_nws_yarp` does not handle the remapping of the joints as it leverages a specific device for that; instead, the old `controlboardwrapper2` was capable of doing remapping as well. As a result, `controlBoard_nws_yarp` does not consider the option `AxisMap`.

Main components affected:
- `iCub_SIM` (is deprecated in favor of Gazebo but it still remains a nice-to-have)
- `canBusMotionControl`
- `embObjMotionControl`

### `iCub_SIM`
- `AxisMap` completely removed w/o problems as no remapping was performed at all.
- Still need to verify the interaction between `robotDescriptionServer` and `controlBoard_nws_yarp`.
- Still to be tested.

### `canBusMotionControl`, `embObjMotionControl`
- Still handle some `AxisMap` options.
