### PR TITLE
Update required `icub_firmware_shared_VERSION` to 1.31.0 for AksIM2 encoder

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -65,8 +65,8 @@ checkandset_dependency(OpenCV)
 checkandset_dependency(Qt5)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
-  if(icub_firmware_shared_VERSION VERSION_LESS 1.30.0)
-    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected: at least 1.30.0 is required")
+  if(icub_firmware_shared_VERSION VERSION_LESS 1.31.0)
+    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected: at least 1.31.0 is required")
   endif()
 endif()
 


### PR DESCRIPTION
**What's new:**
- In order to see the new diagnostics messages generated by the AksIM2 encoder we have to use `icub-firmware-shared` v1.31.0 which contains the new (human-readable) diagnostics messages to visualize on the `yarprobotinterface`

**Notes:**
