### PR TITLE
Enable CI for `embObjBattery` + fix deps on `YARP`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
               -DENABLE_icubmod_canBusInertialMTB:BOOL=ON -DENABLE_icubmod_canBusSkin:BOOL=ON \
               -DENABLE_icubmod_canBusVirtualAnalogSensor:BOOL=ON -DENABLE_icubmod_embObjFTsensor:BOOL=ON \
               -DENABLE_icubmod_embObjIMU:BOOL=ON -DENABLE_icubmod_embObjInertials:BOOL=ON \
-              -DENABLE_icubmod_embObjMais:BOOL=ON -DENABLE_icubmod_embObjMotionControl:BOOL=ON \
+              -DENABLE_icubmod_embObjMais:BOOL=ON -DENABLE_icubmod_embObjMotionControl:BOOL=ON -DENABLE_icubmod_embObjBattery:BOOL=ON \
               -DENABLE_icubmod_embObjSkin:BOOL=ON -DENABLE_icubmod_embObjStrain:BOOL=ON -DENABLE_icubmod_embObjMultipleFTsensors:BOOL=ON \
               -DENABLE_icubmod_parametricCalibrator:BOOL=ON -DENABLE_icubmod_parametricCalibratorEth:BOOL=ON \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
@@ -152,7 +152,7 @@ jobs:
               -DENABLE_icubmod_canBusInertialMTB:BOOL=ON -DENABLE_icubmod_canBusSkin:BOOL=ON \
               -DENABLE_icubmod_canBusVirtualAnalogSensor:BOOL=ON -DENABLE_icubmod_embObjFTsensor:BOOL=ON \
               -DENABLE_icubmod_embObjIMU:BOOL=ON -DENABLE_icubmod_embObjInertials:BOOL=ON \
-              -DENABLE_icubmod_embObjMais:BOOL=ON -DENABLE_icubmod_embObjMotionControl:BOOL=ON \
+              -DENABLE_icubmod_embObjMais:BOOL=ON -DENABLE_icubmod_embObjMotionControl:BOOL=ON -DENABLE_icubmod_embObjBattery:BOOL=ON \
               -DENABLE_icubmod_embObjSkin:BOOL=ON -DENABLE_icubmod_embObjStrain:BOOL=ON -DENABLE_icubmod_embObjMultipleFTsensors:BOOL=ON \
               -DENABLE_icubmod_parametricCalibrator:BOOL=ON -DENABLE_icubmod_parametricCalibratorEth:BOOL=ON \
               -DBUILD_TESTING:BOOL=ON \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,17 +126,30 @@ jobs:
         mkdir -p build
         cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
-              -DICUB_USE_icub_firmware_shared:BOOL=ON -DENABLE_icubmod_serial:BOOL=ON \
-              -DENABLE_icubmod_serialport:BOOL=ON -DENABLE_icubmod_skinWrapper:BOOL=ON \
-              -DENABLE_icubmod_portaudio:BOOL=ON -DENABLE_icubmod_sharedcan:BOOL=ON \
-              -DENABLE_icubmod_canmotioncontrol:BOOL=ON -DENABLE_icubmod_canBusAnalogSensor:BOOL=ON \
-              -DENABLE_icubmod_canBusInertialMTB:BOOL=ON -DENABLE_icubmod_canBusSkin:BOOL=ON \
-              -DENABLE_icubmod_canBusVirtualAnalogSensor:BOOL=ON -DENABLE_icubmod_embObjFTsensor:BOOL=ON \
-              -DENABLE_icubmod_embObjIMU:BOOL=ON -DENABLE_icubmod_embObjInertials:BOOL=ON \
-              -DENABLE_icubmod_embObjMais:BOOL=ON -DENABLE_icubmod_embObjMotionControl:BOOL=ON -DENABLE_icubmod_embObjBattery:BOOL=ON \
-              -DENABLE_icubmod_embObjSkin:BOOL=ON -DENABLE_icubmod_embObjStrain:BOOL=ON -DENABLE_icubmod_embObjMultipleFTsensors:BOOL=ON \
-              -DENABLE_icubmod_parametricCalibrator:BOOL=ON -DENABLE_icubmod_parametricCalibratorEth:BOOL=ON \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+              -DICUB_USE_icub_firmware_shared:BOOL=ON \
+              -DENABLE_icubmod_serial:BOOL=ON \
+              -DENABLE_icubmod_serialport:BOOL=ON \
+              -DENABLE_icubmod_skinWrapper:BOOL=ON \
+              -DENABLE_icubmod_portaudio:BOOL=ON \
+              -DENABLE_icubmod_sharedcan:BOOL=ON \
+              -DENABLE_icubmod_canmotioncontrol:BOOL=ON \
+              -DENABLE_icubmod_canBusAnalogSensor:BOOL=ON \
+              -DENABLE_icubmod_canBusInertialMTB:BOOL=ON \
+              -DENABLE_icubmod_canBusSkin:BOOL=ON \
+              -DENABLE_icubmod_canBusVirtualAnalogSensor:BOOL=ON \
+              -DENABLE_icubmod_embObjFTsensor:BOOL=ON \
+              -DENABLE_icubmod_embObjIMU:BOOL=ON \
+              -DENABLE_icubmod_embObjInertials:BOOL=ON \
+              -DENABLE_icubmod_embObjMais:BOOL=ON \
+              -DENABLE_icubmod_embObjMotionControl:BOOL=ON \
+              -DENABLE_icubmod_embObjBattery:BOOL=ON \
+              -DENABLE_icubmod_embObjSkin:BOOL=ON \
+              -DENABLE_icubmod_embObjStrain:BOOL=ON \
+              -DENABLE_icubmod_embObjMultipleFTsensors:BOOL=ON \
+              -DENABLE_icubmod_parametricCalibrator:BOOL=ON \
+              -DENABLE_icubmod_parametricCalibratorEth:BOOL=ON \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 
     - name: Configure [Ubuntu/macOS]
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
@@ -145,16 +158,28 @@ jobs:
         mkdir -p build
         cd build
         cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-              -DICUB_USE_icub_firmware_shared:BOOL=ON -DENABLE_icubmod_serial:BOOL=ON \
