### PR TITLE
`Firmwareupdater` – Add support for other processes on multi-core boards

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -65,8 +65,8 @@ checkandset_dependency(OpenCV)
 checkandset_dependency(Qt5)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
-  if(icub_firmware_shared_VERSION VERSION_LESS 1.29.0)
-    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected: at least 1.29.0 is required")
+  if(icub_firmware_shared_VERSION VERSION_LESS 1.30.0)
+    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected: at least 1.30.0 is required")
   endif()
 endif()
 

--- a/src/libraries/learningMachine/standalone/CMakeLists.txt
+++ b/src/libraries/learningMachine/standalone/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors: Arjan Gijsberts
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12)
 
 set(PROJECTNAME learningMachine)
 project(${PROJECTNAME})

--- a/src/modules/learningMachine/standalone/CMakeLists.txt
+++ b/src/modules/learningMachine/standalone/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors:  Arjan Gijsberts
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12)
 
 set(PROJECTNAME learningMachine)
 

--- a/src/tools/FirmwareUpdater/firmwareupdatercore.cpp
+++ b/src/tools/FirmwareUpdater/firmwareupdatercore.cpp
@@ -97,8 +97,14 @@ bool FirmwareUpdaterCore::init(Searchable& config, int port, QString address, in
 
                 hostIPaddress = EO_COMMON_IPV4ADDR(ipv0, ipv1, ipv2, ipv3);
 
-                qDebug() << "Invalid IP address found in .ini file (format is 10.0.X.Y:Z , 0 < X,Y < 255 , Z port number)";
-                qDebug() << "Skipped , using defaults!";
+                qDebug() << "Missing or invalid IP address found in .ini file (format is 10.0.X.Y:Z , 0 < X,Y < 255 , Z port number)";
+                qDebug() << "Skipped, using defaults:";
+                if(verbosity >= 1)
+                {
+                    qInfo() << "  - IP address:" << DEFAULT_IP_ADDRESS;
+                    qInfo() << "  - IP port:   " << DEFAULT_IP_PORT;
+                }
+
             }
         }
         
@@ -314,15 +320,17 @@ boardInfo2_t FirmwareUpdaterCore::getMoreDetails(int boardNum,QString *infoStrin
 
 }
 
