### PR TITLE
Create packages only upon manual trigger

### DIFF
--- a/.github/workflows/packages_creation.yml
+++ b/.github/workflows/packages_creation.yml
@@ -13,14 +13,14 @@ jobs:
     - uses: actions/checkout@main
     - run: git fetch --prune --unshallow
 
-    - name: Get Latest Tag
-      id: get_latest_tag
-      uses: WyriHaximus/github-action-get-previous-tag@0.2.0
+    - name: Get Latest Release Info
+      id: latest_release_info
+      uses: jossef/action-latest-release-info@v1.2.0
 
     - name: create version file
       shell: bash
       run: |
-        export ICUB_PACKAGE_VERSION=$( echo ${{ steps.get_latest_tag.outputs.tag }} | sed 's/^v//' )
+        export ICUB_PACKAGE_VERSION=$( echo ${{ steps.latest_release_info.outputs.tag_name }} | sed 's/^v//' )
         echo $ICUB_PACKAGE_VERSION > ICUB_PACKAGE_VERSION.txt
 
     - name: upload url file
@@ -83,7 +83,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ github.event.release.upload_url }}
+        upload_url: ${{ steps.latest_release_info.outputs.upload_url }}
         asset_path: ./${{ steps.package_generation_icub-common.outputs.ICUB_COMMON_PACKAGE_NAME }}
         asset_name: ${{ steps.package_generation_icub-common.outputs.ICUB_COMMON_PACKAGE_NAME }}
         asset_content_type: application/vnd.debian.binary-package
@@ -92,7 +92,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ github.event.release.upload_url }}
+        upload_url: ${{ steps.latest_release_info.outputs.upload_url }}
         asset_path: ./${{ steps.package_generation_icub-main.outputs.ICUB_MAIN_PACKAGE_NAME }}
         asset_name: ${{ steps.package_generation_icub-main.outputs.ICUB_MAIN_PACKAGE_NAME }}
         asset_content_type: application/vnd.debian.binary-package


### PR DESCRIPTION
This PR separates clearly the process of generating a new release from that of generating packages, as the two workflows fall under different accountabilities.