### PR TITLE
POS can use also `mtb4` and `mtb4c` boards

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -65,8 +65,8 @@ checkandset_dependency(OpenCV)
 checkandset_dependency(Qt5)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
-  if(icub_firmware_shared_VERSION VERSION_LESS 1.31.0)
-    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected: at least 1.31.0 is required")
+  if(icub_firmware_shared_VERSION VERSION_LESS 1.32.0)
+    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected: at least 1.32.0 is required")
   endif()
 endif()
 

--- a/src/libraries/icubmod/embObjLib/serviceParser.cpp
+++ b/src/libraries/icubmod/embObjLib/serviceParser.cpp
@@ -1880,7 +1880,7 @@ bool ServiceParser::parseService(Searchable &config, servConfigPOS_t &posconfig)
             boardtype = as_service.settings.enabledsensors[i].boardtype;
             location = as_service.settings.enabledsensors[i].location;
             bool validBoardForPOS = (eobrd_mtb4 == boardtype) || (eobrd_mtb4c == boardtype) || (eobrd_mtb4fap == boardtype) || (eobrd_pmc == boardtype);
-            if(validBoardsForPOS)
+            if(validBoardForPOS)
             {
                 // ok
             }

--- a/src/libraries/icubmod/embObjLib/serviceParser.cpp
+++ b/src/libraries/icubmod/embObjLib/serviceParser.cpp
@@ -1856,7 +1856,7 @@ bool ServiceParser::parseService(Searchable &config, servConfigPOS_t &posconfig)
     }
 
 
-//    // check the num of type of boards. At max we have 2 board types. they must be eitehr mtb4fap or pmc
+//    // check the num and of type of boards. at max we have 2 board types. they must be: mtb4c or mtb4 (or mtb4fap / pmc)
 //    if(as_service.properties.canboards.size() > 2)
 //    {
 //        yError() << "ServiceParser::parseService(POS): too many type board info are configured. The max num is " << eOas_pos_boards_maxnumber;
@@ -1879,13 +1879,14 @@ bool ServiceParser::parseService(Searchable &config, servConfigPOS_t &posconfig)
         {
             boardtype = as_service.settings.enabledsensors[i].boardtype;
             location = as_service.settings.enabledsensors[i].location;
-            if((eobrd_mtb4fap == boardtype) || (eobrd_pmc == boardtype))
+            bool validBoardForPOS = (eobrd_mtb4 == boardtype) || (eobrd_mtb4c == boardtype) || (eobrd_mtb4fap == boardtype) || (eobrd_pmc == boardtype);
+            if(validBoardsForPOS)
             {
                 // ok
             }
             else
             {
-                yError() << "ServiceParser::parseService(POS): sensors must have the boardtype either mtb4fap or pmc. See SENSORS::boardType values";
+                yError() << "ServiceParser::parseService(POS): sensors must have the correct boardtype (mtb4, mtb4c, mtb4fap or pmc).";
                 return false;
             }
 


### PR DESCRIPTION
This PR allows the correct parsing of the POS section of the xml files used for MC in the new hand of `ergoCub` with also the `mtb4` and `mtb4c` boards.
It is associated to:
- https://github.com/robotology/icub-firmware/pull/347
- https://github.com/robotology/icub-firmware-shared/pull/79
- https://github.com/robotology/icub-firmware-build/pull/69
