### PR TITLE
Fix handling of limbs versions in `iKin`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.12)
 
 set(ROOT_PROJECT_NAME ICUB)
 project(${ROOT_PROJECT_NAME} LANGUAGES C CXX
-                             VERSION 1.28.1)
+                             VERSION 2.0.0)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 14)

--- a/app/cartesianSolver/doc.dox
+++ b/app/cartesianSolver/doc.dox
@@ -6,11 +6,11 @@ The Cartesian Solvers Launcher.
 
 \section intro_sec Description
 This application allows the user to launch instances of the iKinCartesianSolver
-on a specific machine belonging to the cluster. Moreover the iCubInterface and
+on a specific machine belonging to the cluster. Moreover the yarprobotinterface and
 the server part of the gaze controller interface are launched as well.
 
 \section int_sec Instantiated Modules
-- \ref icub_iCubInterface
+- yarprobotinterface
 - \ref iKinCartesianSolver
 - \ref iKinGazeCtrl
 
@@ -22,7 +22,7 @@ Customize the file ./scripts/*.template for your specific platform.
 
 - ./scripts/cartesianSolver.xml.template
   launches solvers for the following parts: <i>right_arm, left_arm, right_leg, left_leg.</i>
-  as well as the iCubInterface and the iKinGazeCtrl.
+  as well as the yarprobotinterface and the iKinGazeCtrl.
 
 \author Ugo Pattacini
 

--- a/app/controlBoardDumper/doc.dox
+++ b/app/controlBoardDumper/doc.dox
@@ -8,7 +8,7 @@ voltages, currents, tracking errors).
 
 
 \section dep_sec Dependencies
-Assumes \ref icub_iCubInterface is running.
+Assumes the robot is running.
 
 \section int_sec Instantiated Modules
 - \ref icub_controlBoardDumper 

--- a/app/fingertipsPortScope/doc.dox
+++ b/app/fingertipsPortScope/doc.dox
@@ -13,8 +13,8 @@
  *
  * 
  * \section int_sec Instantiated Modules
- * - \ref yarpscope --context fingertipsPortScope --xml FingertipsPortScopeConf-LeftHandAll.xml 
- * - \ref yarpscope --context fingertipsPortScope --xml FingertipsPortScopeConf-RightHandAll.xml 
+ * - yarpscope --context fingertipsPortScope --xml FingertipsPortScopeConf-LeftHandAll.xml 
+ * - yarpscope --context fingertipsPortScope --xml FingertipsPortScopeConf-RightHandAll.xml 
  *
  * 
  * \section howto How to run the Application

--- a/app/gazeboCartesianControl/conf/iKinGazeCtrl.ini
+++ b/app/gazeboCartesianControl/conf/iKinGazeCtrl.ini
@@ -1,5 +1,5 @@
 robot                 icubSim
-head_version          2.5
+head_version          v2.5
 neck_position_control on
 saccades              off
 

--- a/app/iCubStartup/doc.dox
+++ b/app/iCubStartup/doc.dox
@@ -16,7 +16,7 @@ gaze control as well as the dynamics computed for the whole body.
 - \ref wholeBodyDynamics
 - \ref gravityCompensator
 - \ref icub_fingersTuner
-- \ref imuFilter
+- imuFilter
 
 \section howto How to run the Application
 Customize the file ./scripts/*.template for your specific platform.

--- a/app/robotScripting/doc.dox
+++ b/app/robotScripting/doc.dox
@@ -4,7 +4,7 @@
 \defgroup icub_robotscripting robotScripting
 
 This application allows performing nice preprogrammed demonstrations with the robot. It just starts
-an instance of \ref icub_ctpservice for each part. Commands will be sent from shell (but see
+an instance of \ref ctpservice for each part. Commands will be sent from shell (but see
 also the scripting.py utility in this app directory).
 
 \section dep_sec Dependencies

--- a/src/doc/main.dox
+++ b/src/doc/main.dox
@@ -32,7 +32,7 @@ Topics:
   - The <a href="http://www.robotcub.org/">RobotCub Website</a>.
   - Our software architecture, <a href="http://www.yarp.it/">YARP</a>.
 
-This page can be edited at \link src/doc/main.dox.
+This page can be edited at src/doc/main.dox.
 
 *
 */

--- a/src/libraries/actionPrimitives/CMakeLists.txt
+++ b/src/libraries/actionPrimitives/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(ICUB::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
                                                   "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
 
-target_link_libraries(${PROJECT_NAME} perceptiveModels ${YARP_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} iKin perceptiveModels ${YARP_LIBRARIES})
 
 
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/src/libraries/actionPrimitives/include/iCub/action/actionPrimitives.h
+++ b/src/libraries/actionPrimitives/include/iCub/action/actionPrimitives.h
@@ -36,7 +36,7 @@
  * provides the user a collection of action primitives in task 
  * space and joint space along with an easy way to combine them
  * together forming higher level actions (e.g. grasp(), tap(), 
- * …) in order to eventually execute more sophisticated tasks 
+ * ï¿½) in order to eventually execute more sophisticated tasks 
  * without reference to the motion control details. 
  *  
  * \image html actionPrimitives.jpg 
@@ -437,8 +437,7 @@ public:
     *  @endcode
     *  
     * @note A port called <i> /<local>/<part>/detectGrasp:i </i> is 
-    *       open to acquire data provided by \ref icub_graspDetector
-    *       module.
+    *       open to acquire data provided by graspDetector module.
     */
     virtual bool open(yarp::os::Property &opt);
 

--- a/src/libraries/actionPrimitives/src/actionPrimitives.cpp
+++ b/src/libraries/actionPrimitives/src/actionPrimitives.cpp
@@ -27,6 +27,7 @@
 #include <yarp/math/Rand.h>
 
 #include <iCub/ctrl/math.h>
+#include <iCub/iKin/iKinFwd.h>
 #include <iCub/perception/springyFingers.h>
 #include <iCub/perception/tactileFingers.h>
 #include <iCub/action/actionPrimitives.h>
@@ -57,6 +58,7 @@ using namespace yarp::dev;
 using namespace yarp::sig;
 using namespace yarp::math;
 using namespace iCub::ctrl;
+using namespace iCub::iKin;
 using namespace iCub::perception;
 using namespace iCub::action;
 
