### PR TITLE
Update `serviceParser` + `eomcParser` + `embObjMotionControl` to support `amcbldc` boards in xml files

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -72,8 +72,8 @@ checkandset_dependency(Qt5)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
   # icub-firmware-shared 4.0.7 was actually a wrong version exported by icub-firmware-shared <= 1.15
-  if(icub_firmware_shared_VERSION VERSION_GREATER 4 OR icub_firmware_shared_VERSION VERSION_LESS 1.27.1)
-    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected, but at least 1.27.1 is required")
+  if(icub_firmware_shared_VERSION VERSION_GREATER 4 OR icub_firmware_shared_VERSION VERSION_LESS 1.28.1)
+    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected, but at least 1.28.1 is required")
   endif()
 endif()
 

--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -72,8 +72,8 @@ checkandset_dependency(Qt5)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
   # icub-firmware-shared 4.0.7 was actually a wrong version exported by icub-firmware-shared <= 1.15
-  if(icub_firmware_shared_VERSION VERSION_GREATER 4 OR icub_firmware_shared_VERSION VERSION_LESS 1.28.1)
-    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected, but at least 1.28.1 is required")
+  if(icub_firmware_shared_VERSION VERSION_GREATER 4 OR icub_firmware_shared_VERSION VERSION_LESS 1.28.0)
+    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected, but at least 1.28.0 is required")
   endif()
 endif()
 

--- a/src/libraries/icubmod/embObjLib/serviceParser.cpp
+++ b/src/libraries/icubmod/embObjLib/serviceParser.cpp
@@ -3482,12 +3482,6 @@ bool ServiceParser::check_motion(Searchable &config)
                 yError() << "ServiceParser::check_motion() PROPERTIES.JOINTMAPPING.encoder2.type not valid for item" << i;
                 return false;
             }
-//             //VALE: workaround to solve problem of configuration of encoder connected to 2foc board.
-//             if((eomn_serv_MC_foc == mc_service.type) &&  (eomc_enc_roie == enctype))
-//             {
-//                 enctype = eomc_enc_none;
-//             }
-
 
             enc2.desc.type = enctype;
 
@@ -3506,15 +3500,6 @@ bool ServiceParser::check_motion(Searchable &config)
                     yError() << "ServiceParser::check_motion() PROPERTIES.JOINTMAPPING.encoder2.position not valid for item" << i;
                 return false;
             }
-//              //VALE: workaround to solve problem of configuration of encoder connected to 2foc board.
-//             if((eomn_serv_MC_foc == mc_service.type) &&  (eomc_enc_roie == enctype))
-//             {
-//                  enc2.desc.pos = eomc_pos_none;
-//             }
-//             else
-//             {
-//                  enc2.desc.pos = encposition;
-//             }
 
             enc2.desc.pos = encposition;
 
@@ -3732,6 +3717,9 @@ bool ServiceParser::parseService(Searchable &config, servConfigMC_t &mcconfig)
             data_mc->version.firmware.build = mc_service.properties.canboards.at(0).firmware.build;
             data_mc->version.protocol.major = mc_service.properties.canboards.at(0).protocol.major;
             data_mc->version.protocol.minor = mc_service.properties.canboards.at(0).protocol.minor;
+
+            // we assume that all can boards have the same type for each joint
+            data_mc->type = mc_service.properties.canboards.at(0).type;
 
             // 2. ->arrayofjomodescriptors
             EOarray *arrayofjomos = eo_array_New(4, sizeof(eOmc_jomo_descriptor_t), &data_mc->arrayofjomodescriptors);

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -207,7 +207,7 @@ private:
     double *                                _deadzone;
     std::vector<eomc::kalmanFilterParams_t> _kalman_params;  /** Kalman filter parameters */
 
-    eomc::twofocSpecificInfo_t *            _twofocinfo;
+    eomc::focBasedSpecificInfo_t *            _foc_based_info;
 
     std::vector<eomc::encoder_t>            _jointEncs;
     std::vector<eomc::encoder_t>            _motorEncs;
@@ -294,7 +294,6 @@ private:
     bool isVelocityControlEnabled(int joint);
 
     bool iNeedCouplingsInfo(void); //the device needs coupling info if it manages joints controlled by 2foc and mc4plus.
-    bool iMange2focBoards(void);
 
     bool getJointConfiguration(int joint, eOmc_joint_config_t *jntCfg_ptr);
     bool getMotorConfiguration(int axis, eOmc_motor_config_t *motCfg_ptr);

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.h
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.h
@@ -212,7 +212,7 @@ typedef struct
     int  motorPoles;
     bool hasSpeedEncoder ; //facoltativo
     bool verbose;
-} twofocSpecificInfo_t;
+} focBasedSpecificInfo_t;
 
 
 class JointsSet
@@ -418,7 +418,7 @@ public:
     ~Parser();
 
     bool parsePids(yarp::os::Searchable &config, PidInfo *ppids/*, PidInfo *vpids*/, TrqPidInfo *tpids, PidInfo *cpids, PidInfo *spids, bool lowLevPidisMandatory);
-    bool parse2FocGroup(yarp::os::Searchable &config, twofocSpecificInfo_t *twofocinfo);
+    bool parseFocGroup(yarp::os::Searchable &config, focBasedSpecificInfo_t *foc_based_info, std::string groupName);
     //bool parseCurrentPid(yarp::os::Searchable &config, PidInfo *cpids);//deprecated
     bool parseJointsetCfgGroup(yarp::os::Searchable &config, std::vector<JointsSet> &jsets, std::vector<int> &jointtoset);
     bool parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeouts_t> &timeouts, int defaultVelocityTimeout);


### PR DESCRIPTION
What's new:

- the `parse2FocGroup` has been renamed to `parseFocGroup` and it has been extended to include the `groupName` param valid for either `2FOC` and `AMCBLDC`
- rename `twofocinfo` to `foc_based_info` to be compliant with the meaning of `foc-based`
- removed unused `iMange2focBoards` function
- save the board type in `ServiceParser::parseService`
- minor cleanup of some old comments

**Notes**
- tested on `lego-setup`

cc @pattacini @valegagge @ale-git @mfussi66 