### PR TITLE
Added the mrie encoder name in the parser of motion control service.

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -65,7 +65,7 @@ checkandset_dependency(OpenCV)
 checkandset_dependency(Qt5)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
-  if(icub_firmware_shared_VERSION VERSION_LESS 1.34.1)
+  if(icub_firmware_shared_VERSION VERSION_LESS 1.34.2)
     message(FATAL_ERROR "An old version of icub-firmware-shared has been detected: at least 1.34.1 is required")
   endif()
 endif()

--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -66,7 +66,7 @@ checkandset_dependency(Qt5)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
   if(icub_firmware_shared_VERSION VERSION_LESS 1.34.2)
-    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected: at least 1.34.1 is required")
+    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected: at least 1.34.2 is required")
   endif()
 endif()
 

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -1089,6 +1089,7 @@ void embObjMotionControl::updateDeadZoneWithDefaultValues(void)
             case eomc_enc_hallmotor:
             case eomc_enc_spichainof2:
             case eomc_enc_spichainof3:
+            case eomc_enc_mrie:
             default:
                 _deadzone[i] = 0.0;
             


### PR DESCRIPTION
Now we can use the `mrie` name in the configuration file.
This encoder is used for the new joints.

I already tested this PR on the medium joint setup and it works together.

This code needs the updated `icub-firmware-shared` at version `1.34.2`.
I'll open a new PR for it.