### PR TITLE
Fix CMake for `SkinGui` w/ Fingertips Mk1.1

### DIFF
--- a/src/tools/iCubSkinGui/plugin/CMakeLists.txt
+++ b/src/tools/iCubSkinGui/plugin/CMakeLists.txt
@@ -9,6 +9,8 @@ include_directories(${GSL_INCLUDE_DIRS})
 
 set(QtICubSkinGuiPlugin_SRCS Fingertip2Left.cpp
                              Fingertip2Right.cpp
+                             Fingertip3Left.cpp
+                             Fingertip3Right.cpp
                              Fingertip.cpp
                              PalmLeft.cpp
                              PalmRight.cpp
@@ -20,12 +22,14 @@ set(QtICubSkinGuiPlugin_SRCS Fingertip2Left.cpp
                              TouchSensor.cpp
                              Triangle_10pad.cpp
                              Triangle.cpp
-							 CER_SH_PDL.cpp)
+			     CER_SH_PDL.cpp)
 
 set(QtICubSkinGuiPlugin_HDRS qticubskinguiplugin.h
                              qticubskinguiplugin_plugin.h
                              include/Fingertip2Left.h
                              include/Fingertip2Right.h
+                             include/Fingertip3Left.h
+                             include/Fingertip3Right.h
                              include/Fingertip.h
                              include/PalmLeft.h
                              include/PalmRight.h


### PR DESCRIPTION
This PR fixes #867.

cc @simeonedussoni 