### PR TITLE
Extend path using `GITHUB_PATH` in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ on:
   - cron:  '0 2 * * *'
   workflow_dispatch:
 
-env:
-  PATH_EXTENDED: ${{ github.workspace }}/install/bin:${{ github.workspace }}/install/lib/yarp
-
 jobs:
   build:
     name: '[${{ matrix.os }}@${{ matrix.build_type }}]'
@@ -198,26 +195,29 @@ jobs:
         # Enable ICUB_COMPILE_BINDINGS in Ubuntu
         cmake -DICUB_COMPILE_BINDINGS:BOOL=ON -DCREATE_PYTHON:BOOL=ON .
 
+    - name: Extend Path
+      shell: bash
+      run: |
+        echo "${{ github.workspace }}/install/bin" >> $GITHUB_PATH
+        echo "${{ github.workspace }}/install/lib/yarp" >> $GITHUB_PATH
+        # Fix for using YARP idl generators (that link ACE) in Windows (https://github.com/robotology/idyntree/issues/569)
+        echo "${VCPKG_INSTALLATION_ROOT}/installed/x64-windows/bin" >> $GITHUB_PATH
+
     - name: Build
       shell: bash
       run: |
         cd build
-        # Fix for using YARP idl generators (that link ACE) in Windows
-        # See https://github.com/robotology/idyntree/issues/569 for more details
-        export PATH=${PATH}:${GITHUB_WORKSPACE}/install/bin:${VCPKG_INSTALLATION_ROOT}/installed/x64-windows/bin
         cmake --build . --config ${{ matrix.build_type }}
 
     - name: Install
       shell: bash
       run: |
         cd build
-        export PATH=${PATH}:${PATH_EXTENDED}
         cmake --build . --config ${{ matrix.build_type }} --target install
 
     - name: Test
       shell: bash
       run: |
         cd build
-        export PATH=${PATH}:${PATH_EXTENDED}
         ctest run_unit_test --output-on-failure -C ${{ matrix.build_type }} .
 


### PR DESCRIPTION
As per the title.
See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path.