### PR TITLE
Cleanup use of undefined ICUB_GENERIC_(*)VERSION CMake variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,14 +128,6 @@ add_subdirectory(app)
 # Create everything needed to build our executables.
 add_subdirectory(src)
 
-########### propagate version info to targets
-get_property(ICUB_TARGETS GLOBAL PROPERTY ICUB_TARGETS)
-foreach(t ${ICUB_TARGETS})
-  set_target_properties(${t} PROPERTIES VERSION ${ICUB_GENERIC_VERSION}
-                        SOVERSION ${ICUB_GENERIC_SOVERSION})
-endforeach()
-######################
-
 ## install cmake scripts
 message(STATUS "Installing cmake scripts")
 set(ICUB_CMAKE_SCRIPTS iCubHelpers.cmake iCubOptions.cmake)


### PR DESCRIPTION
The `ICUB_GENERIC_VERSION` and `ICUB_GENERIC_SOVERSION` variables were added in https://github.com/robotology/icub-main/commit/8f3233974a87591710a5e549a04fec59d24c9816, but at some point the code that defined them was removed, and this deadcode was left behind. In this PR I just propose to remove them,  as anyhow we are not mantaning precise soversion in icub-main.