-              -DENABLE_icubmod_serialport:BOOL=ON -DENABLE_icubmod_skinWrapper:BOOL=ON \
-              -DENABLE_icubmod_portaudio:BOOL=ON -DENABLE_icubmod_sharedcan:BOOL=ON \
-              -DENABLE_icubmod_canmotioncontrol:BOOL=ON -DENABLE_icubmod_canBusAnalogSensor:BOOL=ON \
-              -DENABLE_icubmod_canBusInertialMTB:BOOL=ON -DENABLE_icubmod_canBusSkin:BOOL=ON \
-              -DENABLE_icubmod_canBusVirtualAnalogSensor:BOOL=ON -DENABLE_icubmod_embObjFTsensor:BOOL=ON \
-              -DENABLE_icubmod_embObjIMU:BOOL=ON -DENABLE_icubmod_embObjInertials:BOOL=ON \
-              -DENABLE_icubmod_embObjMais:BOOL=ON -DENABLE_icubmod_embObjMotionControl:BOOL=ON -DENABLE_icubmod_embObjBattery:BOOL=ON \
-              -DENABLE_icubmod_embObjSkin:BOOL=ON -DENABLE_icubmod_embObjStrain:BOOL=ON -DENABLE_icubmod_embObjMultipleFTsensors:BOOL=ON \
-              -DENABLE_icubmod_parametricCalibrator:BOOL=ON -DENABLE_icubmod_parametricCalibratorEth:BOOL=ON \
+              -DICUB_USE_icub_firmware_shared:BOOL=ON \
+              -DENABLE_icubmod_serial:BOOL=ON \
+              -DENABLE_icubmod_serialport:BOOL=ON \
+              -DENABLE_icubmod_skinWrapper:BOOL=ON \
+              -DENABLE_icubmod_portaudio:BOOL=ON \
+              -DENABLE_icubmod_sharedcan:BOOL=ON \
+              -DENABLE_icubmod_canmotioncontrol:BOOL=ON \
+              -DENABLE_icubmod_canBusAnalogSensor:BOOL=ON \
+              -DENABLE_icubmod_canBusInertialMTB:BOOL=ON \
+              -DENABLE_icubmod_canBusSkin:BOOL=ON \
+              -DENABLE_icubmod_canBusVirtualAnalogSensor:BOOL=ON \
+              -DENABLE_icubmod_embObjFTsensor:BOOL=ON \
+              -DENABLE_icubmod_embObjIMU:BOOL=ON \
+              -DENABLE_icubmod_embObjInertials:BOOL=ON \
+              -DENABLE_icubmod_embObjMais:BOOL=ON \
+              -DENABLE_icubmod_embObjMotionControl:BOOL=ON \
+              -DENABLE_icubmod_embObjBattery:BOOL=ON \
+              -DENABLE_icubmod_embObjSkin:BOOL=ON \
+              -DENABLE_icubmod_embObjStrain:BOOL=ON \
+              -DENABLE_icubmod_embObjMultipleFTsensors:BOOL=ON \
+              -DENABLE_icubmod_parametricCalibrator:BOOL=ON \
+              -DENABLE_icubmod_parametricCalibratorEth:BOOL=ON \
               -DBUILD_TESTING:BOOL=ON \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 

--- a/src/libraries/icubmod/embObjBattery/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjBattery/CMakeLists.txt
@@ -9,7 +9,7 @@ yarp_prepare_plugin(embObjBattery CATEGORY device
                                  INCLUDE embObjBattery.h
                                  EXTRA_CONFIG WRAPPER=analogServer)
 
