### PR TITLE
Fix two bugs in embObjMultipleFTsensors

### DIFF
--- a/src/libraries/icubmod/embObjMultipleFTsensors/embObjMultipleFTsensors.cpp
+++ b/src/libraries/icubmod/embObjMultipleFTsensors/embObjMultipleFTsensors.cpp
@@ -335,7 +335,7 @@ bool embObjMultipleFTsensors::getSixAxisForceTorqueSensorFrameName(size_t sensor
 
 size_t embObjMultipleFTsensors::getNrOfTemperatureSensors() const
 {
-    return temperaturesensordata_.size();
+    return ftSensorsData_.size();
 }
 
 yarp::dev::MAS_status embObjMultipleFTsensors::getTemperatureSensorStatus(size_t sensorindex) const

--- a/src/libraries/icubmod/embObjMultipleFTsensors/embObjMultipleFTsensors.h
+++ b/src/libraries/icubmod/embObjMultipleFTsensors/embObjMultipleFTsensors.h
@@ -88,7 +88,7 @@ class yarp::dev::embObjMultipleFTsensors : public yarp::dev::DeviceDriver, publi
     double calculateBoardTime(eOabstime_t current);
     bool checkUpdateTimeout(eOprotID32_t id32, eOabstime_t current);
     static constexpr eOabstime_t updateTimeout_{11000};
-    std::vector<yarp::dev::MAS_status> masStatus_{MAS_OK, MAS_OK, MAS_OK, MAS_OK};
+    std::vector<yarp::dev::MAS_status> masStatus_{MAS_WAITING_FOR_FIRST_READ, MAS_WAITING_FOR_FIRST_READ, MAS_WAITING_FOR_FIRST_READ, MAS_WAITING_FOR_FIRST_READ};
 
     static constexpr bool checkUpdateTimeoutFlag_{false};  // Check timer disabled
     static constexpr bool useBoardTimeFlag_{true};         // Calculate board time if true otherway use yarp time


### PR DESCRIPTION
Description of the two bugs:

## Fix implementation of embObjMultipleFTsensors::get<Type>Status methods when no measure has been read

Before this commit, embObjMultipleFTsensors::get<Type>Status returned MAS_OK even if no measure has
been read from the sensor, so it returns MAS_OK and then returns an invalid measure.
After this commit, before a measure has been readed the status returned is MAS_WAITING_FOR_FIRST_READ.

##  Fix implementation of embObjMultipleFTsensors::get<Type>Status methods when no measure has been read

Before this commit, embObjMultipleFTsensors::get<Type>Status returned MAS_OK even if no measure has
been read from the sensor, so it returns MAS_OK and then returns an invalid measure.
After this commit, before a measure has been readed the status returned is MAS_WAITING_FOR_FIRST_READ.