### PR TITLE
Fixed `embObjMultipleFTsensors`: now temperature is published in Celsius degrees

### DIFF
--- a/src/libraries/icubmod/embObjMultipleFTsensors/embObjMultipleFTsensors.cpp
+++ b/src/libraries/icubmod/embObjMultipleFTsensors/embObjMultipleFTsensors.cpp
@@ -370,7 +370,7 @@ bool embObjMultipleFTsensors::getTemperatureSensorMeasure(size_t sensorIndex, do
         return false;
     }
 
-    out = temperaturesensordata_.at(sensorIndex).data_;
+    out = 0.1 * temperaturesensordata_.at(sensorIndex).data_;
     timestamp = temperaturesensordata_.at(sensorIndex).timeStamp_;
     return true;
 }


### PR DESCRIPTION
This PR fixes a bug in `embObjMultipleFTsensors` where temperature was wrongly displayed.

For instance, a value of 31 degrees was published as 310.

Now the temperature is correctly published in Celsius degrees.