-IF (NOT SKIP_embObjCanBatterysensor)
+IF (NOT SKIP_embObjBattery)
 
 
   set(ICUB_COMPILE_EMBOBJ_LIBRARY ON CACHE INTERNAL "use the embObjLib lib")
@@ -35,6 +35,6 @@ IF (NOT SKIP_embObjCanBatterysensor)
                                         
    target_include_directories(embObjBatteryUT PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
   endif()
-
-ENDIF (NOT SKIP_embObjCanBatterysensor)
+  
+ENDIF(NOT SKIP_embObjBattery)
 

--- a/src/libraries/icubmod/embObjBattery/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjBattery/CMakeLists.txt
@@ -9,16 +9,17 @@ yarp_prepare_plugin(embObjBattery CATEGORY device
                                  INCLUDE embObjBattery.h
                                  EXTRA_CONFIG WRAPPER=analogServer)
 
-IF (NOT SKIP_embObjBattery)
+if (NOT SKIP_embObjBattery)
 
 
   set(ICUB_COMPILE_EMBOBJ_LIBRARY ON CACHE INTERNAL "use the embObjLib lib")
 
 
-  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
   yarp_add_plugin(embObjBattery embObjBattery.cpp embObjBattery.h)
-  TARGET_LINK_LIBRARIES(embObjBattery ethResources)
+  target_link_libraries(embObjBattery ethResources
+                        YARP::YARP_os YARP::YARP_dev YARP::YARP_sig)
   icub_export_plugin(embObjBattery)
 
   yarp_install(TARGETS embObjBattery
@@ -28,13 +29,13 @@ IF (NOT SKIP_embObjBattery)
         YARP_INI DESTINATION ${ICUB_PLUGIN_MANIFESTS_INSTALL_DIR})
 
   if (BUILD_TESTING)
-   add_library(embObjBatteryUT STATIC embObjBattery.cpp embObjBattery.h)    
-   target_link_libraries(embObjBatteryUT ethResources
-                                    YARP::YARP_dev
-                                    icub_firmware_shared::embobj)
+   add_library(embObjBatteryUT STATIC embObjBattery.cpp embObjBattery.h)
+    target_link_libraries(embObjBatteryUT ethResources
+                          YARP::YARP_os YARP::YARP_dev YARP::YARP_sig
+                          icub_firmware_shared::embobj)
                                         
    target_include_directories(embObjBatteryUT PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
   endif()
   
-ENDIF(NOT SKIP_embObjBattery)
+endif()
 

--- a/src/libraries/icubmod/embObjMultipleFTsensors/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjMultipleFTsensors/CMakeLists.txt
@@ -9,16 +9,17 @@ yarp_prepare_plugin(embObjMultipleFTsensors CATEGORY device
                                  INCLUDE embObjMultipleFTsensors.h
                                  EXTRA_CONFIG WRAPPER=analogServer)
 
-IF (NOT SKIP_embObjMultipleFTsensors)
+if (NOT SKIP_embObjMultipleFTsensors)
 
 
   set(ICUB_COMPILE_EMBOBJ_LIBRARY ON CACHE INTERNAL "use the embObjLib lib")
 
 
-  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
   yarp_add_plugin(embObjMultipleFTsensors embObjMultipleFTsensors.cpp embObjMultipleFTsensors.h)
-  TARGET_LINK_LIBRARIES(embObjMultipleFTsensors ethResources)
+  target_link_libraries(embObjMultipleFTsensors ethResources
+                        YARP::YARP_os YARP::YARP_dev YARP::YARP_sig)
   icub_export_plugin(embObjMultipleFTsensors)
 
   yarp_install(TARGETS embObjMultipleFTsensors
@@ -28,13 +29,13 @@ IF (NOT SKIP_embObjMultipleFTsensors)
         YARP_INI DESTINATION ${ICUB_PLUGIN_MANIFESTS_INSTALL_DIR})
 
   if (BUILD_TESTING)
-   add_library(embObjMultipleFTsensorsUT STATIC embObjMultipleFTsensors.cpp embObjMultipleFTsensors.h)    
-   target_link_libraries(embObjMultipleFTsensorsUT ethResources
-                                    YARP::YARP_dev
-                                    icub_firmware_shared::embobj)
+   add_library(embObjMultipleFTsensorsUT STATIC embObjMultipleFTsensors.cpp embObjMultipleFTsensors.h)
+    target_link_libraries(embObjMultipleFTsensorsUT ethResources
+                          YARP::YARP_os YARP::YARP_dev YARP::YARP_sig
+                          icub_firmware_shared::embobj)
                                         
    target_include_directories(embObjMultipleFTsensorsUT PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
   endif()
 
-ENDIF (NOT SKIP_embObjMultipleFTsensors)
+endif()
 


### PR DESCRIPTION
This PR enables the CI for `embObjBattery`, which was off apparently for #793.

cc @triccyx 