### PR TITLE
[CI] use `iwr` and `gh` for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,16 @@ jobs:
     # ============
     - name: Dependencies [Windows]
       if: matrix.os == 'windows-latest'
-      shell: bash
+      shell: pwsh
       run: |
-        choco install -y curl wget
-        latest_tag=$(curl --silent https://api.github.com/repos/robotology/robotology-superbuild-dependencies-vcpkg/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
-        echo "Installing robotology-superbuild-dependencies-vcpkg@${latest_tag}"
-        cd C:/
-        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/${latest_tag}/vcpkg-robotology.zip
-        7z x vcpkg-robotology.zip -oC:/
-        echo "VCPKG_INSTALLATION_ROOT=C:/robotology/vcpkg" >> ${GITHUB_ENV}
+        $response = gh api --paginate -H "Accept: application/vnd.github.v3+json" /repos/robotology/robotology-superbuild-dependencies-vcpkg/releases/latest
+        $latest_tag = ($response | ConvertFrom-Json).tag_name
+        echo "Installing robotology-superbuild-dependencies-vcpkg@$latest_tag"
+        iwr -Uri https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/$latest_tag/vcpkg-robotology.zip -OutFile C:/vcpkg-robotology.zip
+        7z x C:/vcpkg-robotology.zip -oC:/
+        "VCPKG_INSTALLATION_ROOT=C:/robotology/vcpkg" >> $env:GITHUB_ENV
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
 
     - name: Dependencies [macOS]
       if: matrix.os == 'macOS-latest'


### PR DESCRIPTION
This PR also solves the rate limited access to retrieve the latest release of the vcpkg dependencies zip.