### PR TITLE
HandMK5: force the use of the latest icub-firmware-shared

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -66,7 +66,7 @@ checkandset_dependency(Qt5)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
   if(icub_firmware_shared_VERSION VERSION_LESS 1.32.1)
-    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected: at least 1.32.0 is required")
+    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected: at least 1.32.1 is required")
   endif()
 endif()
 

--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -65,7 +65,7 @@ checkandset_dependency(OpenCV)
 checkandset_dependency(Qt5)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
-  if(icub_firmware_shared_VERSION VERSION_LESS 1.32.0)
+  if(icub_firmware_shared_VERSION VERSION_LESS 1.32.1)
     message(FATAL_ERROR "An old version of icub-firmware-shared has been detected: at least 1.32.0 is required")
   endif()
 endif()


### PR DESCRIPTION
This PR just ... force to use `icub-firmware-shared` v 1.32.1 because of new names for hand mk5.

It requires this PR to merged first:
- https://github.com/robotology/icub-firmware-shared/pull/78

