### PR TITLE
Delete grabberDual references

### DIFF
--- a/app/default/scripts/cameras_calib.xml.template
+++ b/app/default/scripts/cameras_calib.xml.template
@@ -4,12 +4,12 @@
 </dependencies> 
 <module>
   <name>yarpdev</name>
-      <parameters> --from camera/dragonfly2_config_left.ini --split true</parameters>
+      <parameters> --from camera/dragonfly2_config_left.ini </parameters>
   <node>pc104</node>
 </module>
 <module>
   <name>yarpdev</name>
-      <parameters> --from camera/dragonfly2_config_right.ini --split true</parameters>
+      <parameters> --from camera/dragonfly2_config_right.ini </parameters>
   <node>pc104</node>
 </module>
 <module>

--- a/app/default/scripts/cameras_calib.xml.template
+++ b/app/default/scripts/cameras_calib.xml.template
@@ -4,7 +4,12 @@
 </dependencies> 
 <module>
   <name>yarpdev</name>
-      <parameters> --from camera/ServerGrabberDualDragon.ini --split true</parameters>
+      <parameters> --from camera/dragonfly2_config_left.ini --split true</parameters>
+  <node>pc104</node>
+</module>
+<module>
+  <name>yarpdev</name>
+      <parameters> --from camera/dragonfly2_config_right.ini --split true</parameters>
   <node>pc104</node>
 </module>
 <module>

--- a/app/default/scripts/cameras_calib_bayer_320_240.xml.template
+++ b/app/default/scripts/cameras_calib_bayer_320_240.xml.template
@@ -4,12 +4,12 @@
 </dependencies>
    <module>
       <name>yarpdev</name>
-      <parameters> --from camera/dragonfly2_config_left_320_240.ini --split true</parameters>
+      <parameters> --from camera/dragonfly2_config_left_320_240.ini </parameters>
 	  <node>pc104</node>
    </module>
       <module>
       <name>yarpdev</name>
-      <parameters> --from camera/dragonfly2_config_right_320_240.ini --split true</parameters>
+      <parameters> --from camera/dragonfly2_config_right_320_240.ini </parameters>
 	  <node>pc104</node>
    </module>
     <module>

--- a/app/default/scripts/cameras_calib_bayer_320_240.xml.template
+++ b/app/default/scripts/cameras_calib_bayer_320_240.xml.template
@@ -4,7 +4,12 @@
 </dependencies>
    <module>
       <name>yarpdev</name>
-      <parameters> --from camera/ServerGrabberDualDragonBayer.ini --split true</parameters>
+      <parameters> --from camera/dragonfly2_config_left_320_240.ini --split true</parameters>
+	  <node>pc104</node>
+   </module>
+      <module>
+      <name>yarpdev</name>
+      <parameters> --from camera/dragonfly2_config_right_320_240.ini --split true</parameters>
 	  <node>pc104</node>
    </module>
     <module>

--- a/app/default/scripts/cameras_calib_bayer_640_480.xml.template
+++ b/app/default/scripts/cameras_calib_bayer_640_480.xml.template
@@ -4,12 +4,12 @@
 </dependencies>
 <module>
       <name>yarpdev</name>
-      <parameters> --from camera/dragonfly2_config_left_640_480.ini --split true</parameters>
+      <parameters> --from camera/dragonfly2_config_left_640_480.ini </parameters>
 	  <node>pc104</node>
    </module>
    <module>
       <name>yarpdev</name>
-      <parameters> --from camera/dragonfly2_config_right_640_480.ini --split true</parameters>
+      <parameters> --from camera/dragonfly2_config_right_640_480.ini </parameters>
 	  <node>pc104</node>
    </module>
     <module>

--- a/app/default/scripts/cameras_calib_bayer_640_480.xml.template
+++ b/app/default/scripts/cameras_calib_bayer_640_480.xml.template
@@ -4,7 +4,12 @@
 </dependencies>
 <module>
       <name>yarpdev</name>
-      <parameters> --from camera/ServerGrabberDualDragonBayer640_480.ini --split true</parameters>
+      <parameters> --from camera/dragonfly2_config_left_640_480.ini --split true</parameters>
+	  <node>pc104</node>
+   </module>
+   <module>
+      <name>yarpdev</name>
+      <parameters> --from camera/dragonfly2_config_right_640_480.ini --split true</parameters>
 	  <node>pc104</node>
    </module>
     <module>


### PR DESCRIPTION
As discussed in [#469](https://github.com/robotology/robots-configuration/pull/469), this PR aims to delete the `grabberDual` references already present in icub-main.