### PR TITLE
Change the device running faceExpressions from serialport to serialPort_nws_yarp

### DIFF
--- a/app/faceExpressions/scripts/faceExpressions.xml.template
+++ b/app/faceExpressions/scripts/faceExpressions.xml.template
@@ -2,7 +2,7 @@
 <name>Face Expressions</name>
 <module>
       <name>yarpdev</name>
-      <parameters>--name /icub/face/raw --device serial --subdevice serialport --context faceExpressions --from serialport.ini</parameters>
+      <parameters>--name /icub/face/raw --device serialPort_nws_yarp --subdevice serialport --context faceExpressions --from serialport.ini</parameters>
 	  <node>pc104</node>
 	<tag>face_device</tag>
    </module>

--- a/app/faceExpressions/scripts/faceExpressions.xml.template
+++ b/app/faceExpressions/scripts/faceExpressions.xml.template
@@ -2,7 +2,7 @@
 <name>Face Expressions</name>
 <module>
       <name>yarpdev</name>
-      <parameters>--name /icub/face/raw --device serialPort_nws_yarp --subdevice serialport --context faceExpressions --from serialport.ini</parameters>
+      <parameters>--name /icub/face/raw --device serialPort_nws_yarp --subdevice serialport --context faceExpressions --from serialPort_nws_yarp.ini</parameters>
 	  <node>pc104</node>
 	<tag>face_device</tag>
    </module>


### PR DESCRIPTION
With the last releases, the old `serialport` device used for running the faceExpressions.xml application could not be found (see figure below) 

![MicrosoftTeams-image (7)](https://github.com/robotology/icub-main/assets/114698424/b08307b1-2c4d-470c-838e-113e295768c6)

In this way, it is replaced with the new `serialPort_nws_yarp` which runs properly on iCubGenova11.