### PR TITLE
EthCalibrator: fixed CheckHwFault

### DIFF
--- a/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.h
+++ b/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.h
@@ -111,7 +111,8 @@ private:
     bool goToStartupPosition(int j);
     bool checkCalibrateJointEnded(std::list<int> set);
     bool checkGoneToZeroThreshold(int j);
-    bool checkHwFault(int j);
+    bool checkHwFault(); 
+
 
     yarp::dev::PolyDriver *dev2calibrate;
     yarp::dev::IControlCalibration *iCalibrate;


### PR DESCRIPTION
During the investigation of [this ticket](https://github.com/robotology/icub-tech-support/issues/1544), @MSECode and I noticed some bugs in the `Ethernet calibrator`.

 1. there is an empty debug string: `DEBUG] Left_Arm_Calibrator : Joints calibration order:      ` 
2. the `checkHWFault` function performed a loop on the joints in (0, totJointsToCalibrate) range instead of on the list containing the required joints.
3. the return value of `checkHWFault` function was ignored.

We fixed them in this way:
1. 
![Screenshot from 2023-04-27 12-03-54](https://user-images.githubusercontent.com/4233231/234830442-ee60dda1-ffb0-4070-b48b-45c1236623b6.png)

2. the loop in performed on the elements containing in the list of joints to calibrate 

| Before | After |
|---|---|
| ![Screenshot from 2023-04-27 12-06-07](https://user-images.githubusercontent.com/4233231/234831009-d1b75d41-0b85-4ecb-b066-d12b18e35c30.png) | ![Screenshot from 2023-04-27 12-06-50](https://user-images.githubusercontent.com/4233231/234831126-d4aae953-20da-4c5c-87e5-c0c8635813f7.png) |

3. Added a check on the return value of `checkHWFault` function
![Screenshot from 2023-04-27 12-09-23](https://user-images.githubusercontent.com/4233231/234831890-23bedb8f-b74a-4a49-a914-69fd7976ed5d.png)




## Results:
Here there are the logs of the left arm during calibration where the joint number 9 is omitted

**Before**
``` 
[DEBUG] left_arm-calibrator starting calibration of device left_arm-mc_remapper
[INFO] Left_Arm_Calibrator : starting calibration
[ERROR] Left_Arm_Calibrator cannot perform 'check hardware fault' operation because joint number 9 is out of range [].
[DEBUG] Left_Arm_Calibrator : Joints calibration order:
[WARNING] Left_Arm_Calibrator  is calibrating only a subset of the robot part. 

```

**After**
```

[DEBUG] left_arm-calibrator starting calibration of device left_arm-mc_remapper
[INFO] Left_Arm_Calibrator : starting calibration
[DEBUG] Left_Arm_Calibrator : Joints calibration order: 4 5 6 3 2 0 1 7 8 10 11 12
[WARNING] Left_Arm_Calibrator  is calibrating only a subset of the robot part. Calibrating  12  over a total of  13

```