@@ -407,9 +409,9 @@ bool ActionPrimitives::handleTorsoDOF(Property &opt, const string &key)
     {
         Bottle info;
         cartCtrl->getInfo(info);
-        double hwver=info.find("arm_version").asFloat64();
+        iKinLimbVersion hwver(info.find("arm_version").asString());
         map<string,int> remap{{ACTIONPRIM_TORSO_PITCH,0},{ACTIONPRIM_TORSO_ROLL,1},{ACTIONPRIM_TORSO_YAW,2}};
-        if (hwver>=3.0)
+        if (hwver>=iKinLimbVersion("3.0"))
         {
             remap[ACTIONPRIM_TORSO_ROLL]=0;
             remap[ACTIONPRIM_TORSO_PITCH]=1;

--- a/src/libraries/iKin/include/iCub/iKin/iKinFwd.h
+++ b/src/libraries/iKin/include/iCub/iKin/iKinFwd.h
@@ -1040,12 +1040,124 @@ public:
 /**
 * \ingroup iKinFwd
 *
+* A class for defining the versions of the iCub limbs.
+*/
+class iKinLimbVersion
+{
+protected:
+    unsigned long int major;
+    unsigned long int minor;
+
+public:
+    /**
+    * Default Constructor. 
+    */
+    iKinLimbVersion();
+
+    /**
+    * Constructor. 
+    * @param version is a string for specifying different 
+    *              kinematics, e.g., "1.23".
+    */
+    iKinLimbVersion(const std::string &version);
+
+    /**
+    * Constructor. 
+    * @param major the major version. 
+    * @param minor the mninor version. 
+    */
+    iKinLimbVersion(const unsigned long int major, const unsigned long int minor);
+
+    /**
+    * Copy Constructor. 
+    */
+    iKinLimbVersion(const iKinLimbVersion& v);
+
+    /**
+    * Return the major version.
+    * @return the major version. 
+    */
+    unsigned long int get_major() const;
+
+    /**
+    * Return the minor version.
+    * @return the minor version. 
+    */
+    unsigned long int get_minor() const;
+
+    /**
+     * Return the version string.
+     * @return the version string. 
+     */
+    std::string get_version() const;
+
+    /**
+    * Overloaded assignment operator.
+    * @param v the version to be assigned. 
+    * @return . 
+    */
+    iKinLimbVersion& operator=(const iKinLimbVersion& v);
+
+    /**
+    * Overloaded < operator.
+    * @param v the version to compare with. 
+    * @return true iff < v. 
+    */
+    bool operator<(const iKinLimbVersion& v) const;
+
+    /**
+    * Overloaded <= operator.
+    * @param v the version to compare with. 
+    * @return true iff <= v. 
+    */
+    bool operator<=(const iKinLimbVersion& v) const;
+
+    /**
+    * Overloaded == operator.
+    * @param v the version to compare with. 
+    * @return true iff == v. 
+    */
+    bool operator==(const iKinLimbVersion& v) const;
+
+     /**
+    * Overloaded != operator.
+    * @param v the version to compare with. 
+    * @return true iff != v. 
+    */
+    bool operator!=(const iKinLimbVersion& v) const;
+
+    /**
+    * Overloaded >=</=> operator.
+    * @param v the version to compare with. 
+    * @return true iff >= v. 
+    */
+    bool operator>=(const iKinLimbVersion& v) const;
+
+   /**
+    * Overloaded > operator.
+    * @param v the version to compare with. 
+    * @return true iff > v. 
+    */
+    bool operator>(const iKinLimbVersion& v) const;
+
+    /**
+    * Overloaded - operator.
+    * @param v the version to compare with. 
+    * @return the distance from v.
+    */
+    iKinLimbVersion operator-(const iKinLimbVersion& v) const;
+};
+
+
+/**
+* \ingroup iKinFwd
+*
 * A class for defining the iCub Torso.
 */
 class iCubTorso : public iKinLimb
 {
 protected:
-    double version;
+    iKinLimbVersion version;
 
     virtual void allocate(const std::string &_type);
 
@@ -1081,7 +1193,7 @@ public:
 class iCubArm : public iKinLimb
 {
 protected:
-    double version;
+    iKinLimbVersion version;
 
     virtual void allocate(const std::string &_type);
 
@@ -1236,7 +1348,7 @@ public:
 class iCubLeg : public iKinLimb
 {
 protected:
-    double version;
+    iKinLimbVersion version;
 
     virtual void allocate(const std::string &_type);
 
@@ -1273,7 +1385,7 @@ public:
 class iCubEye : public iKinLimb
 {
 protected:
-    double version;
+    iKinLimbVersion version;
 
     virtual void allocate(const std::string &_type);
 
@@ -1364,7 +1476,7 @@ public:
 class iCubInertialSensor : public iKinLimb
 {
 protected:
-    double version;
+    iKinLimbVersion version;
 
     virtual void allocate(const std::string &_type);
 
@@ -1401,7 +1513,7 @@ public:
 class iCubInertialSensorWaist : public iKinLimb
 {
 protected:
-    double version;
+    iKinLimbVersion version;
 
     virtual void allocate(const std::string &_type);
 

--- a/src/libraries/iKin/src/iKinFwd.cpp
+++ b/src/libraries/iKin/src/iKinFwd.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <cstdlib>
+#include <cstdio>
 #include <sstream>
 #include <cmath>
 #include <algorithm>
@@ -24,15 +25,6 @@ using namespace yarp::sig;
 using namespace yarp::math;
 using namespace iCub::ctrl;
 using namespace iCub::iKin;
-
-namespace iCub {
-  namespace iKin {
-    constexpr double version_epsilon = 1e-6;
-    inline bool is_version(const double v1, const double v2) {
-      return (fabs(v1 - v2) < version_epsilon);
-    }
-  }
-}
 
 
 /************************************************************************/
@@ -1551,6 +1543,134 @@ void iKinLimb::dispose()
 
 
 /************************************************************************/
+iKinLimbVersion::iKinLimbVersion() : major(0), minor(0)
+{
+}
+
+
+/************************************************************************/
+iKinLimbVersion::iKinLimbVersion(const string &version)
+{
+    size_t point=version.find('.');
+    if ((point!=string::npos) && (point!=version.length()-1))
+    {
+        major=strtoul(version.substr(0,point).c_str(),NULL,0);
+        minor=strtoul(version.substr(point+1).c_str(),NULL,0);
+    }
+    else
+    {
+        major=strtoul(version.c_str(),NULL,0);
+        minor=0U;
+    }
+}
+
+
+/************************************************************************/
+iKinLimbVersion::iKinLimbVersion(const unsigned long int major,
+                                 const unsigned long int minor)
+{
+    this->major=major;
+    this->minor=minor;
+}
+
+
+/************************************************************************/
+iKinLimbVersion::iKinLimbVersion(const iKinLimbVersion& v)
+{
+    major=v.major;
+    minor=v.minor;
+}
+
+
+/************************************************************************/
+unsigned long int iKinLimbVersion::get_major() const
+{
+    return major;
+}
+
+
+/************************************************************************/
+unsigned long int iKinLimbVersion::get_minor() const
+{
+    return minor;
+}
+
+
+/************************************************************************/
+string iKinLimbVersion::get_version() const
+{
+    ostringstream version;
+    version<<major<<"."<<minor;
+    return version.str();
+}
+
+
+/************************************************************************/
+iKinLimbVersion& iKinLimbVersion::operator=(const iKinLimbVersion& v)
+{
+    major=v.major;
+    minor=v.minor;
+    return *this;
+}
+
+
+/************************************************************************/
+bool iKinLimbVersion::operator<(const iKinLimbVersion& v) const
+{
+    if (major<v.major)
+        return true;
+    else if (major==v.major)
+        return minor<v.minor;
+    else
+        return false;
+}
+
+
+/************************************************************************/
+bool iKinLimbVersion::operator>(const iKinLimbVersion& v) const
+{
+   return !(*this<v);
+}
+
+
+/************************************************************************/
+bool iKinLimbVersion::operator==(const iKinLimbVersion& v) const
+{
+   return (major==v.major) && (minor==v.minor);
+}
+
+
+/************************************************************************/
+bool iKinLimbVersion::operator!=(const iKinLimbVersion& v) const
+{
+   return !(*this==v);
+}
+
+
+/************************************************************************/
+bool iKinLimbVersion::operator<=(const iKinLimbVersion& v) const
+{
+    return (*this<v) || (*this==v);
+}
+
+
+/************************************************************************/
+bool iKinLimbVersion::operator>=(const iKinLimbVersion& v) const
+{
+    return (*this>v) || (*this==v);
+}
+
+
+/************************************************************************/
+iKinLimbVersion iKinLimbVersion::operator-(const iKinLimbVersion& v) const
+{
+   unsigned long int m1=(major>v.major)?major-v.major:v.major-major;
+   unsigned long int m2=(minor>v.minor)?minor-v.minor:v.minor-minor;
+   return iKinLimbVersion(m1,m2);
+}
+
+
+/************************************************************************/
 iCubTorso::iCubTorso() : iKinLimb(string("v1"))
 {
     allocate(getType());
@@ -1568,15 +1688,15 @@ iCubTorso::iCubTorso(const string &_type) : iKinLimb(_type)
 void iCubTorso::allocate(const string &_type)
 {
     if (getType().size()>1)
-        version=strtod(getType().substr(1).c_str(),NULL);
+        version=iKinLimbVersion(getType().substr(1));
     else
-        version=1.0;
+        version=iKinLimbVersion("1.0");
 
     Matrix H0(4,4);
     H0.zero();
     H0(3,3)=1.0;
 
-    if (version<3.0)
+    if (version<iKinLimbVersion("3.0"))
     {
         H0(0,1)=-1.0;
         H0(1,2)=-1.0;
@@ -1617,7 +1737,7 @@ bool iCubTorso::alignJointsBounds(const deque<IControlLimits*> &lim)
         if (!limTorso.getLimits(iTorso,&min,&max))
             return false;
 
-        if (version<3.0)
+        if (version<iKinLimbVersion("3.0"))
         {
             (*this)[2-iTorso].setMin(CTRL_DEG2RAD*min);
             (*this)[2-iTorso].setMax(CTRL_DEG2RAD*max);
@@ -1655,18 +1775,18 @@ void iCubArm::allocate(const string &_type)
     if (underscore!=string::npos)
     {
         arm=getType().substr(0,underscore);
-        version=strtod(getType().substr(underscore+2).c_str(),NULL);
+        version=iKinLimbVersion(getType().substr(underscore+2));
     }
     else
     {
         arm=getType();
-        version=1.0;
+        version=iKinLimbVersion("1.0");
     }
 
     Matrix H0(4,4);
     H0.zero();
 
-    if (version<3.0)
+    if (version<iKinLimbVersion("3.0"))
     {
         H0(0,1)=-1.0;
         H0(1,2)=-1.0;
@@ -1684,7 +1804,7 @@ void iCubArm::allocate(const string &_type)
 
     if (arm=="right")
     {
-        if (version<3.0)
+        if (version<iKinLimbVersion("3.0"))
         {
             pushLink(new iKinLink(     0.032,      0.0,  M_PI/2.0,                 0.0, -22.0*CTRL_DEG2RAD,  84.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(       0.0,  -0.0055,  M_PI/2.0,           -M_PI/2.0, -39.0*CTRL_DEG2RAD,  39.0*CTRL_DEG2RAD));
@@ -1693,12 +1813,12 @@ void iCubArm::allocate(const string &_type)
             pushLink(new iKinLink(       0.0,      0.0, -M_PI/2.0,           -M_PI/2.0,   0.0*CTRL_DEG2RAD, 160.8*CTRL_DEG2RAD));
             pushLink(new iKinLink(    -0.015, -0.15228, -M_PI/2.0, -105.0*CTRL_DEG2RAD, -37.0*CTRL_DEG2RAD, 100.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(     0.015,      0.0,  M_PI/2.0,                 0.0,   5.5*CTRL_DEG2RAD, 106.0*CTRL_DEG2RAD));
-        if (version<1.7)
+        if (version<iKinLimbVersion("1.7"))
             pushLink(new iKinLink(       0.0,  -0.1373,  M_PI/2.0,           -M_PI/2.0, -50.0*CTRL_DEG2RAD,  50.0*CTRL_DEG2RAD));
         else
             pushLink(new iKinLink(       0.0,  -0.1413,  M_PI/2.0,           -M_PI/2.0, -50.0*CTRL_DEG2RAD,  50.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(       0.0,      0.0,  M_PI/2.0,            M_PI/2.0, -65.0*CTRL_DEG2RAD,  10.0*CTRL_DEG2RAD));
-        if (version<2.0)
+        if (version<iKinLimbVersion("2.0"))
             pushLink(new iKinLink(    0.0625,    0.016,       0.0,                M_PI, -25.0*CTRL_DEG2RAD,  25.0*CTRL_DEG2RAD));
         else
             pushLink(new iKinLink(    0.0625,  0.02598,       0.0,                M_PI, -25.0*CTRL_DEG2RAD,  25.0*CTRL_DEG2RAD));
@@ -1722,7 +1842,7 @@ void iCubArm::allocate(const string &_type)
         if (arm!="left")
             type.replace(0,underscore,"left");
 
-        if (version<3.0)
+        if (version<iKinLimbVersion("3.0"))
         {
             pushLink(new iKinLink(     0.032,      0.0,  M_PI/2.0,                 0.0, -22.0*CTRL_DEG2RAD,  84.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(       0.0,  -0.0055,  M_PI/2.0,           -M_PI/2.0, -39.0*CTRL_DEG2RAD,  39.0*CTRL_DEG2RAD));
@@ -1731,12 +1851,12 @@ void iCubArm::allocate(const string &_type)
             pushLink(new iKinLink(       0.0,      0.0,  M_PI/2.0,           -M_PI/2.0,   0.0*CTRL_DEG2RAD, 160.8*CTRL_DEG2RAD));
             pushLink(new iKinLink(     0.015,  0.15228, -M_PI/2.0,   75.0*CTRL_DEG2RAD, -37.0*CTRL_DEG2RAD, 100.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(    -0.015,      0.0,  M_PI/2.0,                 0.0,   5.5*CTRL_DEG2RAD, 106.0*CTRL_DEG2RAD));
-        if (version<1.7)
+        if (version<iKinLimbVersion("1.7"))
             pushLink(new iKinLink(       0.0,   0.1373,  M_PI/2.0,           -M_PI/2.0, -50.0*CTRL_DEG2RAD,  50.0*CTRL_DEG2RAD));
         else
             pushLink(new iKinLink(       0.0,   0.1413,  M_PI/2.0,           -M_PI/2.0, -50.0*CTRL_DEG2RAD,  50.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(       0.0,      0.0,  M_PI/2.0,            M_PI/2.0, -65.0*CTRL_DEG2RAD,  10.0*CTRL_DEG2RAD));
-        if (version<2.0)
+        if (version<iKinLimbVersion("2.0"))
             pushLink(new iKinLink(    0.0625,   -0.016,       0.0,                 0.0, -25.0*CTRL_DEG2RAD,  25.0*CTRL_DEG2RAD));
         else
             pushLink(new iKinLink(    0.0625, -0.02598,       0.0,                 0.0, -25.0*CTRL_DEG2RAD,  25.0*CTRL_DEG2RAD));
@@ -1780,7 +1900,7 @@ bool iCubArm::alignJointsBounds(const deque<IControlLimits*> &lim)
         if (!limTorso.getLimits(iTorso,&min,&max))
             return false;
 
-        if (version<3.0)
+        if (version<iKinLimbVersion("3.0"))
         {
             (*this)[2-iTorso].setMin(CTRL_DEG2RAD*min);
             (*this)[2-iTorso].setMax(CTRL_DEG2RAD*max);
@@ -2282,12 +2402,12 @@ void iCubLeg::allocate(const string &_type)
     if (underscore!=string::npos)
     {
         leg=getType().substr(0,underscore);
-        version=strtod(getType().substr(underscore+2).c_str(),NULL);
+        version=iKinLimbVersion(getType().substr(underscore+2));
     }
     else
     {
         leg=getType();
-        version=1.0;
+        version=iKinLimbVersion("1.0");
     }
 
     Matrix H0(4,4);
@@ -2300,7 +2420,7 @@ void iCubLeg::allocate(const string &_type)
 
     if (leg=="right")
     {
-        if (version<2.0)
+        if (version<iKinLimbVersion("2.0"))
         {
             H0(1,3)=0.0681;
 
@@ -2311,7 +2431,7 @@ void iCubLeg::allocate(const string &_type)
             pushLink(new iKinLink(   0.0,     0.0,  M_PI/2.0,       0.0,  -42.0*CTRL_DEG2RAD,  21.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(-0.041,     0.0,      M_PI,       0.0,  -24.0*CTRL_DEG2RAD,  24.0*CTRL_DEG2RAD));
         }
-        else if (version<3.0)
+        else if (version<iKinLimbVersion("3.0"))
         {
             H0(1,3)=0.0681;
 
@@ -2343,7 +2463,7 @@ void iCubLeg::allocate(const string &_type)
     }
     else  // left
     {
-        if (version<2.0)
+        if (version<iKinLimbVersion("2.0"))
         {
             H0(1,3)=-0.0681;
 
@@ -2354,7 +2474,7 @@ void iCubLeg::allocate(const string &_type)
             pushLink(new iKinLink(   0.0,     0.0, -M_PI/2.0,       0.0,  -42.0*CTRL_DEG2RAD,  21.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(-0.041,     0.0,       0.0,       0.0,  -24.0*CTRL_DEG2RAD,  24.0*CTRL_DEG2RAD));
         }
-        else if (version<3.0)
+        else if (version<iKinLimbVersion("3.0"))
         {
             H0(1,3)=-0.0681;
 
@@ -2435,12 +2555,12 @@ void iCubEye::allocate(const string &_type)
     if (underscore!=string::npos)
     {
         eye=getType().substr(0,underscore);
-        version=strtod(getType().substr(underscore+2).c_str(),NULL);
+        version=iKinLimbVersion(getType().substr(underscore+2));
     }
     else
     {
         eye=getType();
-        version=1.0;
+        version=iKinLimbVersion("1.0");
     }
 
     Matrix H0(4,4);
@@ -2453,7 +2573,7 @@ void iCubEye::allocate(const string &_type)
 
     if (eye=="right")
     {
-        if (version<2.0)
+        if (version<iKinLimbVersion("2.0"))
         {
             pushLink(new iKinLink(  0.032,     0.0,  M_PI/2.0,       0.0, -22.0*CTRL_DEG2RAD, 84.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(    0.0, -0.0055,  M_PI/2.0, -M_PI/2.0, -39.0*CTRL_DEG2RAD, 39.0*CTRL_DEG2RAD));
@@ -2464,7 +2584,7 @@ void iCubEye::allocate(const string &_type)
             pushLink(new iKinLink(    0.0,   0.034, -M_PI/2.0,       0.0, -35.0*CTRL_DEG2RAD, 15.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(    0.0,     0.0,  M_PI/2.0, -M_PI/2.0, -50.0*CTRL_DEG2RAD, 50.0*CTRL_DEG2RAD));
         }
-        else if (version<3.0)
+        else if (version<iKinLimbVersion("3.0"))
         {
             pushLink(new iKinLink(  0.032,     0.0,  M_PI/2.0,       0.0, -22.0*CTRL_DEG2RAD, 84.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(    0.0, -0.0055,  M_PI/2.0, -M_PI/2.0, -39.0*CTRL_DEG2RAD, 39.0*CTRL_DEG2RAD));
@@ -2496,7 +2616,7 @@ void iCubEye::allocate(const string &_type)
     }
     else  // left
     {
-        if (version<2.0)
+        if (version<iKinLimbVersion("2.0"))
         {
             pushLink(new iKinLink(  0.032,     0.0,  M_PI/2.0,       0.0, -22.0*CTRL_DEG2RAD, 84.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(    0.0, -0.0055,  M_PI/2.0, -M_PI/2.0, -39.0*CTRL_DEG2RAD, 39.0*CTRL_DEG2RAD));
@@ -2507,7 +2627,7 @@ void iCubEye::allocate(const string &_type)
             pushLink(new iKinLink(    0.0,  -0.034, -M_PI/2.0,       0.0, -35.0*CTRL_DEG2RAD, 15.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(    0.0,     0.0,  M_PI/2.0, -M_PI/2.0, -50.0*CTRL_DEG2RAD, 50.0*CTRL_DEG2RAD));
         }
-        else if (version<3.0)
+        else if (version<iKinLimbVersion("3.0"))
         {
             pushLink(new iKinLink(  0.032,     0.0,  M_PI/2.0,       0.0, -22.0*CTRL_DEG2RAD, 84.0*CTRL_DEG2RAD));
             pushLink(new iKinLink(    0.0, -0.0055,  M_PI/2.0, -M_PI/2.0, -39.0*CTRL_DEG2RAD, 39.0*CTRL_DEG2RAD));
@@ -2538,16 +2658,19 @@ void iCubEye::allocate(const string &_type)
         }
     }
 
-    if (is_version(version, 2.8)) // event driven cameras virtual image plane
+    // event driven cameras virtual image plane
+    if (version==iKinLimbVersion("2.8"))
     {
-        Matrix HN = yarp::math::eye(4, 4);
-        HN(2, 3) = -0.01;
+        Matrix HN=yarp::math::eye(4, 4);
+        HN(2, 3)=-0.01;
         setHN(HN);
     }
-    else if (is_version(version, 2.10) || is_version(version, 3.1)) // Basler 4k cameras image plane
+    // Basler 4k cameras image plane
+    else if ((version==iKinLimbVersion("2.10")) ||
+             (version==iKinLimbVersion("3.1")))
     {
-        Matrix HN = yarp::math::eye(4, 4);
-        HN(2, 3) = -5.4e-3;
+        Matrix HN=yarp::math::eye(4, 4);
+        HN(2, 3)=-5.4e-3;
         setHN(HN);
     }
 
@@ -2575,7 +2698,7 @@ bool iCubEye::alignJointsBounds(const deque<IControlLimits*> &lim)
         if (!limTorso.getLimits(iTorso,&min,&max))
             return false;
 
-        if (version<3.0)
+        if (version<iKinLimbVersion("3.0"))
         {
             (*this)[2-iTorso].setMin(CTRL_DEG2RAD*min);
             (*this)[2-iTorso].setMax(CTRL_DEG2RAD*max);
@@ -2673,15 +2796,15 @@ iCubInertialSensor::iCubInertialSensor(const string &_type) : iKinLimb(_type)
 void iCubInertialSensor::allocate(const string &_type)
 {
     if (getType().size()>1)
-        version=strtod(getType().substr(1).c_str(),NULL);
+        version=iKinLimbVersion(getType().substr(1));
     else
-        version=1.0;
+        version=iKinLimbVersion("1.0");
 
     Matrix H0(4,4);
     H0.zero();
     H0(3,3)=1.0;
 
-    if (version<2.0)
+    if (version<iKinLimbVersion("2.0"))
     {
         H0(0,1)=-1.0;
         H0(1,2)=-1.0;
@@ -2695,7 +2818,7 @@ void iCubInertialSensor::allocate(const string &_type)
         pushLink(new iKinLink(    0.0,   0.001, -M_PI/2.0, -M_PI/2.0, -70.0*CTRL_DEG2RAD, 60.0*CTRL_DEG2RAD));
         pushLink(new iKinLink( 0.0225,  0.1005, -M_PI/2.0,  M_PI/2.0, -55.0*CTRL_DEG2RAD, 55.0*CTRL_DEG2RAD));
     }
-    else if (version<3.0)
+    else if (version<iKinLimbVersion("3.0"))
     {
         H0(0,1)=-1.0;
         H0(1,2)=-1.0;
@@ -2734,7 +2857,7 @@ void iCubInertialSensor::allocate(const string &_type)
     HN(3,3)=1.0;
     setHN(HN);
 
-    if (version>2.0)
+    if (version>iKinLimbVersion("2.0"))
     {
         Matrix HN=eye(4,4);
         HN(0,3)=0.0087;
@@ -2744,7 +2867,7 @@ void iCubInertialSensor::allocate(const string &_type)
     }
 
     // further displacement for >= 2.6
-    if (version>=2.6)
+    if (version>=iKinLimbVersion("2.6"))
     {
         Matrix HN=zeros(4,4);
         HN(0,3)=0.0323779;
@@ -2777,7 +2900,7 @@ bool iCubInertialSensor::alignJointsBounds(const deque<IControlLimits*> &lim)
         if (!limTorso.getLimits(iTorso,&min,&max))
             return false;
 
-        if (version<3.0)
+        if (version<iKinLimbVersion("3.0"))
         {
             (*this)[2-iTorso].setMin(CTRL_DEG2RAD*min);
             (*this)[2-iTorso].setMax(CTRL_DEG2RAD*max);
@@ -2821,9 +2944,9 @@ iCubInertialSensorWaist::iCubInertialSensorWaist(const string &_type) : iKinLimb
 void iCubInertialSensorWaist::allocate(const string &_type)
 {
     if (getType().size()>1)
-        version=strtod(getType().substr(1).c_str(),NULL);
+        version=iKinLimbVersion(getType().substr(1));
     else
-        version=2.7;
+        version=iKinLimbVersion("2.7");
 
     Matrix H0(4,4);
     H0.zero();

--- a/src/libraries/iKin/src/iKinFwd.cpp
+++ b/src/libraries/iKin/src/iKinFwd.cpp
@@ -1665,8 +1665,10 @@ bool iKinLimbVersion::operator>=(const iKinLimbVersion& v) const
 iKinLimbVersion iKinLimbVersion::operator-(const iKinLimbVersion& v) const
 {
    unsigned long int m1=(major>v.major)?major-v.major:v.major-major;
-   unsigned long int m2=(minor>v.minor)?minor-v.minor:v.minor-minor;
-   return iKinLimbVersion(m1,m2);
+   unsigned long int m2=0L;
+   if (m1==0L)
+       m2=(minor>v.minor)?minor-v.minor:v.minor-minor;
+   return iKinLimbVersion(m1, m2);
 }
 
 

--- a/src/libraries/iKin/src/iKinInv.cpp
+++ b/src/libraries/iKin/src/iKinInv.cpp
@@ -988,5 +988,3 @@ MultiRefMinJerkCtrl::~MultiRefMinJerkCtrl()
     delete I;
 }
 
-
-

--- a/src/libraries/iKin/src/iKinSlv.cpp
+++ b/src/libraries/iKin/src/iKinSlv.cpp
@@ -12,7 +12,7 @@
 #include <cmath>
 #include <algorithm>
 
-#include <yarp/os/LogStream.h>
+#include <yarp/os/Log.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Time.h>
 
@@ -1762,7 +1762,7 @@ PartDescriptor *iCubArmCartesianSolver::getPartDesc(Searchable &options)
 {
     type="right";
     string part_type=type;
-    double version=1.0;
+    iKinLimbVersion version("1.0");
     if (options.check("type"))
     {
         type=options.find("type").asString();
@@ -1772,7 +1772,7 @@ PartDescriptor *iCubArmCartesianSolver::getPartDesc(Searchable &options)
 
         size_t underscore=type.find('_');
         if (underscore!=string::npos)
-            version=strtod(type.substr(underscore+2).c_str(),NULL);
+            version=iKinLimbVersion(type.substr(underscore+2));
     }
 
     string robot=options.check("robot",Value("icub")).asString();
@@ -1801,9 +1801,9 @@ PartDescriptor *iCubArmCartesianSolver::getPartDesc(Searchable &options)
     p->cns=new iCubAdditionalArmConstraints(*static_cast<iCubArm*>(p->lmb));
     p->prp.push_back(optTorso);
     p->prp.push_back(optArm);
-    p->rvs.push_back(version<3.0);  // torso
-    p->rvs.push_back(false);        // arm
-    p->num=2;                       // number of parts
+    p->rvs.push_back(version<iKinLimbVersion("3.0"));   // torso
+    p->rvs.push_back(false);                            // arm
+    p->num=2;                                           // number of parts
 
     return p;
 }
@@ -1858,7 +1858,7 @@ PartDescriptor *iCubLegCartesianSolver::getPartDesc(Searchable &options)
 {
     type="right";
     string part_type=type;
-    double version=1.0;
+    iKinLimbVersion version("1.0");
     if (options.check("type"))
     {
         type=options.find("type").asString();
@@ -1868,7 +1868,7 @@ PartDescriptor *iCubLegCartesianSolver::getPartDesc(Searchable &options)
 
         size_t underscore=type.find('_');
         if (underscore!=string::npos)
-            version=strtod(type.substr(underscore+2).c_str(),NULL);
+            version=iKinLimbVersion(type.substr(underscore+2));
     }
 
     string robot=options.check("robot",Value("icub")).asString();

--- a/src/libraries/icubmod/cartesianController/ClientCartesianController.cpp
+++ b/src/libraries/icubmod/cartesianController/ClientCartesianController.cpp
@@ -29,7 +29,7 @@
 
 #include <iCub/iKin/iKinInv.h>
 
-#define CARTCTRL_CLIENT_VER     1.1
+#define CARTCTRL_CLIENT_VER     "2.0"
 #define CARTCTRL_DEFAULT_TMO    0.1 // [s]
 
 using namespace std;
@@ -120,11 +120,11 @@ bool ClientCartesianController::open(Searchable &config)
         getInfoHelper(info);
         if (info.check("server_version"))
         {
-            double server_version=info.find("server_version").asFloat64();
+            string server_version=info.find("server_version").asString();
             if (server_version!=CARTCTRL_CLIENT_VER)
             {
-                yError("version mismatch => server(%g) != client(%g); please update accordingly",
-                       server_version,CARTCTRL_CLIENT_VER);
+                yError("version mismatch => server(%s) != client(%s); please update accordingly",
+                       server_version.c_str(),CARTCTRL_CLIENT_VER);
                 close();
                 return false;
             }

--- a/src/libraries/icubmod/cartesianController/ServerCartesianController.cpp
+++ b/src/libraries/icubmod/cartesianController/ServerCartesianController.cpp
@@ -30,7 +30,7 @@
 
 #include <iCub/iKin/iKinVocabs.h>
 
-#define CARTCTRL_SERVER_VER                 1.1
+#define CARTCTRL_SERVER_VER                 "2.0"
 #define CARTCTRL_DEFAULT_PER                0.01    // [s]
 #define CARTCTRL_DEFAULT_TASKVEL_PERFACTOR  4
 #define CARTCTRL_DEFAULT_TOL                1e-2
@@ -3487,19 +3487,19 @@ bool ServerCartesianController::getInfo(Bottle &info)
 
         Bottle &serverVer=info.addList();
         serverVer.addString("server_version");
-        serverVer.addFloat64(CARTCTRL_SERVER_VER);
+        serverVer.addString(CARTCTRL_SERVER_VER);
 
         string kinPartStr(kinPart);
         string type=limbState->getType();
 
         size_t pos=type.find("_v");
-        double hwVer=1.0;
+        iKinLimbVersion hwVer("1.0");
         if (pos!=string::npos)
-            hwVer=strtod(type.substr(pos+2).c_str(),NULL);        
+            hwVer=iKinLimbVersion(type.substr(pos+2));
 
         Bottle &partVer=info.addList();
         partVer.addString(kinPartStr+"_version");
-        partVer.addFloat64(hwVer);
+        partVer.addString(hwVer.get_version());
 
         Bottle &partType=info.addList();
         partType.addString(kinPartStr+"_type");

--- a/src/libraries/icubmod/gazeController/ClientGazeController.cpp
+++ b/src/libraries/icubmod/gazeController/ClientGazeController.cpp
@@ -25,7 +25,7 @@
 #include <yarp/math/Math.h>
 #include "ClientGazeController.h"
 
-#define GAZECTRL_CLIENT_VER     1.2
+#define GAZECTRL_CLIENT_VER     "2.0"
 #define GAZECTRL_DEFAULT_TMO    0.1     // [s]
 #define GAZECTRL_ACK            Vocab32::encode("ack")
 #define GAZECTRL_NACK           Vocab32::encode("nack")
@@ -125,11 +125,11 @@ bool ClientGazeController::open(Searchable &config)
         getInfoHelper(info);
         if (info.check("server_version"))
         {
-            double server_version=info.find("server_version").asFloat64();
+            string server_version=info.find("server_version").asString();
             if (server_version!=GAZECTRL_CLIENT_VER)
             {
-                yError("version mismatch => server(%g) != client(%g); please update accordingly",
-                       server_version,GAZECTRL_CLIENT_VER);
+                yError("version mismatch => server(%s) != client(%s); please update accordingly",
+                       server_version.c_str(),GAZECTRL_CLIENT_VER);
                 close();
                 return false;
             }

--- a/src/modules/actionsRenderingEngine/src/MotorThread.cpp
+++ b/src/modules/actionsRenderingEngine/src/MotorThread.cpp
@@ -2683,11 +2683,11 @@ bool MotorThread::exploreTorso(Bottle &options)
 
     Bottle info;
     ctrl_gaze->getInfo(info);
-    double head_version=info.check("head_version",Value(1.0)).asFloat64();
+    iKinLimbVersion head_version(info.check("head_version",Value("1.0")).asString());
 
     ostringstream type;
     type<<(dominant_eye==LEFT?"left":"right");
-    if (head_version==2.0)
+    if (head_version==iKinLimbVersion("2.0"))
         type<<"_v2";
 
     iCubEye iKinTorso=iCubEye(type.str());

--- a/src/modules/actionsRenderingEngine/src/main.cpp
+++ b/src/modules/actionsRenderingEngine/src/main.cpp
@@ -34,7 +34,7 @@ information according to the current "stereo to cartesian" modality chosen:
 -- homography: which assumes that the target point lies on a table and exploits
 homography to obtain the relative 3D cartesian coordinates.
 
--- disparity: which uses the \ref StereoDisparity module to obtain the 3D cartesian
+-- disparity: which uses the StereoDisparity module to obtain the 3D cartesian
 estimate of the 2D target.
 
 -- network: which uses a previously trained neural network structure to predict the

--- a/src/modules/cartesianInterfaceControl/CMakeLists.txt
+++ b/src/modules/cartesianInterfaceControl/CMakeLists.txt
@@ -5,6 +5,6 @@
 
 project(cartesianInterfaceControl)
 add_executable(${PROJECT_NAME} main.cpp)
-target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} iKin ${YARP_LIBRARIES})
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 

--- a/src/modules/cartesianInterfaceControl/main.cpp
+++ b/src/modules/cartesianInterfaceControl/main.cpp
@@ -16,80 +16,80 @@
  * Public License for more details
 */
 
-/** 
+/**
+@ingroup icub_module
+
 \defgroup cartesianInterfaceControl cartesianInterfaceControl
- 
-@ingroup icub_module  
- 
-Just an example of how to control the iCub arm in the 
+
+Just an example of how to control the iCub arm in the
 operational space making use of the Cartesian Interface.
- 
+
 Copyright (C) 2010 RobotCub Consortium
- 
-Author: Ugo Pattacini 
+
+Author: Ugo Pattacini
 
 CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
 \section intro_sec Description
- 
+
 This module relies on \ref icub_cartesian_interface to provide a
-kind of easy-to-use port-based front-end for controlling the 
-iCub's arm in the operational space. 
- 
-\section lib_sec Libraries 
-- YARP libraries. 
+kind of easy-to-use port-based front-end for controlling the
+iCub's arm in the operational space.
+
+\section lib_sec Libraries
+- YARP libraries.
 
 \section parameters_sec Parameters
---name \e name 
-- The parameter \e name identifies the controller's name; all 
+--name \e name
+- The parameter \e name identifies the controller's name; all
   the open ports will be tagged with the prefix
   /<name>/<part>/. If not specified \e armCtrl is assumed.
- 
---robot \e name 
+
+--robot \e name
 - The parameter \e name selects the robot name to connect to; if
   not specified \e icub is assumed.
- 
---part \e type 
+
+--part \e type
 - The parameter \e type selects the robot's arm to work with. It
   can be \e right_arm or \e left_arm; if not specified
   \e right_arm is assumed.
- 
+
 --T \e time
 - specify the task execution time in seconds; by default \e time
   is 2.0 seconds. Note that this is just an approximation of
   execution time since there exists a controller running
   underneath.
- 
---tol \e tol 
-- specify the cartesian tolerance in meters for reaching the 
+
+--tol \e tol
+- specify the cartesian tolerance in meters for reaching the
   target.
- 
+
 --DOF8
-- enable the control of torso yaw joint. 
- 
+- enable the control of torso yaw joint.
+
 --DOF9
-- enable the control of torso yaw/pitch joints. 
- 
+- enable the control of torso yaw/pitch joints.
+
 --DOF10
-- enable the control of torso yaw/roll/pitch joints. 
- 
---onlyXYZ  
-- disable orientation control. 
- 
---reinstate_context 
+- enable the control of torso yaw/roll/pitch joints.
+
+--onlyXYZ
+- disable orientation control.
+
+--reinstate_context
 - reinstate controller context upon target reception.
- 
+
 \section portsa_sec Ports Accessed
 
-The robot interface is assumed to be operative; in particular, 
-the ICartesianControl interface must be available. 
- 
-\section portsc_sec Ports Created 
- 
+The robot interface is assumed to be operative; in particular,
+the ICartesianControl interface must be available.
+
+\section portsc_sec Ports Created
+
 The module creates the ports required for the communication with
-the robot (through interfaces) and the following ports: 
- 
-- \e /<name>/<part>/xd:i receives the target end-effector 
+the robot (through interfaces) and the following ports:
+
+- \e /<name>/<part>/xd:i receives the target end-effector
   pose. It accepts 7 double (also as a Bottle object): 3 for xyz
   and 4 for orientation in axis/angle mode.
 
@@ -100,12 +100,12 @@ the robot (through interfaces) and the following ports:
 \section in_files_sec Input Data Files
 None.
 
-\section out_data_sec Output Data Files 
-None. 
- 
+\section out_data_sec Output Data Files
+None.
+
 \section conf_file_sec Configuration Files
-None. 
- 
+None.
+
 \section tested_os_sec Tested OS
 Windows, Linux
 

--- a/src/modules/cartesianInterfaceControl/main.cpp
+++ b/src/modules/cartesianInterfaceControl/main.cpp
@@ -129,6 +129,8 @@ Windows, Linux
 #include <yarp/dev/CartesianControl.h>
 #include <yarp/dev/PolyDriver.h>
 
+#include <iCub/iKin/iKinFwd.h>
+
 #define MAX_TORSO_PITCH     30.0    // [deg]
 #define EXECTIME_THRESDIST  0.3     // [m]
 #define PRINT_STATUS_PER    1.0     // [s]
@@ -138,6 +140,7 @@ using namespace yarp::os;
 using namespace yarp::dev;
 using namespace yarp::sig;
 using namespace yarp::math;
+using namespace iCub::iKin;
 
 
 /************************************************************************/
@@ -193,11 +196,11 @@ class CtrlThread : public PeriodicThread {
 
     Bottle info;
     iarm->getInfo(info);
-    double hwver = info.find("arm_version").asFloat64();
-    printf("Detected arm kinematics version %g\n", hwver);
+    iKinLimbVersion hwver(info.find("arm_version").asString());
+    printf("Detected arm kinematics version %s\n", hwver.get_version().c_str());
 
     map<string, int> torsoJointsRemap{{ "pitch", 0 }, { "roll", 1 }, { "yaw", 2 }};
-    if (hwver >= 3.0) {
+    if (hwver >= iKinLimbVersion("3.0")) {
       torsoJointsRemap["roll"] = 0;
       torsoJointsRemap["pitch"] = 1;
     }

--- a/src/modules/ctpService/main.cpp
+++ b/src/modules/ctpService/main.cpp
@@ -5,11 +5,11 @@
  *
  */
 
-/** 
+/**
+@ingroup icub_module
+
 \defgroup ctpService constantTimePositionService
- 
-@ingroup icub_module 
- 
+
 A simple service that allows you to send constant time position
 commands to any of the robot ports.
 
@@ -18,7 +18,7 @@ commands to any of the robot ports.
 Sit silently and waits for incoming commands. Receive position
 commands requests and sends position commands, but it computes
 the reference speeds so that commands are all executed in the same
-time irrespectively of the current position (the service reads 
+time irrespectively of the current position (the service reads
 the current encoders and compute the reference speed accordingly).
 
 \section ports_sec Ports and Messages
@@ -31,10 +31,10 @@ the current encoders and compute the reference speed accordingly).
  - /ctpservice/local/{part}/state:i
  - /ctpservice/local/{part}/command:o
 
-- Output, to interface with the @ref icub_velocityControl 
+- Output, to interface with the @ref icub_velocityControl
   module:
  - /ctpservice/{part}/vc:o
- 
+
 Here {part} is replaced with the robot part (see --part parameter)
 
 ctpservice is a default value that can be replaced with --name.
@@ -43,21 +43,21 @@ Incoming commands are the following:
 
 [ctpn] [time] TIME(seconds) [off] j [pos] list
 
-Execute command. Command will take TIME seconds, the list of position will be sent to the motors
-starting from offset j.
- 
-or 
- 
-[ctpq] [time] TIME (seconds) [off] j [pos] list 
- 
- 
-Queue commands for execution. Command will take TIME seconds, the list of position will be sent to the motors
-starting from offset j
- 
-or 
- 
+Execute command. Command will take TIME seconds, the list of position will be
+sent to the motors starting from offset j.
+
+or
+
+[ctpq] [time] TIME (seconds) [off] j [pos] list
+
+
+Queue commands for execution. Command will take TIME seconds, the list of
+position will be sent to the motors starting from offset j
+
+or
+
 [ctpf] filename (in yarpdatadumper format)
- 
+
 Example:
 This requires 1 second movement of joints 5,6,7 to 10 10 10 respectively:
 [ctpn] [time] 1 [off] 5 [pos] (10 10 10)
@@ -65,7 +65,8 @@ This requires 1 second movement of joints 5,6,7 to 10 10 10 respectively:
 \section parameters_sec Parameters
 Run as:
 
-ctpService --robot robotname --part part [--name modulename] [--autochange_control_mode_enable]
+ctpService --robot robotname --part part [--name modulename]
+[--autochange_control_mode_enable]
 
 robot: name of robot (e.g. icub)
 
@@ -73,20 +74,21 @@ part: prefix for part name (e.g. right_arm)
 
 name: [optional] module name (used to form port names)
 
-autochange_control_mode_enable: [optional] sets the joints to position mode when trying to execute the command (default off)
+autochange_control_mode_enable: [optional] sets the joints to position mode when
+trying to execute the command (default off)
 
-\section lib_sec Libraries 
-- YARP libraries. 
- 
+\section lib_sec Libraries
+- YARP libraries.
+
 \section tested_os_sec Tested OS
 Windows, Linux
 
 Copyright (C) 2010 RobotCub Consortium
 
 CopyPolicy: Released under the terms of the GNU GPL v2.0.
- 
-Author: Lorenzo Natale 
-*/ 
+
+Author: Lorenzo Natale
+*/
 
 #include <yarp/os/Network.h>
 #include <yarp/os/RFModule.h>

--- a/src/modules/iKinCartesianSolver/main.cpp
+++ b/src/modules/iKinCartesianSolver/main.cpp
@@ -16,63 +16,63 @@
  * Public License for more details
 */
 
-/** 
-\defgroup iKinCartesianSolver iKinCartesianSolver 
- 
-@ingroup icub_module  
- 
-Just a container which runs the \ref iKinSlv "Cartesian Solver" 
-taking parameters from a configuration file. 
- 
+/**
+@ingroup icub_module
+
+\defgroup iKinCartesianSolver iKinCartesianSolver
+
+Just a container which runs the \ref iKinSlv "Cartesian Solver"
+taking parameters from a configuration file.
+
 Copyright (C) 2010 RobotCub Consortium
- 
-Author: Ugo Pattacini 
+
+Author: Ugo Pattacini
 
 CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-\section intro_sec Description 
-See \ref iKinSlv "Cartesian Solver" for documentation. 
- 
-\section lib_sec Libraries 
-- YARP libraries. 
-- \ref iKin "iKin" library (it requires IPOPT: see the 
+\section intro_sec Description
+See \ref iKinSlv "Cartesian Solver" for documentation.
+
+\section lib_sec Libraries
+- YARP libraries.
+- \ref iKin "iKin" library (it requires IPOPT: see the
   <a
   href="http://wiki.icub.org/wiki/Installing_IPOPT">wiki</a>).
 
 \section parameters_sec Parameters
 --part \e type [mandatory]
-- select the part to run. \e type is the group name within the 
+- select the part to run. \e type is the group name within the
   configuration file (e.g. left_arm, right_arm, ...).
 
 --context \e directory [optional]
 - allow specifying a different path where to search the
-  configuration file (beware of the  
-  <a href="http://www.yarp.it/yarp_data_dirs.html">context  
-  search policy</a>).  
- 
---from \e file [optional]
-- allow specifying a different configuration file from the 
-  default one which is \e cartesianSolver.ini.
- 
-\section portsa_sec Ports Accessed
- 
-All ports which allow the access to motor interface shall be 
-previously open. 
+  configuration file (beware of the
+  <a href="http://www.yarp.it/yarp_data_dirs.html">context
+  search policy</a>).
 
-\section portsc_sec Ports Created 
- 
+--from \e file [optional]
+- allow specifying a different configuration file from the
+  default one which is \e cartesianSolver.ini.
+
+\section portsa_sec Ports Accessed
+
+All ports which allow the access to motor interface shall be
+previously open.
+
+\section portsc_sec Ports Created
+
 - /<solverName>/in : for requests in streaming mode.
 - /<solverName>/rpc : for requests and replies.
-- /<solverName>/out : for output streaming. 
- 
+- /<solverName>/out : for output streaming.
+
 \note for a detailed description, see \ref iKinSlv.
- 
+
 \section conf_file_sec Configuration Files
- 
-Here's how the configuration file will look like for the 
-specific icub part left_arm: 
- 
-\code 
+
+Here's how the configuration file will look like for the
+specific icub part left_arm:
+
+\code
 [left_arm]
 robot          icub
 name           cartesianSolver/left_arm
@@ -80,40 +80,40 @@ type           left
 period         20
 dof            (0 0 0 1 1 1 1 1 1 1)
 rest_pos       (0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0)
-rest_weights   (1.0 1.0 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0) 
+rest_weights   (1.0 1.0 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0)
 pose           full
 mode           shot
 verbosity      off
 maxIter        200
 tol            0.001
-interPoints    off 
-ping_robot_tmo 20.0 
-\endcode 
- 
-Here's how the configuration file will look like for a custom 
-robot part: 
- 
-\code 
+interPoints    off
+ping_robot_tmo 20.0
+\endcode
+
+Here's how the configuration file will look like for a custom
+robot part:
+
+\code
 [left_arm]
 robot           my-robot
-name            cartesianSolver/left_arm 
+name            cartesianSolver/left_arm
 type            left
 period          20
 dof             (1 1 1 1 1 1 1)
 rest_pos        (0.0 0.0 0.0 0.0 0.0 0.0 0.0)
-rest_weights    (0.0 0.0 0.0 0.0 0.0 0.0 0.0) 
+rest_weights    (0.0 0.0 0.0 0.0 0.0 0.0 0.0)
 pose            full
 mode            shot
 verbosity       off
 maxIter         200
 tol             0.001
-interPoints     off 
-ping_robot_tmo  20.0 
- 
-CustomKinFile   cartesian/kinematics.ini 
-NumberOfDrivers 1 
+interPoints     off
+ping_robot_tmo  20.0
+
+CustomKinFile   cartesian/kinematics.ini
+NumberOfDrivers 1
 driver_0        (Key left_arm) (JointsOrder direct)
-  
+
 LIC_num         7
 LIC_0           (C (1.71 -1.71    0.0  0.0 0.0 0.0 0.0)) (lB -6.051)
 LIC_1           (C (1.71 -1.71  -1.71  0.0 0.0 0.0 0.0)) (lB -6.397) (uB 1.962)
@@ -122,11 +122,11 @@ LIC_3           (C ( 0.0   1.0 0.0427  0.0 0.0 0.0 0.0)) (lB  0.461)
 LIC_4           (C ( 0.0   1.0    0.0  0.0 0.0 0.0 0.0))             (uB 1.745)
 LIC_5           (C ( 0.0   0.0    0.0  2.5 1.0 0.0 0.0))             (uB 5.280)
 LIC_6           (C ( 0.0   0.0    0.0 -2.5 1.0 0.0 0.0)) (lB -5.280)
-\endcode 
- 
+\endcode
+
 \note for a detailed description of options, see \ref iKinSlv
       "Cartesian Solver".
- 
+
 \section tested_os_sec Tested OS
 Windows, Linux
 

--- a/src/modules/iKinGazeCtrl/include/iCub/utils.h
+++ b/src/modules/iKinGazeCtrl/include/iCub/utils.h
@@ -131,8 +131,6 @@ public:
     std::pair<Vector,bool>  get_gyro();
     std::pair<Vector,bool>  get_accel();
 
-    string  headVersion2String();
-
     // data members that do not need protection
     xdPort         *port_xd;
     string          robotName;
@@ -142,7 +140,7 @@ public:
     double          eyesBoundVer;
     double          gyro_noise_threshold;
     double          stabilizationGain;
-    double          head_version;
+    iKinLimbVersion head_version;
     double          saccadesInhibitionPeriod;
     double          saccadesActivationAngle;
     int             neckSolveCnt;

--- a/src/modules/iKinGazeCtrl/src/controller.cpp
+++ b/src/modules/iKinGazeCtrl/src/controller.cpp
@@ -34,10 +34,10 @@ Controller::Controller(PolyDriver *_drvTorso, PolyDriver *_drvHead, ExchangeData
                        printAccTime(0.0)
 {
     // Instantiate objects
-    neck=new iCubHeadCenter("right_"+commData->headVersion2String());
-    eyeL=new iCubEye("left_"+commData->headVersion2String());
-    eyeR=new iCubEye("right_"+commData->headVersion2String());
-    imu=new iCubInertialSensor(commData->headVersion2String());
+    neck=new iCubHeadCenter("right_v"+commData->head_version.get_version());
+    eyeL=new iCubEye("left_v"+commData->head_version.get_version());
+    eyeR=new iCubEye("right_v"+commData->head_version.get_version());
+    imu=new iCubInertialSensor(commData->head_version.get_version());
 
     // remove constraints on the links: logging purpose
     imu->setAllConstraints(false);

--- a/src/modules/iKinGazeCtrl/src/localizer.cpp
+++ b/src/modules/iKinGazeCtrl/src/localizer.cpp
@@ -31,7 +31,7 @@ Localizer::Localizer(ExchangeData *_commData, const unsigned int _period) :
 {
     iCubHeadCenter eyeC("right_v"+commData->head_version.get_version());
     eyeL=new iCubEye("left_v"+commData->head_version.get_version());
-    eyeR=new iCubEye("rightv_"+commData->head_version.get_version());
+    eyeR=new iCubEye("right_v"+commData->head_version.get_version());
 
     // remove constraints on the links
     // we use the chains for logging purpose

--- a/src/modules/iKinGazeCtrl/src/localizer.cpp
+++ b/src/modules/iKinGazeCtrl/src/localizer.cpp
@@ -29,9 +29,9 @@ Localizer::Localizer(ExchangeData *_commData, const unsigned int _period) :
                      PeriodicThread((double)_period/1000.0), commData(_commData),
                      period(_period)
 {
-    iCubHeadCenter eyeC("right_"+commData->headVersion2String());
-    eyeL=new iCubEye("left_"+commData->headVersion2String());
-    eyeR=new iCubEye("right_"+commData->headVersion2String());
+    iCubHeadCenter eyeC("right_v"+commData->head_version.get_version());
+    eyeL=new iCubEye("left_v"+commData->head_version.get_version());
+    eyeR=new iCubEye("rightv_"+commData->head_version.get_version());
 
     // remove constraints on the links
     // we use the chains for logging purpose

--- a/src/modules/iKinGazeCtrl/src/main.cpp
+++ b/src/modules/iKinGazeCtrl/src/main.cpp
@@ -17,9 +17,9 @@
 */
 
 /**
-\defgroup iKinGazeCtrl iKinGazeCtrl
-
 @ingroup icub_module
+
+\defgroup iKinGazeCtrl iKinGazeCtrl
 
 Gaze controller based on iKin.
 
@@ -212,8 +212,7 @@ Factors</a>.
 
 --head_version \e ver
 - This option specifies the kinematic structure of the head; the value
-  \e ver is a double in the set {1.0, 2.0, 2.5, 2.6, 2.7, 3.0}, being 1.0
-  the default version.
+  \e ver is a string (e.g., "1.0", "2.0"), being "1.0" the default.
 
 --verbose
 - Enable some output print-out.
@@ -432,7 +431,7 @@ following ports:
       target with stereo input.
     - [get] [info]: returns (enclosed in a list) a property-like
       bottle containing useful information, such as the
-      "head_version" (e.g. 1.0, 2.0, ...), the
+      "head_version" (e.g. "1.0", "2.0", ...), the
       "min_allowed_vergence" (in degrees), a list of the
       available "events", the intrinsic and extrinsic camera
       parameters used.

--- a/src/modules/iKinGazeCtrl/src/main.cpp
+++ b/src/modules/iKinGazeCtrl/src/main.cpp
@@ -212,7 +212,7 @@ Factors</a>.
 
 --head_version \e ver
 - This option specifies the kinematic structure of the head; the value
-  \e ver is a string (e.g., "1.0", "2.0"), being "1.0" the default.
+  \e ver is a string (e.g., "v1.0", "v2.0"), being "v1.0" the default.
 
 --verbose
 - Enable some output print-out.
@@ -564,6 +564,8 @@ Windows, Linux
 #include <mutex>
 #include <cmath>
 #include <algorithm>
+#include <cctype>
+#include <string>
 #include <fstream>
 #include <iomanip>
 #include <map>
@@ -1138,10 +1140,17 @@ public:
         min_abs_vel=CTRL_DEG2RAD*fabs(rf.check("min_abs_vel",Value(0.0)).asFloat64());
         ping_robot_tmo=rf.check("ping_robot_tmo",Value(40.0)).asFloat64();
 
+        auto head_version=rf.check("head_version",Value("v1.0")).asString();
+        if ((head_version.length()<2) || (tolower(head_version[0])!='v'))
+        {
+            yWarning("Unrecognized \"head_version\" %s; going with default version",head_version.c_str());
+            head_version="v1.0";
+        }
+        commData.head_version = constrainHeadVersion(iKinLimbVersion(head_version.substr(1)));
+
         commData.robotName=rf.check("robot",Value("icub")).asString();
         commData.eyeTiltLim[0]=eyeTiltGroup.check("min",Value(-20.0)).asFloat64();
         commData.eyeTiltLim[1]=eyeTiltGroup.check("max",Value(15.0)).asFloat64();
-        commData.head_version=constrainHeadVersion(iKinLimbVersion(rf.check("head_version",Value("1.0")).asString()));
         commData.verbose=rf.check("verbose");
         commData.saccadesOn=(rf.check("saccades",Value("on")).asString()=="on");
         commData.neckPosCtrlOn=(rf.check("neck_position_control",Value("on")).asString()=="on");

--- a/src/modules/iKinGazeCtrl/src/main.cpp
+++ b/src/modules/iKinGazeCtrl/src/main.cpp
@@ -155,7 +155,7 @@ Factors</a>.
 
 --imu::source_port_name \e name
 - Allow specifying a different source port for the IMU data
-  (see IMU filtering tools such as e.g. \ref imuFilter).
+  (see IMU filtering tools such as e.g. imuFilter).
 
 --imu::stabilization_gain \e gain
 - Specify the integral gain (in [1/s]) used for gaze
@@ -301,7 +301,6 @@ following ports:
 - \e /<ctrlName>/q:o returns the actual joints configuration
   during movement (Vector of 9 double). The order for torso
   angles is the one defined by kinematic chain.
-  Useful in conjunction with the \ref iKinGazeView "viewer".
   Units in degrees.
 
 - \e /<ctrlName>/angles:o returns the current azimuth/elevation

--- a/src/modules/iKinGazeCtrl/src/solver.cpp
+++ b/src/modules/iKinGazeCtrl/src/solver.cpp
@@ -32,10 +32,10 @@ EyePinvRefGen::EyePinvRefGen(PolyDriver *_drvTorso, PolyDriver *_drvHead,
                              Ts(_period/1000.0),                     counterRotGain(_counterRotGain)
 {
     // Instantiate objects
-    neck=new iCubHeadCenter("right_"+commData->headVersion2String());
-    eyeL=new iCubEye("left_"+commData->headVersion2String());
-    eyeR=new iCubEye("right_"+commData->headVersion2String());
-    imu=new iCubInertialSensor(commData->headVersion2String());
+    neck=new iCubHeadCenter("right_v"+commData->head_version.get_version());
+    eyeL=new iCubEye("left_v"+commData->head_version.get_version());
+    eyeR=new iCubEye("right_v"+commData->head_version.get_version());
+    imu=new iCubInertialSensor(commData->head_version.get_version());
 
     // remove constraints on the links: logging purpose
     imu->setAllConstraints(false);
@@ -465,10 +465,10 @@ Solver::Solver(PolyDriver *_drvTorso, PolyDriver *_drvHead, ExchangeData *_commD
                ctrl(_ctrl),                            period(_period),         Ts(_period/1000.0)
 {
     // Instantiate objects
-    neck=new iCubHeadCenter("right_"+commData->headVersion2String());
-    eyeL=new iCubEye("left_"+commData->headVersion2String());
-    eyeR=new iCubEye("right_"+commData->headVersion2String());
-    imu=new iCubInertialSensor(commData->headVersion2String());
+    neck=new iCubHeadCenter("right_v"+commData->head_version.get_version());
+    eyeL=new iCubEye("left_v"+commData->head_version.get_version());
+    eyeR=new iCubEye("right_v"+commData->head_version.get_version());
+    imu=new iCubInertialSensor(commData->head_version.get_version());
     torsoVel=new AWLinEstimator(16,0.5);    
 
     // remove constraints on the links: logging purpose

--- a/src/modules/iKinGazeCtrl/src/utils.cpp
+++ b/src/modules/iKinGazeCtrl/src/utils.cpp
@@ -19,7 +19,6 @@
 #include <cmath>
 #include <limits>
 #include <algorithm>
-#include <sstream>
 
 #include <iCub/utils.h>
 #include <iCub/solver.h>
@@ -157,7 +156,7 @@ ExchangeData::ExchangeData()
 
     robotName="";
     localStemName="";
-    head_version=1.0;
+    head_version=iKinLimbVersion("1.0");
     tweakOverwrite=true;
     tweakFile="";
     iGyro = nullptr;
@@ -375,13 +374,6 @@ std::pair<Vector,bool>  ExchangeData::get_accel() {
     return ret; // RVO
 }
 
-/************************************************************************/
-string ExchangeData::headVersion2String()
-{
-    ostringstream str;
-    str<<"v"<<head_version;
-    return str.str();
-}
 
 /************************************************************************/
 bool GazeComponent::getExtrinsicsMatrix(const string &type, Matrix &M)
@@ -555,7 +547,7 @@ Matrix alignJointsBounds(iKinChain *chain, PolyDriver *drvTorso,
         {   
             if (lims->getLimits(i,&min,&max))
             {
-                if (commData->head_version<3.0)
+                if (commData->head_version<iKinLimbVersion("3.0"))
                 {
                     (*chain)[nJointsTorso-1-i].setMin(CTRL_DEG2RAD*min);
                     (*chain)[nJointsTorso-1-i].setMax(CTRL_DEG2RAD*max);
@@ -657,7 +649,7 @@ bool getFeedback(Vector &fbTorso, Vector &fbHead, PolyDriver *drvTorso,
         if (encs->getEncodersTimed(fb.data(),stamps.data()))
         {
             for (int i=0; i<nJointsTorso; i++)
-                fbTorso[i]=CTRL_DEG2RAD*((commData->head_version<3.0)?fb[nJointsTorso-1-i]:fb[i]);
+                fbTorso[i]=CTRL_DEG2RAD*((commData->head_version<iKinLimbVersion("3.0"))?fb[nJointsTorso-1-i]:fb[i]);
         }
         else
             ret=false;

--- a/src/modules/skinManager/include/iCub/skinManager/skinManager.h
+++ b/src/modules/skinManager/include/iCub/skinManager/skinManager.h
@@ -28,7 +28,7 @@ and writes the compensated values on output ports.
 The module can manage many input ports at the same time (see parameter "inputPorts").
 For each input port the compensated tactile data are written on the corresponding output port (see parameter "outputPorts").
 Optionally, the module also can apply a smoothing filter (low pass filter) and/or a binarization filter to the data.
-The \ref icub_skinManagerGui can be used to control and monitor an instance of the skinManager module.
+The skinManagerGui can be used to control and monitor an instance of the skinManager module.
 If the 3d position of the tactile sensors is provided, then this module computes the skinContacts (see library skinDynLib),
  which can be used by \ref wholeBodyDynamics to compute the contact forces.
 
@@ -143,11 +143,11 @@ will be accessed.
 - Every port specified in the "outputPorts" parameter: outputs a yarp::sig::Vector containing the compensated tactile data.
 - "/"+moduleName+"/monitor:o": \n 
     outputs a yarp::os::Bottle containing streaming information regarding the compensation status 
-    (used to communicate with the \ref icub_skinManagerGui). The first value is the data frequency, while
+    (used to communicate with the skinManagerGui). The first value is the data frequency, while
     all the following ones represent the drift compensated so far for each taxel.
 - "/"+moduleName+"/info:o": \n 
     outputs a yarp::os::Bottle containing occasional information regarding the compensation status 
-    such as warning or error messages (used to communicate with the \ref icub_skinManagerGui). Possible messages may regard 
+    such as warning or error messages (used to communicate with the skinManagerGui). Possible messages may regard 
     an error in the sensor reading or an excessive drift of the baseline of a taxel.\n
 - "/"+moduleName+"/skin_events:o": \n
     outputs a iCub::skinDynLib::skinContactList containing the list of contacts.
@@ -155,7 +155,7 @@ will be accessed.
 <b>Input ports</b>
 - For each port specified in the "inputPorts" parameter a local port is created with the name
   "/"+moduleName+index+"/input", where "index" is an increasing counter starting from 0.
-- "/"+moduleName+"/rpc:i": input port to control the module (alternatively the \ref icub_skinManagerGui can be used). 
+- "/"+moduleName+"/rpc:i": input port to control the module (alternatively the skinManagerGui can be used). 
     This port accepts a yarp::os::yarp::os::Bottle that contains one of these commands:
     - "calib": force the sensor calibration
     - "get touch thr": return a yarp::os::yarp::os::Bottle containing the 95 percentile values of the tactile sensors

--- a/src/modules/templatePFTracker/src/main.cpp
+++ b/src/modules/templatePFTracker/src/main.cpp
@@ -16,12 +16,24 @@
  * Public License for more details
  */
 
-/** 
-\defgroup icub_templatePFTracker Template Tracking with Particle Filter
+/**
 @ingroup icub_module
- 
-This module expects a template from the following port /templatePFTracker/template/image:i in order to commence tracking. This is a simple single-object tracker that uses a color histogram-based observation model. 
-Particle filtering is a Monte Carlo sampling approach to Bayesian filtering.The particle filtering algorithm maintains a probability distribution over the state of the system it is monitoring, in this case, the state -- location, scale, etc. -- of the object being tracked. Particle filtering represents the distribution as a set of weighted samples, or particles. Each particle describes one possible location of the object being tracked. The set of particles contains more weight at locations where the object being tracked is more likely to be. The most probable state of the object is determined by finding the location in the particle filtering distribution with the highest weight.
+
+\defgroup icub_templatePFTracker Template Tracking with Particle Filter
+
+This module expects a template from the following port
+/templatePFTracker/template/image:i in order to commence tracking. This is a
+simple single-object tracker that uses a color histogram-based observation
+model. Particle filtering is a Monte Carlo sampling approach to Bayesian
+filtering.The particle filtering algorithm maintains a probability distribution
+over the state of the system it is monitoring, in this case, the state --
+location, scale, etc. -- of the object being tracked. Particle filtering
+represents the distribution as a set of weighted samples, or particles. Each
+particle describes one possible location of the object being tracked. The set of
+particles contains more weight at locations where the object being tracked is
+more likely to be. The most probable state of the object is determined by
+finding the location in the particle filtering distribution with the highest
+weight.
 
 \section lib_sec Libraries
 YARP libraries and OpenCV
@@ -30,80 +42,84 @@ YARP libraries and OpenCV
 
 Command-line Parameters
 
-The following key-value pairs can be specified as command-line parameters by prefixing \c -- to the key 
-(e.g. \c --from file.ini. The value part can be changed to suit your needs; the default values are shown below. 
+The following key-value pairs can be specified as command-line parameters by
+prefixing \c -- to the key (e.g. \c --from file.ini. The value part can be
+changed to suit your needs; the default values are shown below.
 
-- \c from \c templatePFTracker.ini \n 
+- \c from \c templatePFTracker.ini \n
   specifies the configuration file
 
 - \c context \c particleFiltering \n
   specifies the sub-path from \c $ICUB_ROOT/icub/app to the configuration file
 
-- \c name \c templatePFTracker \n   
-  specifies the name of the module (used to form the stem of module port names)  
+- \c name \c templatePFTracker \n
+  specifies the name of the module (used to form the stem of module port names)
 
 <b>Configuration File Parameters </b>
 
-The following key-value pairs can be specified as parameters in the configuration file 
-(they can also be specified as command-line parameters if you so wish). 
-The value part can be changed to suit your needs; the default values are shown below. 
-  
-- \c inputPortNameTemp \c /templatePFTracker/template/image:i \n    
-  specifies the input port name (this string will be prefixed by \c /templatePFTracker 
-  or whatever else is specifed by the name parameter
+The following key-value pairs can be specified as parameters in the
+configuration file (they can also be specified as command-line parameters if you
+so wish). The value part can be changed to suit your needs; the default values
+are shown below.
 
-- \c inputPortNameLeft \c /templatePFTracker/left/image:i \n    
-  specifies the input port name (this string will be prefixed by \c /templatePFTracker 
-  or whatever else is specifed by the name parameter
+- \c inputPortNameTemp \c /templatePFTracker/template/image:i \n
+  specifies the input port name (this string will be prefixed by \c
+/templatePFTracker or whatever else is specifed by the name parameter
 
-- \c inputPortNameRight \c /templatePFTracker/right/image:i \n    
-  specifies the input port name (this string will be prefixed by \c /templatePFTracker 
-  or whatever else is specifed by the name parameter
+- \c inputPortNameLeft \c /templatePFTracker/left/image:i \n
+  specifies the input port name (this string will be prefixed by \c
+/templatePFTracker or whatever else is specifed by the name parameter
 
-- \c outputPortNameLeft \c /templatePFTracker/left/image:o \n  
-  specifies the output port name (this string will be prefixed by \c /templatePFTracker 
-  or whatever else is specifed by the name parameter
+- \c inputPortNameRight \c /templatePFTracker/right/image:i \n
+  specifies the input port name (this string will be prefixed by \c
+/templatePFTracker or whatever else is specifed by the name parameter
 
-- \c outputPortNameRight \c /templatePFTracker/right/image:o \n  
-  specifies the output port name (this string will be prefixed by \c /templatePFTracker 
-  or whatever else is specifed by the name parameter
+- \c outputPortNameLeft \c /templatePFTracker/left/image:o \n
+  specifies the output port name (this string will be prefixed by \c
+/templatePFTracker or whatever else is specifed by the name parameter
 
-  \c outputPortNameLeftBlob \c /templatePFTracker/leftblob/image:o \n  
-  specifies the output port name (this string will be prefixed by \c /templatePFTracker 
-  or whatever else is specifed by the name parameter
+- \c outputPortNameRight \c /templatePFTracker/right/image:o \n
+  specifies the output port name (this string will be prefixed by \c
+/templatePFTracker or whatever else is specifed by the name parameter
 
-- \c outputPortNameLeftBlob \c /templatePFTracker/rightblob/image:o \n  
-  specifies the output port name (this string will be prefixed by \c /templatePFTracker 
-  or whatever else is specifed by the name parameter
+  \c outputPortNameLeftBlob \c /templatePFTracker/leftblob/image:o \n
+  specifies the output port name (this string will be prefixed by \c
+/templatePFTracker or whatever else is specifed by the name parameter
 
-- \c outputPortNameTarget \c /templatePFTracker/target:o \n  
-  specifies the output port name (this string will be prefixed by \c /templatePFTracker 
-  or whatever else is specifed by the name parameter
-  Sends a Bottle list containing info on the tracking process:
-  cog.x + cog.y + boundingBox.topLeft.x + boundingBox.topLeft.y
+- \c outputPortNameLeftBlob \c /templatePFTracker/rightblob/image:o \n
+  specifies the output port name (this string will be prefixed by \c
+/templatePFTracker or whatever else is specifed by the name parameter
+
+- \c outputPortNameTarget \c /templatePFTracker/target:o \n
+  specifies the output port name (this string will be prefixed by \c
+/templatePFTracker or whatever else is specifed by the name parameter Sends a
+Bottle list containing info on the tracking process: cog.x + cog.y +
+boundingBox.topLeft.x + boundingBox.topLeft.y
   + boundingBox.BottomRight.x + boundingBox.BottomRight.y eg:
   (180.0 116.0 167.0 102.0 193.0 130.0)
 
 \section portsa_sec Ports Accessed
 
 - None
-                     
+
 \section portsc_sec Ports Created
 
  <b>Input ports</b>
 
  - \c /templatePFTracker \n
-   This port is used to change the parameters of the module at run time or stop the module. \n
-   The following commands are available
+   This port is used to change the parameters of the module at run time or stop
+the module. \n The following commands are available
 
    \c help \n
    \c quit \n
 
-   Note that the name of this port mirrors whatever is provided by the \c --name parameter value
-   The port is attached to the terminal so that you can type in commands and receive replies.
-   The port can be used by other modules but also interactively by a user through the yarp rpc directive, viz.: \c yarp \c rpc \c /yuvProc
-   This opens a connection from a terminal to the port and allows the user to then type in commands and receive replies.
-      
+   Note that the name of this port mirrors whatever is provided by the \c --name
+parameter value The port is attached to the terminal so that you can type in
+commands and receive replies. The port can be used by other modules but also
+interactively by a user through the yarp rpc directive, viz.: \c yarp \c rpc \c
+/yuvProc This opens a connection from a terminal to the port and allows the user
+to then type in commands and receive replies.
+
  - \c /templatePFTracker/template/image:i \n
  - \c /templatePFTracker/left/image:i \n
  - \c /templatePFTracker/right/image:i \n
@@ -132,18 +148,19 @@ None
 
 \section tested_os_sec Tested OS
 
-Linux: Ubuntu 9.10 and Debian Stable 
+Linux: Ubuntu 9.10 and Debian Stable
 
 \section example_sec Example Instantiation of the Module
 
-<tt>templatePFTracker --name tracker --context templatePFTracker --from templatePFTracker.ini </tt>
+<tt>templatePFTracker --name tracker --context templatePFTracker --from
+templatePFTracker.ini </tt>
 
-\author Vadim Tikhanoff 
+\author Vadim Tikhanoff
 
 Copyright (C) 2009 RobotCub Consortium
 
 CopyPolicy: Released under the terms of the GNU GPL v2.0.
-*/ 
+*/
 
 #include <iCub/particleFilter.h>
 

--- a/src/modules/velocityControl/main.cpp
+++ b/src/modules/velocityControl/main.cpp
@@ -46,8 +46,7 @@ module.
 (possible values are 20 or 10).
 
 \section portsa_sec Ports Accessed
-It assumes \ref icub_iCubInterface runs. It accesses velocity and 
-encoder ports created by iCubInterface.
+It accesses ports created when the robot is launched.
 
 \section portsc_sec Ports Created
 The module instantiates a control_board device, which opens the

--- a/src/tools/fingersTuner/idl_dox/fingersTuner_IDL.h
+++ b/src/tools/fingersTuner/idl_dox/fingersTuner_IDL.h
@@ -10,10 +10,9 @@
 
 class fingersTuner_IDL;
 
-
 /**
  * fingersTuner_IDL
- * IDL Interface to \ref fingersTuner services.
+ * IDL Interface to \ref icub_fingersTuner services.
  */
 class fingersTuner_IDL : public yarp::os::Wire {
 public:

--- a/src/tools/fingersTuner/main.cpp
+++ b/src/tools/fingersTuner/main.cpp
@@ -16,8 +16,9 @@
 */
 
 /**
-\defgroup icub_fingersTuner Fingers PID Tuner
 @ingroup icub_tools
+
+\defgroup icub_fingersTuner Fingers PID Tuner
 
 A module that provides tuning capabilities of the low-level PID
 controllers for the robot's fingers.
@@ -67,7 +68,8 @@ in the first case it is asked the module at startup to store locally the PIDs
 values available onboard the robot, while in the second case the local
 configuration values will be uploaded to the robot. \n
 The option <b>idling</b> allows putting in idle specific coupled joints that
-should be not controlled in position during the tuning of the joint under subject.
+should be not controlled in position during the tuning of the joint under
+subject.
 
 \section portsif_sec Ports Interface
 The interface to this module is implemented through

--- a/src/tools/iCubGui/src/main.cpp
+++ b/src/tools/iCubGui/src/main.cpp
@@ -12,110 +12,110 @@
  */
 
 /**
-*
-* \defgroup icub_gui iCubGui
-* @ingroup icub_guis
-*
-*
-* A gui that shows the full state of the robot. At the moment
-* encoders and inertial sensors.
-*
-*
-* \section intro_sec Description
-*
-* Display a kinematic model of the robot from the encoders. It also
-* shows a representation of the output of the inertial sensor.
-*
-* \image html icubgui-merged.jpg "Screenshots: iCubGui running on Linux"
-* \image latex icubgui1.eps "Screenshots: iCubGui running on Linux" width=10cm
-*
-* \section visobj_sec Vision objects
-*
-* iCubGui can also display data blobs from vision modules, representing them as
-* 3D ellipsoids characterized by name, dimensions, color, transparency, position
-* and orientation. Objects in iCubGui are managed by a port specified in the
-* iCubGui.ini configuration file with the tag \e objport, as follows:
-*
-* \code
-* robot /icubSim
-* geometry skeleton.ini
-* objport /iCubGui/objects
-* \endcode
-*
-* To add an object to the display object list, send to iCubGui a bottle
-* composed as following on the port specified in iCubGui.ini:
-*
-* \code
-* yarp::os::Bottle obj;
-*
-* obj.addString("object"); // command to add/update an object
-* obj.addString("my_object_name");
-*
-* // object dimensions in millimiters
-* // (it will be displayed as an ellipsoid with the tag "my_object_name")
-* obj.addFloat64(dimX);
-* obj.addFloat64(dimY);
-* obj.addFloat64(dimZ);
-*
-* // object position in millimiters
-* // reference frame: X=fwd, Y=left, Z=up
-* obj.addFloat64(posX);
-* obj.addFloat64(posY);
-* obj.addFloat64(posZ);
-*
-* // object orientation (roll, pitch, yaw) in degrees
-* obj.addFloat64(rotX);
-* obj.addFloat64(rotY);
-* obj.addFloat64(rotZ);
-*
-* // object color (0-255)
-* obj.addInt32(R);
-* obj.addInt32(G);
-* obj.addInt32(B);
-* // transparency (0.0=invisible 1.0=solid)
-* obj.addFloat64(alpha);
-* \endcode
-*
-* To delete an object:
-*
-* \code
-* yarp::os::Bottle obj;
-*
-* obj.addString("delete");
-* obj.addString("my_object_name");
-* \endcode
-*
-* To reset the object list:
-*
-* \code
-* yarp::os::Bottle obj;
-*
-* obj.addString("reset");
-* \endcode
-*
-* \section lib_sec Libraries
-*  - YARP
-*  - Qt5, glut, opengl.
-*
-* \section parameters_sec Parameters
-* None.
-*
-* \section portsa_sec Ports Accessed
-*
-* Needs access to all the robot interfaces and ports (from iCubInterface).
-*
-* \section tested_os_sec Tested OS
-*
-* Linux and Windows.
-*
-* \author Alessandro Scalzo
-*
-* Copyright (C) 2009 RobotCub Consortium
-*
-* CopyPolicy: Released under the terms of the GNU GPL v2.0.
-*
-* This file can be edited at src/gui/iCubGui/src/main.cpp.
-*/
+ * @ingroup icub_guis
+ * 
+ * \defgroup icub_gui iCubGui
+ *
+ *
+ * A gui that shows the full state of the robot. At the moment
+ * encoders and inertial sensors.
+ *
+ *
+ * \section intro_sec Description
+ *
+ * Display a kinematic model of the robot from the encoders. It also
+ * shows a representation of the output of the inertial sensor.
+ *
+ * \image html icubgui-merged.jpg "Screenshots: iCubGui running on Linux"
+ * \image latex icubgui1.eps "Screenshots: iCubGui running on Linux" width=10cm
+ *
+ * \section visobj_sec Vision objects
+ *
+ * iCubGui can also display data blobs from vision modules, representing them as
+ * 3D ellipsoids characterized by name, dimensions, color, transparency,
+ * position and orientation. Objects in iCubGui are managed by a port specified
+ * in the iCubGui.ini configuration file with the tag \e objport, as follows:
+ *
+ * \code
+ * robot /icubSim
+ * geometry skeleton.ini
+ * objport /iCubGui/objects
+ * \endcode
+ *
+ * To add an object to the display object list, send to iCubGui a bottle
+ * composed as following on the port specified in iCubGui.ini:
+ *
+ * \code
+ * yarp::os::Bottle obj;
+ *
+ * obj.addString("object"); // command to add/update an object
+ * obj.addString("my_object_name");
+ *
+ * // object dimensions in millimiters
+ * // (it will be displayed as an ellipsoid with the tag "my_object_name")
+ * obj.addFloat64(dimX);
+ * obj.addFloat64(dimY);
+ * obj.addFloat64(dimZ);
+ *
+ * // object position in millimiters
+ * // reference frame: X=fwd, Y=left, Z=up
+ * obj.addFloat64(posX);
+ * obj.addFloat64(posY);
+ * obj.addFloat64(posZ);
+ *
+ * // object orientation (roll, pitch, yaw) in degrees
+ * obj.addFloat64(rotX);
+ * obj.addFloat64(rotY);
+ * obj.addFloat64(rotZ);
+ *
+ * // object color (0-255)
+ * obj.addInt32(R);
+ * obj.addInt32(G);
+ * obj.addInt32(B);
+ * // transparency (0.0=invisible 1.0=solid)
+ * obj.addFloat64(alpha);
+ * \endcode
+ *
+ * To delete an object:
+ *
+ * \code
+ * yarp::os::Bottle obj;
+ *
+ * obj.addString("delete");
+ * obj.addString("my_object_name");
+ * \endcode
+ *
+ * To reset the object list:
+ *
+ * \code
+ * yarp::os::Bottle obj;
+ *
+ * obj.addString("reset");
+ * \endcode
+ *
+ * \section lib_sec Libraries
+ *  - YARP
+ *  - Qt5, glut, opengl.
+ *
+ * \section parameters_sec Parameters
+ * None.
+ *
+ * \section portsa_sec Ports Accessed
+ *
+ * Needs access to all the robot interfaces and ports (from iCubInterface).
+ *
+ * \section tested_os_sec Tested OS
+ *
+ * Linux and Windows.
+ *
+ * \author Alessandro Scalzo
+ *
+ * Copyright (C) 2009 RobotCub Consortium
+ *
+ * CopyPolicy: Released under the terms of the GNU GPL v2.0.
+ *
+ * This file can be edited at src/gui/iCubGui/src/main.cpp.
+ */
 
 #include <signal.h>
 

--- a/src/tools/joystickCheck/joystickCheck.cpp
+++ b/src/tools/joystickCheck/joystickCheck.cpp
@@ -16,43 +16,45 @@
  * Public License for more details
 */
 
-/** 
-\defgroup joystickCheck joystickCheck
- 
+/**
 @ingroup icub_tools
- 
+
+\defgroup joystickCheck joystickCheck
+
 This module is used to check if one joystick is currently used.
- 
+
 Copyright (C) 2011 RobotCub Consortium
- 
+
 Author: Marco Randazzo
 
 CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
 \section intro_sec Description
- 
-The module returns 1 to the O.S. if at least one axis/button of the default joystick is pressed, 0 otherwise (no axis/buttons pressed or no joysticks active).
+
+The module returns 1 to the O.S. if at least one axis/button of the default
+joystick is pressed, 0 otherwise (no axis/buttons pressed or no joysticks
+active).
 
 \section portsa_sec Ports Accessed
-None. 
- 
-\section portsc_sec Ports Created 
-None. 
+None.
+
+\section portsc_sec Ports Created
+None.
 
 \section in_files_sec Input Data Files
 None.
 
-\section out_data_sec Output Data Files 
-None. 
- 
+\section out_data_sec Output Data Files
+None.
+
 \section conf_file_sec Configuration Files
-None. 
+None.
 
 \section tested_os_sec Tested OS
 Windows, Linux
 
 \author Marco Randazzo
-*/ 
+*/
 
 #include <iostream>
 #include <SDL.h>

--- a/src/tools/joystickCtrl/main.cpp
+++ b/src/tools/joystickCtrl/main.cpp
@@ -16,58 +16,61 @@
  * Public License for more details
 */
 
-/** 
-\defgroup joystickCtrl joystickCtrl
- 
+/**
 @ingroup icub_tools
- 
+
+\defgroup joystickCtrl joystickCtrl
+
 A configurable tool to send on a yarp port the data retrieved from a joystick.
- 
+
 Copyright (C) 2010 RobotCub Consortium
- 
+
 Author: Marco Randazzo
 
 CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
 \section intro_sec Description
- 
+
 This module reads the axis data from a connected joystick and
-outputs them on a yarp port. The format of the output can be specified using a configuration file.
- 
-\section lib_sec Libraries 
-- YARP libraries. 
+outputs them on a yarp port. The format of the output can be specified using a
+configuration file.
+
+\section lib_sec Libraries
+- YARP libraries.
 - SDL libraries.
 
 \section parameters_sec Parameters
-The only used parameter is the name of the configuration file. The configuration file name can be specified using --from \e file 
-You can also use the \e --context option to change the current context (e.g. the directory where to search the configuration file).
- 
+The only used parameter is the name of the configuration file. The configuration
+file name can be specified using --from \e file You can also use the \e
+--context option to change the current context (e.g. the directory where to
+search the configuration file).
+
 \section portsa_sec Ports Accessed
-None. 
- 
-\section portsc_sec Ports Created 
+None.
+
+\section portsc_sec Ports Created
 The module creates the port /joystickCtrl:o used to transmit the joystick data.
-The output of the port consists in a sequence of <n> doubles (<n> depending on the number of axes specified
-in the configuration file) containing the readings.
+The output of the port consists in a sequence of <n> doubles (<n> depending on
+the number of axes specified in the configuration file) containing the readings.
 The port /joystickCtrl/axis:o contains the axis output only (raw data).
 The port /joystickCtrl/buttons:o contains the buttons output only (raw data).
 
 \section in_files_sec Input Data Files
 None.
 
-\section out_data_sec Output Data Files 
-None. 
- 
+\section out_data_sec Output Data Files
+None.
+
 \section conf_file_sec Configuration Files
-A description of the available configuration options can be 
-found in the example files located under joystickControl 
-context. 
- 
+A description of the available configuration options can be
+found in the example files located under joystickControl
+context.
+
 \section tested_os_sec Tested OS
 Windows, Linux
 
 \author Marco Randazzo
-*/ 
+*/
 
 #include <yarp/os/Network.h>
 #include <yarp/os/RFModule.h>

--- a/src/tools/stereoCalib/src/main.cpp
+++ b/src/tools/stereoCalib/src/main.cpp
@@ -17,25 +17,26 @@
 */
 
 /**
-\defgroup icub_stereoCalib stereoCalib
-
 @ingroup icub_tools
+
+\defgroup icub_stereoCalib stereoCalib
 
 Calibrate the iCub's stereo system (both intrinsics and extrinsics).
 
 Copyright (C) 2011 RobotCub Consortium
- 
+
 Author: Sean Ryan Fanello
- 
+
 Date: first release on 26/03/2011
 
 CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
 \section intro_sec Description
-The module performs the stereo calibration (both intrinsic and extrinsic parameters).
-A chessboard pattern is required, for convenience, a chessboard calibration image is provided in the 
-icub-main/app/cameraCalibration/data directory. In the config 
-file calibrationConf.ini you should have the following group: 
+The module performs the stereo calibration (both intrinsic and extrinsic
+parameters). A chessboard pattern is required, for convenience, a chessboard
+calibration image is provided in the icub-main/app/cameraCalibration/data
+directory. In the config file calibrationConf.ini you should have the following
+group:
 
 \code
 [STEREO_CALIBRATION_CONFIGURATION]
@@ -46,54 +47,68 @@ numberOfImages N
 MonoCalib value
 \endcode
 
-This is the ONLY group used by the module. Other groups in your config file will be discarded. See below for the parameter description. Calibration results will be saved in the specified context (default is: $ICUB_ROOT/main/app/cameraCalibration/conf/outputCalib.ini). You should replace your old calibration file (e.g. icubEyes.ini) with this new one.
+This is the ONLY group used by the module. Other groups in your config file will
+be discarded. See below for the parameter description. Calibration results will
+be saved in the specified context (default is:
+$ICUB_ROOT/main/app/cameraCalibration/conf/outputCalib.ini). You should replace
+your old calibration file (e.g. icubEyes.ini) with this new one.
 
-\note If you are using low resolution images (320x240) you should use a big chessboard pattern (i.e. with square side length of ~4cm). 
-\note Make sure to show the pattern horizontally. 
-\note Further information can be found in the <a 
+\note If you are using low resolution images (320x240) you should use a big
+chessboard pattern (i.e. with square side length of ~4cm). \note Make sure to
+show the pattern horizontally. \note Further information can be found in the <a
       href="http://wiki.icub.org/wiki/Stereo_calibration">wiki</a>.
- 
-\section lib_sec Libraries 
+
+\section lib_sec Libraries
 YARP libraries and OpenCV
 
 \section parameters_sec Parameters
---boardWidth \e numOfCornW 
-- The parameter \e numOfCornW identifies the number of inner corners in the Width direction of the chess.
-   
---boardHeight \e numOfCornH 
-- The parameter \e numOfCornH identifies the number of inner corners in the Height direction of the chess.
+--boardWidth \e numOfCornW
+- The parameter \e numOfCornW identifies the number of inner corners in the
+Width direction of the chess.
 
---boardSize \e squareLength 
-- The parameter \e squareLength identifies the length (in meters) of the squares in the chess (usually 0.03m).
+--boardHeight \e numOfCornH
+- The parameter \e numOfCornH identifies the number of inner corners in the
+Height direction of the chess.
 
---numberOfImages \e Num 
-- The parameter \e Num identifies the number of pairs with the pattern needed before the stereo calibration (default 30).
+--boardSize \e squareLength
+- The parameter \e squareLength identifies the length (in meters) of the squares
+in the chess (usually 0.03m).
 
---MonoCalib \e Val 
-- The parameter \e Val identifies if the module has to run the stereo calibration (Val=0) or the mono calibration (Val=1). For the mono calibration connect only the camera that you want to calibrate.
+--numberOfImages \e Num
+- The parameter \e Num identifies the number of pairs with the pattern needed
+before the stereo calibration (default 30).
+
+--MonoCalib \e Val
+- The parameter \e Val identifies if the module has to run the stereo
+calibration (Val=0) or the mono calibration (Val=1). For the mono calibration
+connect only the camera that you want to calibrate.
 
 \section portsc_sec Ports Created
-- <i> /stereoCalib/cam/left:i </i> accepts the incoming images from the left eye. 
-- <i> /stereoCalib/cam/right:i </i> accepts the incoming images from the right eye. 
+- <i> /stereoCalib/cam/left:i </i> accepts the incoming images from the left
+eye.
+- <i> /stereoCalib/cam/right:i </i> accepts the incoming images from the right
+eye.
 
 - <i> /stereoCalib/cam/left:o </i> outputs the left eye image.
 - <i> /stereoCalib/cam/right:o </i> outputs the right eye image.
 
-- <i> /stereoCalib/cmd </i> for terminal commands comunication. 
+- <i> /stereoCalib/cmd </i> for terminal commands comunication.
  Recognized remote commands:
-    - [start]: Starts the calibration procedure, you have to show the chessboard image in different positions and orientations. After N times (N specified in the config file, see above). the module will run the stereo calibration
+    - [start]: Starts the calibration procedure, you have to show the chessboard
+image in different positions and orientations. After N times (N specified in the
+config file, see above). the module will run the stereo calibration
 
 \section in_files_sec Input Data Files
 None.
 
 \section out_data_sec Output Data Files
-outputCalib.ini 
- 
+outputCalib.ini
+
 \section tested_os_sec Tested OS
 Windows and Linux.
 
 \author Sean Ryan Fanello
-*/ 
+*/
 
 #include "stereoCalibModule.h"
 #include <yarp/dev/Drivers.h>


### PR DESCRIPTION
This PR follows up on comments reported in #838 for which limbs version 2.10 is handled equally to 2.1 in iKin, for example.

To remedy this, a dedicated class `iKinLimbVersion` is introduced and thus all the related components have been updated.

This is an old flaw that emerges now as we have crafted the new iCub version 2.10.

The gaze and cartesian controller client/server versions have been upgraded to 2.0 to notify a breaking change in the way `getInfo()` operates for the hardware-version[^1].

Careful tests need to be done.

[^1]: Other code that needs to be upgraded:
      - https://github.com/robotology/stereo-vision/blob/master/lib/src/disparityThread.cpp#L381
      - https://github.com/robotology/icub-basic-demos/blob/master/demoRedBall/src/main.cpp#L706