-QString FirmwareUpdaterCore::getProcessFromUint(uint8_t id)
+QString FirmwareUpdaterCore::getProcessFromUint(uint8_t id, bool isMultiCore)
 {
     switch (id) {
     case uprot_proc_Loader:
         return "eLoader";
     case uprot_proc_Updater:
         return "eUpdater";
-    case uprot_proc_Application:
-        return "eApplication";
+    case uprot_proc_Application00:
+        return isMultiCore ? "eApplication_core_0" : "eApplication";
+    case uprot_proc_Application01:
+        return "eApplication_core_1";
     case uprot_proc_ApplPROGupdater:
         return "eApplPROGupdater";
     default:

--- a/src/tools/FirmwareUpdater/firmwareupdatercore.h
+++ b/src/tools/FirmwareUpdater/firmwareupdatercore.h
@@ -12,6 +12,9 @@
 
 using namespace yarp::os;
 
+#define DEFAULT_IP_ADDRESS "10.0.1.104"
+#define DEFAULT_IP_PORT 3333
+
 class FirmwareUpdaterCore : public QObject
 {
     Q_OBJECT
@@ -53,7 +56,8 @@ public:
     bool goToMaintenance();
     bool eraseEthEprom();
     void eraseCanEprom();
-    QString getProcessFromUint(uint8_t id);
+    QString getProcessFromUint(uint8_t id, bool isMultiCore = false);
+
     cDownloader *getDownloader();
 
 

--- a/src/tools/FirmwareUpdater/mainwindow.cpp
+++ b/src/tools/FirmwareUpdater/mainwindow.cpp
@@ -1009,27 +1009,30 @@ void MainWindow::onAppendInfo(boardInfo2_t info,eOipv4addr_t address)
     infoTreeWidget->addTopLevelItem(propertiesNode);
 
     constexpr uint8_t maxNumberOfProcessesOnSingleCore {3};
-
-    QString type;
-    switch (info.boardtype) {
-    case eobrd_ethtype_ems4:
-        type = "ems";
-        break;
-    case eobrd_ethtype_mc4plus:
-        type = "mc4plus";
-        break;
-    case eobrd_ethtype_mc2plus:
-        type = "mc2plus";
-        break;
-    case eobrd_ethtype_none:
-        type = "none";
-        break;
-    case eobrd_ethtype_unknown:
-        type = "unknown";
-        break;
-    default:
-        break;
-    }
+    
+    QString type = eoboards_type2string(eoboards_ethtype2type(info.boardtype));
+    // switch (info.boardtype) {
+    // case eobrd_ethtype_amc:
+    //     type = "amc";
+    //     break;
+    // case eobrd_ethtype_ems4:
+    //     type = "ems";
+    //     break;
+    // case eobrd_ethtype_mc4plus:
+    //     type = "mc4plus";
+    //     break;
+    // case eobrd_ethtype_mc2plus:
+    //     type = "mc2plus";
+    //     break;
+    // case eobrd_ethtype_none:
+    //     type = "none";
+    //     break;
+    // case eobrd_ethtype_unknown:
+    //     type = "unknown";
+    //     break;
+    // default:
+    //     break;
+    // }
 
     QTreeWidgetItem *typeNode = new QTreeWidgetItem(boardNode, QStringList() << "Type" << type);
     boardNode->addChild(typeNode);
@@ -1093,7 +1096,7 @@ void MainWindow::onAppendInfo(boardInfo2_t info,eOipv4addr_t address)
     boardNode->addChild(statusNode);
 
     /*******************************************************************************/
-    bool isMulticore = info.processes.numberofthem > maxNumberOfProcessesOnSingleCore;
+    bool isMulticore = (eoboards_type2numberofcores(eoboards_ethtype2type(info.boardtype))) > 1 ? true : false;
     QTreeWidgetItem *startUpNode = new QTreeWidgetItem(bootStrapNode, QStringList() << "Startup" << core->getProcessFromUint(info.processes.startup, isMulticore));
     bootStrapNode->addChild(startUpNode);
     bootStrapNode->setExpanded(true);

--- a/src/tools/FirmwareUpdater/mainwindow.cpp
+++ b/src/tools/FirmwareUpdater/mainwindow.cpp
@@ -157,6 +157,7 @@ MainWindow::MainWindow(FirmwareUpdaterCore *core, bool adminMode, QWidget *paren
     connect(ui->btnCahngeInfo,SIGNAL(clicked(bool)),this,SLOT(onChangeInfo(bool)));
     connect(ui->btnChangeIp,SIGNAL(clicked(bool)),this,SLOT(onChangeAddress(bool)));
     connect(ui->btnChangeCanAddr,SIGNAL(clicked(bool)),this,SLOT(onChangeAddress(bool)));
+    connect(ui->btnEraseApplication,SIGNAL(clicked(bool)),this,SLOT(onEraseApplication(bool)));
     connect(ui->btnRestart,SIGNAL(clicked(bool)),this,SLOT(onRestartBoards(bool)));
     //connect(ui->btnRestartSecs,SIGNAL(clicked(bool)),this,SLOT(onRestartBoards5Secs(bool)));
     connect(ui->btnCalibrate,SIGNAL(clicked(bool)),this,SLOT(onCalibrate(bool)));
@@ -716,6 +717,12 @@ void MainWindow::onChangeAddress(bool click)
     }
 }
 
+void MainWindow::onEraseApplication(bool click)
+{
+    // TODO: work in progress
+    std::cout << "Erase application button clicked! Functionality not yet implemented." << std::endl;
+}
+
 void MainWindow::onChangeInfo(bool click)
 {
     if(selectedNodes.count() != 1){
@@ -1001,6 +1008,8 @@ void MainWindow::onAppendInfo(boardInfo2_t info,eOipv4addr_t address)
     infoTreeWidget->addTopLevelItem(bootStrapNode);
     infoTreeWidget->addTopLevelItem(propertiesNode);
 
+    constexpr uint8_t maxNumberOfProcessesOnSingleCore {3};
+
     QString type;
     switch (info.boardtype) {
     case eobrd_ethtype_ems4:
@@ -1084,48 +1093,53 @@ void MainWindow::onAppendInfo(boardInfo2_t info,eOipv4addr_t address)
     boardNode->addChild(statusNode);
 
     /*******************************************************************************/
-
-    QTreeWidgetItem *startUpNode = new QTreeWidgetItem(bootStrapNode, QStringList() << "Startup" << core->getProcessFromUint(info.processes.startup));
+    bool isMulticore = info.processes.numberofthem > maxNumberOfProcessesOnSingleCore;
+    QTreeWidgetItem *startUpNode = new QTreeWidgetItem(bootStrapNode, QStringList() << "Startup" << core->getProcessFromUint(info.processes.startup, isMulticore));
     bootStrapNode->addChild(startUpNode);
     bootStrapNode->setExpanded(true);
 
-    QTreeWidgetItem *defaultNode = new QTreeWidgetItem(bootStrapNode, QStringList() << "Default" << core->getProcessFromUint(info.processes.def2run));
+    QTreeWidgetItem *defaultNode = new QTreeWidgetItem(bootStrapNode, QStringList() << "Default" << core->getProcessFromUint(info.processes.def2run, isMulticore));
     bootStrapNode->addChild(defaultNode);
 
-    QTreeWidgetItem *runningNode = new QTreeWidgetItem(bootStrapNode, QStringList() << "Running" << core->getProcessFromUint(info.processes.runningnow));
+    QTreeWidgetItem *runningNode = new QTreeWidgetItem(bootStrapNode, QStringList() << "Running" << core->getProcessFromUint(info.processes.runningnow, isMulticore));
     bootStrapNode->addChild(runningNode);
 
     /*******************************************************************************/
 
-
     propertiesNode->setExpanded(true);
-    for(int i= 0; i<(int)info.processes.numberofthem;i++){
+    for(uint8_t i= 0; i < info.processes.numberofthem; i++){
+        eOuprot_procinfo_t pinfo;
+        if(i < maxNumberOfProcessesOnSingleCore)
+        {
+            pinfo = info.processes.info[i];
+        }
+        else
+        {
+            pinfo = info.extraprocesses[i-maxNumberOfProcessesOnSingleCore];
+        }
+        
         QTreeWidgetItem *processNode = new QTreeWidgetItem(propertiesNode, QStringList() << QString("Process %1").arg(i));
         propertiesNode->addChild(processNode);
         processNode->setExpanded(true);
 
-        QTreeWidgetItem *processType = new QTreeWidgetItem(processNode, QStringList() << "Type" << core->getProcessFromUint(info.processes.info[i].type));
+        QTreeWidgetItem *processType = new QTreeWidgetItem(processNode, QStringList() << "Type" << core->getProcessFromUint(pinfo.type, isMulticore));
         processNode->addChild(processType);
 
-        QTreeWidgetItem *processVersion = new QTreeWidgetItem(processNode, QStringList() << "Version" << QString("%1.%2").arg(info.processes.info[i].version.major).arg(info.processes.info[i].version.minor));
+        QTreeWidgetItem *processVersion = new QTreeWidgetItem(processNode, QStringList() << "Version" << QString("%1.%2").arg(pinfo.version.major).arg(pinfo.version.minor));
         processNode->addChild(processVersion);
 
-        QTreeWidgetItem *processDate = new QTreeWidgetItem(processNode, QStringList() << "Date" << QDateTime(QDate(info.processes.info[i].date.year,info.processes.info[i].date.month,info.processes.info[i].date.day),
-                                                                                                             QTime(info.processes.info[i].date.hour,info.processes.info[i].date.min)).toString("yyyy/MM/dd - hh:mm"));
+        QTreeWidgetItem *processDate = new QTreeWidgetItem(processNode, QStringList() << "Date" << QDateTime(QDate(pinfo.date.year,pinfo.date.month,pinfo.date.day),
+                                                                                                             QTime(pinfo.date.hour,pinfo.date.min)).toString("yyyy/MM/dd - hh:mm"));
         processNode->addChild(processDate);
 
-        QTreeWidgetItem *processBuilt = new QTreeWidgetItem(processNode, QStringList() << "Built On" << QDateTime(QDate(info.processes.info[i].compilationdate.year,info.processes.info[i].compilationdate.month,info.processes.info[i].compilationdate.day),
-                                                                                                      QTime(info.processes.info[i].compilationdate.hour,info.processes.info[i].compilationdate.min)).toString("yyyy/MM/dd - hh:mm"));
+        QTreeWidgetItem *processBuilt = new QTreeWidgetItem(processNode, QStringList() << "Built On" << QDateTime(QDate(pinfo.compilationdate.year,pinfo.compilationdate.month,pinfo.compilationdate.day),
+                                                                                                      QTime(pinfo.compilationdate.hour,pinfo.compilationdate.min)).toString("yyyy/MM/dd - hh:mm"));
         processNode->addChild(processBuilt);
 
-        QTreeWidgetItem *processRom= new QTreeWidgetItem(processNode, QStringList() << "ROM" << QString("[%1, %1+%2) kb").arg(info.processes.info[i].rom_addr_kb).arg(info.processes.info[i].rom_size_kb));
+        std::string processStorageName = (i < maxNumberOfProcessesOnSingleCore) ? "ROM" : "FLASH";
+        QTreeWidgetItem *processRom= new QTreeWidgetItem(processNode, QStringList() << processStorageName.c_str() << QString("[%1, %1+%2) kb").arg(pinfo.rom_addr_kb).arg(pinfo.rom_size_kb));
         processNode->addChild(processRom);
-
-
-
     }
-
-
 }
 
 
@@ -1274,6 +1288,7 @@ void MainWindow::onConnect()
             }
             else{
                 QMessageBox msgBox;
+                msgBox.setIcon(QMessageBox::Warning);
                 if(it->text(PROCESS).contains("eApplPROGupdater" ))
                 {
                     msgBox.setText("The executing process is the " + sss + " which does not allow CAN discovery but only the programming of the eUpdater. You have to put the board in maintenance mode");
@@ -1349,6 +1364,7 @@ void MainWindow::checkEnableButtons()
         ui->btnCahngeInfo->setEnabled(false);
         ui->btnCalibrate->setEnabled(false);
         ui->btnChangeCanAddr->setEnabled(false);
+        ui->btnEraseApplication->setEnabled(false);
         ui->btnChangeIp->setEnabled(false);
         ui->btnEraseEeprom->setEnabled(false);
         ui->btnJumpUpdater->setEnabled(false);
@@ -1379,6 +1395,7 @@ void MainWindow::checkEnableButtons()
             ui->btnCalibrate->setEnabled(false);
 
             ui->btnChangeCanAddr->setEnabled(false);
+            ui->btnEraseApplication->setEnabled(false);
             ui->btnCahngeInfo->setEnabled(false);
 
             ui->btnChangeIp->setEnabled(false);
@@ -1420,6 +1437,7 @@ void MainWindow::checkEnableButtons()
             //ui->btnRestartSecs->setEnabled(true);
             if(canUploadApp){
                 ui->btnUploadApp->setEnabled(true);
+                ui->btnEraseApplication->setEnabled(true);                
             }else{
                 ui->btnUploadApp->setEnabled(false);
             }
@@ -1470,6 +1488,7 @@ void MainWindow::checkEnableButtons()
             }
         }else{
             ui->btnChangeCanAddr->setEnabled(false);
+            ui->btnEraseApplication->setEnabled(false);
             ui->btnCahngeInfo->setEnabled(false);
             ui->btnCalibrate->setEnabled(false);
             ui->btnEraseEeprom->setEnabled(false);
@@ -1485,6 +1504,7 @@ void MainWindow::checkEnableButtons()
         ui->btnGoToApplication->setEnabled(false);
         ui->btnGoToMaintenance->setEnabled(false);
         ui->btnUploadApp->setEnabled(true);
+        ui->btnEraseApplication->setEnabled(true);
         ui->btnUploadLoader->setEnabled(false);
         ui->btnUploadUpdater->setEnabled(false);
         ui->actionSel->setEnabled(true);

--- a/src/tools/FirmwareUpdater/mainwindow.h
+++ b/src/tools/FirmwareUpdater/mainwindow.h
@@ -112,6 +112,7 @@ private slots:
     void onChangeInfo(bool);
     void onSelectionCheckDestroy(QObject*);
     void onChangeAddress(bool);
+    void onEraseApplication(bool);
     void onRestartBoards(bool click);
 
     //void onRestartBoards5Secs(bool click);

--- a/src/tools/FirmwareUpdater/mainwindow.ui
+++ b/src/tools/FirmwareUpdater/mainwindow.ui
@@ -94,7 +94,7 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="3">
+         <item row="0" column="2">
           <widget class="QPushButton" name="btnGoToApplication">
            <property name="enabled">
             <bool>false</bool>
@@ -120,7 +120,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="2">
+         <item row="2" column="1">
           <widget class="QPushButton" name="btnUploadApp">
            <property name="enabled">
             <bool>false</bool>
@@ -133,7 +133,7 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="2">
+         <item row="0" column="1">
           <widget class="QPushButton" name="btnGoToMaintenance">
            <property name="enabled">
             <bool>false</bool>
@@ -187,7 +187,7 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="2">
+         <item row="1" column="1">
           <widget class="QPushButton" name="btnRestart">
            <property name="enabled">
             <bool>false</bool>
@@ -213,7 +213,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="3">
+         <item row="2" column="2">
           <widget class="QPushButton" name="btnJumpUpdater">
            <property name="enabled">
             <bool>false</bool>
@@ -226,7 +226,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="2">
+         <item row="2" column="1">
           <widget class="QPushButton" name="btnUploadUpdater">
            <property name="enabled">
             <bool>false</bool>
@@ -239,7 +239,7 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="2">
+         <item row="5" column="1">
           <widget class="QPushButton" name="btnBootUpdater">
            <property name="enabled">
             <bool>false</bool>
@@ -265,7 +265,20 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="3">
+         <item row="7" column="1">
+          <widget class="QPushButton" name="btnEraseApplication">
+           <property name="disabled">
+            <bool>false</bool>
+           </property>
+           <property name="toolTip">
+            <string>It allows you to erase an application process.</string>
+           </property>
+           <property name="text">
+            <string>Erase Application</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
           <widget class="QPushButton" name="btnBlink">
            <property name="enabled">
             <bool>false</bool>
@@ -278,7 +291,7 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="3">
+         <item row="5" column="2">
           <widget class="QPushButton" name="btnEraseEeprom">
            <property name="enabled">
             <bool>false</bool>

--- a/src/tools/FirmwareUpdater/mainwindow.ui
+++ b/src/tools/FirmwareUpdater/mainwindow.ui
@@ -267,7 +267,7 @@
          </item>
          <item row="7" column="1">
           <widget class="QPushButton" name="btnEraseApplication">
-           <property name="disabled">
+           <property name="enabled">
             <bool>false</bool>
            </property>
            <property name="toolTip">

--- a/src/tools/canLoader/canLoaderLib/downloader.h
+++ b/src/tools/canLoader/canLoaderLib/downloader.h
@@ -31,13 +31,13 @@ public:
  int  appl_vers_build;      // the build number of the version of the sw it is running (former ...). not meaningful for bootloader
  int  prot_vers_major;      // the major number of the can protocol of the application. not meaningful for bootloader
  int  prot_vers_minor;      // the minor number of the can protocol of the application. not meaningful for bootloader
- char serial [50];          // only for strain
+ char serial [50] = {""};   // only for strain
  int  strainregsetinuse;    // only for strain
  int  strainregsetatboot;   // only for strain
  int  status;
  bool selected;
  bool eeprom;
- char add_info [50];    // but can protocol supports upt to 32 bytes
+ char add_info [50] = {""}; // but can protocol supports upt to 32 bytes
 };
 
 //*****************************************************************/

--- a/src/tools/embObjProtoTools/boardTransceiver/CMakeLists.txt
+++ b/src/tools/embObjProtoTools/boardTransceiver/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors: Alberto Cardellino
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 
 # Name of the project must correspond to the class name that needs to be
 # instantiated by the factory - so embObjLib is not ok

--- a/src/tools/embObjProtoTools/embObjProto_debugParser/CMakeLists.txt
+++ b/src/tools/embObjProtoTools/embObjProto_debugParser/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors: Valentina Gaggero
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 
 set(PROJECTNAME embObjProto_debugParser)
 

--- a/src/tools/embObjProtoTools/nvListPrinter/CMakeLists.txt
+++ b/src/tools/embObjProtoTools/nvListPrinter/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors: Valentina Gaggero
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 
 set(PROJECTNAME nvid_printer)
 

--- a/src/tools/emsBackDoorManager/CMakeLists.txt
+++ b/src/tools/emsBackDoorManager/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors: Valentina Gaggero
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 
 set(PROJECTNAME emsBackDoorManager)
 

--- a/src/tools/ethLoader/ethLoaderLib/EthBoard.h
+++ b/src/tools/ethLoader/ethLoaderLib/EthBoard.h
@@ -44,6 +44,7 @@ struct boardInfo2_t
     eOversion_t         versionOfRunning;   // we keep this info (which for protversion is also inside processes.info[processes.runningnow].version) because ...
                                             // in the case of protversion 0 we dont have any info about which process is running now.
     string              moreinfostring;
+    eOuprot_procinfo_t  extraprocesses[2];  // this buffer is used to to transport the information related to the extraprocesses running multi-core processors
 
     boardInfo2_t()
     {
@@ -68,6 +69,7 @@ struct boardInfo2_t
         maintenanceIsActive = false;
         versionOfRunning.major = versionOfRunning.minor = 0;
         moreinfostring.clear();
+        extraprocesses[0].type = extraprocesses[1].type = uprot_proc_None;
     }
 };
 

--- a/src/tools/ethLoader/ethLoaderLib/EthMaintainer.cpp
+++ b/src/tools/ethLoader/ethLoaderLib/EthMaintainer.cpp
@@ -799,7 +799,7 @@ string EthMaintainer::processDiscoveryReplies2(EthBoardList &boardlist, double w
                 }
             }
         }
-        if(uprot_OPC_DISCOVER2 == disc2->discoveryreply.reply.opc)
+        else if(uprot_OPC_DISCOVER2 == disc2->discoveryreply.reply.opc)
         {
             // the board has replied with the new multi-application-processes protocol.
 

--- a/src/tools/ethLoader/ethLoaderLib/EthMaintainer.h
+++ b/src/tools/ethLoader/ethLoaderLib/EthMaintainer.h
@@ -224,6 +224,7 @@ protected:
     // it forms the string returned by cmdGetMoreInfo() by formatting the field
     // eOuprot_cmd_MOREINFO_REPLY_t::discover sent by the remote board. the formatting can hence be defined in here.
     std::string prepareMoreInfoText(eOuprot_cmd_DISCOVER_REPLY_t * disc, const char *ipv4string);
+    std::string prepareMoreInfoText(eOuprot_cmd_DISCOVER_REPLY2_t * disc, const char *ipv4string);
 
     // it forms the string returned by cmdGetMoreInfo() just copying the field
     // eOuprot_cmd_MOREINFO_REPLY_t::description[] inside the UDP packet as filled by the remote board.

--- a/src/tools/ethLoader/ethLoaderLib/EthUpdater.cpp
+++ b/src/tools/ethLoader/ethLoaderLib/EthUpdater.cpp
@@ -22,6 +22,7 @@ const int EthUpdater::partition_UPDATER = uprot_partitionUPDATER;
 #define PRINT_DEBUG_INFO_ON_TERMINAL
 
 
+// TODO: check here if it is called and when (it seems that it's never called)
 int EthUpdater::cmdDiscover()
 {
     mBoardList.empty();
@@ -48,10 +49,13 @@ int EthUpdater::cmdDiscover()
         char ipaddr[20];
         snprintf(ipaddr, sizeof(ipaddr), "%d.%d.%d.%d",(rxAddress>>24)&0xFF, (rxAddress>>16)&0xFF, (rxAddress>>8)&0xFF, rxAddress&0xFF);
 
+        // if I received the extended reply I'll pass throughout it
+
+
+        // otherwise process it as usual
         if(uprot_OPC_DISCOVER == disc->reply.opc)
         {
             // the board has replied with the new protocol.
-
             if (rxAddress != mMyAddress)
             {
                 boardInfo_t binfo = {0};

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -4,7 +4,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license. See the accompanying LICENSE file for details.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 include(FetchContent)
 


### PR DESCRIPTION
**What's new:**

#### main changes
- EthMaintainer now uses the new `eOuprot_cmd_DISCOVER_REPLY2_t` to parse the reply coming from the AMC multi-core family boards. 
- A new `uprot_OPC_DISCOVER2` help the `processDiscoveryReplies2` to discriminate the parsing strategy, maintaining the back-compatibility with the existing ones. 
- `prepareMoreInfoText` now parses the info contained in the `extraprocesses` when they exist.

#### minor changes
- Align all the `cmake_minimum_required` to VERSION 3.12
- A new `Erase Application` button is visible when running the `Firmwareupdate` with the administrator privileges (`-a`)
- Add a new warning (⚠️) icon to the dialog window when we try to discover the CAN boards through ETH boards that are running the default application
- Add some useful comments in `EthUpdater.cpp`
- Remove previous existing warnings ⚠️:
  - Resolve some todos simplifying the code
  - Remove unused dead code
  - Fix indentation
  - Fix comparisons between different naive types 

**Notes:**
- tested with: EMS4, AMC, AMCBLDC
- The `Erase Application` is currently a work in progress, so at the moment it does nothing (it is disabled by default)

cc @pattacini @marcoaccame @mfussi66 @davidetome 