### PR TITLE
Fix BUILD_SHARED_LIBS set to ON and add test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
         cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
               -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \ \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DBUILD_SHARED_LIBS:BOOL=${{ matrix.build_shared_libs }} \
               -DICUB_USE_icub_firmware_shared:BOOL=ON \
               -DENABLE_icubmod_serial:BOOL=ON \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         build_type: [Release]
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        build_shared_libs: [ON, OFF]
 
     steps:
     - name: Checkout the code
@@ -151,7 +152,8 @@ jobs:
         cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
               -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \ \
+              -DBUILD_SHARED_LIBS:BOOL=${{ matrix.build_shared_libs }} \
               -DICUB_USE_icub_firmware_shared:BOOL=ON \
               -DENABLE_icubmod_serial:BOOL=ON \
               -DENABLE_icubmod_serialport:BOOL=ON \
@@ -186,6 +188,7 @@ jobs:
         cd build
         cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -DBUILD_SHARED_LIBS:BOOL=${{ matrix.build_shared_libs }} \
               -DICUB_USE_icub_firmware_shared:BOOL=ON \
               -DENABLE_icubmod_serial:BOOL=ON \
               -DENABLE_icubmod_serialport:BOOL=ON \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    name: '[${{ matrix.os }}@${{ matrix.build_type }}]'
+    name: '[${{ matrix.os }}@${{ matrix.build_type }}@BUILD_SHARED_LIBS:${{ matrix.build_shared_libs }}]'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/src/tools/canLoader/canLoader-console/CMakeLists.txt
+++ b/src/tools/canLoader/canLoader-console/CMakeLists.txt
@@ -10,8 +10,6 @@ file(GLOB folder_header *.h)
 source_group("Source Files" FILES ${folder_source})
 source_group("Header Files" FILES ${folder_header})
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../canLoaderLib)
-
 add_executable(${PROJECT_NAME} ${folder_header} ${folder_source})
 
 target_link_libraries(${PROJECT_NAME} canLoaderLib)

--- a/src/tools/strainCalib/strainCalibLib/CMakeLists.txt
+++ b/src/tools/strainCalib/strainCalibLib/CMakeLists.txt
@@ -8,14 +8,14 @@ source_group("Source Files" FILES ${folder_source})
 source_group("Header Files" FILES ${folder_header})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../ethLoader/ethLoaderLib)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../canLoader/canLoaderLib)
 
 add_library(${PROJECT_NAME} ${folder_source} ${folder_header})
 
 target_link_libraries(${PROJECT_NAME} YARP::YARP_os
                                       YARP::YARP_dev
                                       ACE::ACE
-                                      icub_firmware_shared::embobj)
+                                      icub_firmware_shared::embobj
+                                      canLoaderLib)
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
                                                   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 


### PR DESCRIPTION
Ädd missing link between `strainCalibLib` and `canLoaderLib` to fix compilation with `BUILD_SHARED_LIBS` set to `ON`. To avoid future regressions, I also added tests with BUILD_SHARED_LIBS=ON . If we want to avoid to double the number of tests, we can also switch to use `BUILD_SHARED_LIBS` by default.