### PR TITLE
dragonfly2: remove deprecated interfaces

### DIFF
--- a/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.cpp
+++ b/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.cpp
@@ -11,7 +11,6 @@
 
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 
@@ -24,7 +23,7 @@ using namespace yarp::dev;
 inline CFWCamera_DR2_2* RES(void *res) { return (CFWCamera_DR2_2*)res; }
 ////////////////////////////////////////////////////////////////////////
 
-bool DragonflyDeviceDriver2Rgb::getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image) 
+bool DragonflyDeviceDriver2Rgb::getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image)
 {
     return RES(system_resources)->CaptureImage(image);
 }
@@ -44,7 +43,7 @@ int DragonflyDeviceDriver2Rgb::height () const
 	return RES(system_resources)->height();
 }
 
-bool DragonflyDeviceDriver2Raw::getImage(yarp::sig::ImageOf<yarp::sig::PixelMono>& image) 
+bool DragonflyDeviceDriver2Raw::getImage(yarp::sig::ImageOf<yarp::sig::PixelMono>& image)
 {
     return RES(system_resources)->CaptureImage(image);
 }
@@ -96,7 +95,7 @@ bool DragonflyDeviceDriver2::open(yarp::os::Searchable& config)
 		fprintf(stderr,"DragonflyDeviceDriver2: can't open camera\n");
 		return false;
 	}
-	
+
     return true;
 }
 
@@ -111,34 +110,9 @@ bool DragonflyDeviceDriver2::close(void)
 	return false;
 }
 
-bool DragonflyDeviceDriver2::getRawBuffer(unsigned char *buff)
-{
-    return RES(system_resources)->CaptureRaw(buff);
-}
-
-bool DragonflyDeviceDriver2::getRgbBuffer(unsigned char *buff)
-{
-    return RES(system_resources)->CaptureRgb(buff);
-}
-
 yarp::os::Stamp DragonflyDeviceDriver2::getLastInputStamp()
 {
 	return RES(system_resources)->getLastInputStamp();
-}
-
-int DragonflyDeviceDriver2::getRawBufferSize()
-{
-    return RES(system_resources)->getRawBufferSize();
-}
-
-int DragonflyDeviceDriver2::width () const
-{
-	return RES(system_resources)->width();
-}
-
-int DragonflyDeviceDriver2::height () const
-{
-	return RES(system_resources)->height();
 }
 
 // SET

--- a/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.h
+++ b/src/libraries/icubmod/dragonfly2/common/DragonflyDeviceDriver2.h
@@ -17,10 +17,12 @@
 // May 06, readapted for YARP2 by nat
 
 #include <yarp/os/Bottle.h>
-#include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IPreciselyTimed.h>
+#include <yarp/dev/IFrameGrabberControls.h>
+#include <yarp/dev/IFrameGrabberControlsDC1394.h>
+#include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/dev/IVisualParams.h>
 
 namespace yarp {
@@ -33,7 +35,7 @@ namespace yarp {
 }
 
 /**
-* \file FirewireCamera.h device driver for managing the 
+* \file FirewireCamera.h device driver for managing the
 * IEEE-1394-DR2 Camera
 */
 
@@ -285,8 +287,6 @@ This file can be edited at /src/libraries/icubmod/dragonfly2/common/DragonflyDev
 class yarp::dev::DragonflyDeviceDriver2 :
     public DeviceDriver,
     public IPreciselyTimed,
-    public IFrameGrabber,
-    public IFrameGrabberRgb,
     public IFrameGrabberControls,
     public IFrameGrabberControlsDC1394,
     public IRgbVisualParams
@@ -320,39 +320,6 @@ public:
     virtual bool close(void);
 
     /**
-    * Implements FrameGrabber basic interface.
-    * @param buffer the pointer to the array to store the last frame.
-    * @return returns true/false on success/failure.
-    */
-    virtual bool getRawBuffer(unsigned char *buffer);
-
-    /**
-    * Implements the Frame grabber basic interface.
-    * @return the size of the raw buffer (for the Dragonfly
-    * camera this is 1x640x480).
-    */
-    virtual int getRawBufferSize();
-
-    /**
-    * Implements FrameGrabber basic interface.
-    */
-    virtual int height() const;
-
-    /**
-    * Implements FrameGrabber basic interface.
-    */
-    virtual int width() const;
-
-    /** 
-    * FrameGrabber bgr interface, returns the last acquired frame as
-    * a buffer of bgr triplets. A demosaicking method is applied to 
-    * reconstuct the color from the Bayer pattern of the sensor.
-    * @param buffer pointer to the array that will contain the last frame.
-    * @return true/false upon success/failure
-    */
-    virtual bool getRgbBuffer(unsigned char *buffer);
-
-    /** 
     * Implements the IPreciselyTimed interface.
     * @return the yarp::os::Stamp of the last image acquired
     */
@@ -360,7 +327,7 @@ public:
 
     /**
     * Set Brightness.
-    * @param v normalized image brightness [0.0 : 1.0]. 
+    * @param v normalized image brightness [0.0 : 1.0].
     * @return true/false upon success/failure
     */
     virtual bool setBrightness(double v);
@@ -371,7 +338,7 @@ public:
     */
     virtual bool setExposure(double v);
     /**
-    * Set Sharpness. 
+    * Set Sharpness.
     * @param v normalized image sharpness [0.0 : 1.0].
     * @return true/false upon success/failure
     */
@@ -391,7 +358,7 @@ public:
     virtual bool setHue(double v);
     /**
     * Set Saturation.
-    * @param v normalized image saturation [0.0 : 1.0]. 
+    * @param v normalized image saturation [0.0 : 1.0].
     * @return true/false upon success/failure
     */
     virtual bool setSaturation(double v);
@@ -400,7 +367,7 @@ public:
     * @param v normalized image gamma [0.0 : 1.0].
     * @return true/false upon success/failure
     */
-    virtual bool setGamma(double v);		
+    virtual bool setGamma(double v);
     /**
     * Set Shutter.
     * @param v normalized camera shutter time [0.0 : 1.0].
@@ -408,13 +375,13 @@ public:
     */
     virtual bool setShutter(double v);
     /**
-    * Set Gain. 
+    * Set Gain.
     * @param v normalized camera gain [0.0 : 1.0].
     * @return true/false upon success/failure
     */
     virtual bool setGain(double v);
     /**
-    * Set Iris. 
+    * Set Iris.
     * @param v normalized camera iris [0.0 : 1.0].
     * @return true/false upon success/failure
     */
@@ -433,12 +400,12 @@ public:
     * Get Exposure.
     * @return normalized image exposure [0.0 : 1.0].
     */
-    virtual double getExposure();    
+    virtual double getExposure();
     /**
     * Get Sharpness.
     * @return normalized image sharpness [0.0 : 1.0].
     */
-    virtual double getSharpness();    
+    virtual double getSharpness();
     /**
     * Get White Balance.
     * @param blue normalized blue balance [0.0 : 1.0].
@@ -516,7 +483,7 @@ public:
     * Get feature value.
     * @param feature feature ID
     * @return normalized feature value [0.0 : 1.0].
-    */	
+    */
     virtual double getFeatureDC1394(int feature);
 
     /**
@@ -549,7 +516,7 @@ public:
     * Has feature Manual mode?
     * @param feature feature ID.
     * @return true=YES, false=NO.
-    */	
+    */
     virtual bool hasManualDC1394(int feature);
     /**
     * Has feature Manual mode?
@@ -588,7 +555,7 @@ public:
     *			mask|=1<<(modes.modes[m]-DC1394_VIDEO_MODE_MIN);
     *
     * 0=160x120 YUV444, 1=320x240 YUV422, 2=640x480 YUV411, 3=640x480 YUV422, 4=640x480 RGB8, 5=640x480 MONO8,
-    * 6=640x480 MONO16,7=800x600 YUV422, 8=800x600 RGB8, 9=800x600_MONO8, 10=1024x768 YUV422, 11=1024x768 RGB8, 12=1024x768 MONO8, 
+    * 6=640x480 MONO16,7=800x600 YUV422, 8=800x600 RGB8, 9=800x600_MONO8, 10=1024x768 YUV422, 11=1024x768 RGB8, 12=1024x768 MONO8,
     * 13=800x600 MONO16, 14=1024x768 MONO16, 15=1280x960 YUV422, 16=1280x960 RGB8, 17=1280x960_MONO8, 18=1600x1200 YUV422, 19=1600x1200 RGB8,
     * 20=1600x1200 MONO8, 21=1280x960 MONO16, 22=1600x1200_MONO16, 23=EXIF, 24=FORMAT7 0, 25=FORMAT7 1, 26=FORMAT7 2, 27=FORMAT7 3,
     * 28=FORMAT7 4, 29=FORMAT7 5, 30=FORMAT7 6, 31=FORMAT7 7
@@ -598,7 +565,7 @@ public:
     /**
     * Get camera acquisition mode.
     * @return video mode ID: 0=160x120 YUV444, 1=320x240 YUV422, 2=640x480 YUV411, 3=640x480 YUV422, 4=640x480 RGB8, 5=640x480 MONO8,
-    * 6=640x480 MONO16,7=800x600 YUV422, 8=800x600 RGB8, 9=800x600_MONO8, 10=1024x768 YUV422, 11=1024x768 RGB8, 12=1024x768 MONO8, 
+    * 6=640x480 MONO16,7=800x600 YUV422, 8=800x600 RGB8, 9=800x600_MONO8, 10=1024x768 YUV422, 11=1024x768 RGB8, 12=1024x768 MONO8,
     * 13=800x600 MONO16, 14=1024x768 MONO16, 15=1280x960 YUV422, 16=1280x960 RGB8, 17=1280x960_MONO8, 18=1600x1200 YUV422, 19=1600x1200 RGB8,
     * 20=1600x1200 MONO8, 21=1280x960 MONO16, 22=1600x1200_MONO16, 23=EXIF, 24=FORMAT7 0, 25=FORMAT7 1, 26=FORMAT7 2, 27=FORMAT7 3,
     * 28=FORMAT7 4, 29=FORMAT7 5, 30=FORMAT7 6, 31=FORMAT7 7
@@ -607,7 +574,7 @@ public:
     /**
     * Set camera acquisition mode.
     * @param video_mode ID: 0=160x120 YUV444, 1=320x240 YUV422, 2=640x480 YUV411, 3=640x480 YUV422, 4=640x480 RGB8, 5=640x480 MONO8,
-    * 6=640x480 MONO16,7=800x600 YUV422, 8=800x600 RGB8, 9=800x600_MONO8, 10=1024x768 YUV422, 11=1024x768 RGB8, 12=1024x768 MONO8, 
+    * 6=640x480 MONO16,7=800x600 YUV422, 8=800x600 RGB8, 9=800x600_MONO8, 10=1024x768 YUV422, 11=1024x768 RGB8, 12=1024x768 MONO8,
     * 13=800x600 MONO16, 14=1024x768 MONO16, 15=1280x960 YUV422, 16=1280x960 RGB8, 17=1280x960_MONO8, 18=1600x1200 YUV422, 19=1600x1200 RGB8,
     * 20=1600x1200 MONO8, 21=1280x960 MONO16, 22=1600x1200_MONO16, 23=EXIF, 24=FORMAT7 0, 25=FORMAT7 1, 26=FORMAT7 2, 27=FORMAT7 3,
     * 28=FORMAT7 4, 29=FORMAT7 5, 30=FORMAT7 6, 31=FORMAT7 7
@@ -695,7 +662,7 @@ public:
     */
     virtual bool getWhiteBalanceDC1394(double &b, double &r);
 
-    /** 
+    /**
     * Get maximum image dimensions in Format 7 mode.
     * @param xdim maximum width
     * @param ydim maximum height
@@ -707,7 +674,7 @@ public:
     */
     virtual bool getFormat7MaxWindowDC1394(unsigned int &xdim,unsigned int &ydim,unsigned int &xstep,unsigned int &ystep,unsigned int &xoffstep,unsigned int &yoffstep);
 
-    /** 
+    /**
     * Get image dimensions in Format 7 mode.
     * @param xdim image width
     * @param ydim image height
@@ -716,7 +683,7 @@ public:
     * @return true/false upon success/failure
     */
     virtual bool getFormat7WindowDC1394(unsigned int &xdim,unsigned int &ydim,int &x0,int &y0);
-    /** 
+    /**
     * Set image dimensions in Format 7 mode.
     * @param xdim image width
     * @param ydim image height
@@ -736,7 +703,7 @@ public:
     * Get Operation Mode.
     * @return true=1394b false=LEGACY
     */
-    virtual bool getOperationModeDC1394(); 
+    virtual bool getOperationModeDC1394();
 
     /**
     * Set image transmission ON/OFF.
@@ -754,7 +721,7 @@ public:
 
     /**
     * Set feature commands propagation ON/OFF.
-    * All the cameras on the same Firewire bus can be adjusted at once setting broadcast ON. In this way, they will share the feature settings. 
+    * All the cameras on the same Firewire bus can be adjusted at once setting broadcast ON. In this way, they will share the feature settings.
     * @param onoff true=ON false=OFF
     * @return true/false upon success/failure
     */
@@ -782,13 +749,13 @@ public:
     */
     virtual bool setCaptureDC1394(bool bON);
 
-    /** 
+    /**
     * Get Firewire communication packet size.
     * In Format7 mode the framerate depends from packet size.
     * @return bytes per packet
     */
     virtual unsigned int getBytesPerPacketDC1394();
-    /** 
+    /**
     * Set Firewire communication packet size.
     * In Format7 mode the framerate depends from packet size.
     * @param bpp bytes per packet
@@ -913,7 +880,7 @@ protected:
 * |:-----------------:|
 * | `dragonfly2` |
 */
-class yarp::dev::DragonflyDeviceDriver2Rgb : 
+class yarp::dev::DragonflyDeviceDriver2Rgb :
     public yarp::dev::DragonflyDeviceDriver2,
     public IFrameGrabberImage,
     public IFrameGrabberImageRaw
@@ -933,9 +900,9 @@ public:
     */
     virtual ~DragonflyDeviceDriver2Rgb(){}
 
-    /** 
+    /**
     * FrameGrabber image interface, returns the last acquired frame as
-    * an rgb image. A demosaicking method is applied to 
+    * an rgb image. A demosaicking method is applied to
     * reconstuct the color from the Bayer pattern of the sensor.
     * @param image that will store the last frame.
     * @return true/false upon success/failure
@@ -950,13 +917,13 @@ public:
         */
     bool getImage(yarp::sig::ImageOf<yarp::sig::PixelMono>& image);
 
-    /** 
+    /**
      * Return the height of each frame.
      * @return image height
      */
     virtual int height() const;
 
-    /** 
+    /**
      * Return the width of each frame.
      * @return image width
      */
@@ -992,22 +959,22 @@ public:
     */
     virtual ~DragonflyDeviceDriver2Raw(){}
 
-    /** 
+    /**
     * FrameGrabber image interface, returns the last acquired frame as
-    * an rgb image. A demosaicking method is applied to 
+    * an rgb image. A demosaicking method is applied to
     * reconstuct the color from the Bayer pattern of the sensor.
     * @param image that will store the last frame.
     * @return true/false upon success/failure
     */
     bool getImage(yarp::sig::ImageOf<yarp::sig::PixelMono>& image);
 
-    /** 
+    /**
      * Return the height of each frame.
      * @return image height
      */
     virtual int height() const;
 
-    /** 
+    /**
      * Return the width of each frame.
      * @return image width
      */

--- a/src/libraries/icubmod/dragonfly2/linux/FirewireCameraDC1394-DR2_2.h
+++ b/src/libraries/icubmod/dragonfly2/linux/FirewireCameraDC1394-DR2_2.h
@@ -26,9 +26,10 @@
 #include <yarp/os/Stamp.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
-#include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/os/Value.h>
 #include <yarp/dev/IVisualParams.h>
+#include <yarp/dev/IFrameGrabberControlsDC1394.h>
+#include <yarp/dev/IFrameGrabberControls.h>
 
 #define NUM_DMA_BUFFERS 4
 
@@ -41,7 +42,7 @@
 #define DR_BAYER16_640x480       4
 #define DR_YUV_640x480           5
 
-//#define DR_YUV_320x240         
+//#define DR_YUV_320x240
 #define DR_RGB_512x384           6
 #define DR_RGB_800x600           7
 #define DR_YUV_800x600           8
@@ -52,12 +53,12 @@
 class CFWCamera_DR2_2 : public yarp::dev::IFrameGrabberControlsDC1394,
                         public yarp::dev::IRgbVisualParams
 {
-public:   
+public:
     CFWCamera_DR2_2(bool raw);
 
     virtual ~CFWCamera_DR2_2()
     {
-        if (m_pCamera) Close(); 
+        if (m_pCamera) Close();
     }
 
     int width();
@@ -103,7 +104,7 @@ protected:
     unsigned int m_RawBufferSize;
     unsigned int m_XDim,m_YDim;
     int m_Framerate;
-    
+
     unsigned int m_GainSaveValue,m_ShutterSaveValue;
     dc1394feature_mode_t m_GainSaveModeAuto,m_ShutterSaveModeAuto;
 
@@ -231,7 +232,7 @@ public:
     virtual unsigned int getColorCodingDC1394();
 
     // 22
-    virtual bool setColorCodingDC1394(int coding);	
+    virtual bool setColorCodingDC1394(int coding);
 
     // 25
     virtual bool getFormat7MaxWindowDC1394(unsigned int &xdim,unsigned int &ydim,unsigned int &xstep,unsigned int &ystep,unsigned int &xoffstep,unsigned int &yoffstep);
@@ -240,7 +241,7 @@ public:
     virtual bool setFormat7WindowDC1394(unsigned int xdim,unsigned int ydim,int x0,int y0);
 
     // 27
-    virtual bool getFormat7WindowDC1394(unsigned int &xdim,unsigned int &ydim,int &x0,int &y0);	
+    virtual bool getFormat7WindowDC1394(unsigned int &xdim,unsigned int &ydim,int &x0,int &y0);
 
     // 28
     virtual bool setOperationModeDC1394(bool b1394b);
@@ -302,10 +303,10 @@ public:
     // GET
 
     virtual double getBrightness();
-    virtual double getExposure();	
+    virtual double getExposure();
     virtual double getSharpness();
-    virtual bool getWhiteBalance(double &blue, double &red);	
-    virtual double getHue();	
+    virtual bool getWhiteBalance(double &blue, double &red);
+    virtual double getHue();
     virtual double getSaturation();
     virtual double getGamma();
     virtual double getShutter();

--- a/src/libraries/icubmod/dragonfly2/winnt/FirewireCameraDC1394-DR2_2.h
+++ b/src/libraries/icubmod/dragonfly2/winnt/FirewireCameraDC1394-DR2_2.h
@@ -22,7 +22,6 @@
 #include <Flycapture2.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Stamp.h>
-#include <yarp/dev/FrameGrabberInterfaces.h>
 
 #define DR_UNINIT           0
 #define DR_RGB_HALF_RES     1
@@ -34,11 +33,11 @@
 
 class CFWCamera_DR2_2 : public yarp::dev::IFrameGrabberControlsDC1394
 {
-public:   
+public:
     CFWCamera_DR2_2(bool raw) : mRawDriver(raw)
 	{
 	}
-	
+
 	virtual ~CFWCamera_DR2_2()
 	{
 		Close();
@@ -91,7 +90,7 @@ protected:
     bool mHires;
 	FlyCapture2::CameraInfo m_CameraInfo;
 	int m_BusSpeedBS;
-	
+
 	FlyCapture2::FC2Config m_CamConfig;
 
 	FlyCapture2::Format7ImageSettings m_F7ImageSettings;
@@ -107,7 +106,7 @@ protected:
 
     bool m_bFrameIsValid;
     bool m_bCameraOn;
- 
+
 	unsigned int m_XDim,m_YDim;
 
 	unsigned int m_iMin[FlyCapture2::UNSPECIFIED_PROPERTY_TYPE],m_iMax[FlyCapture2::UNSPECIFIED_PROPERTY_TYPE];
@@ -247,7 +246,7 @@ public:
 	virtual unsigned int getColorCodingDC1394();
 
 	// 22
-	virtual bool setColorCodingDC1394(int coding);	
+	virtual bool setColorCodingDC1394(int coding);
 
 	// 25
 	virtual bool getFormat7MaxWindowDC1394(unsigned int &xdim,unsigned int &ydim,unsigned int &xstep,unsigned int &ystep,unsigned int &xoffstep,unsigned int &yoffstep);
@@ -256,8 +255,8 @@ public:
 	virtual bool setFormat7WindowDC1394(unsigned int xdim,unsigned int ydim,int x0,int y0);
 
 	// 27
-	virtual bool getFormat7WindowDC1394(unsigned int &xdim,unsigned int &ydim,int &x0,int &y0);	
-	
+	virtual bool getFormat7WindowDC1394(unsigned int &xdim,unsigned int &ydim,int &x0,int &y0);
+
 	// 28
 	virtual bool setOperationModeDC1394(bool b1394b);
 
@@ -297,9 +296,9 @@ public:
 	///////////////////////////////////////////////
 	// base class implementation
 	///////////////////////////////////////////////
-	
+
 	// SET
-		
+
 	virtual bool setBrightness(double v);
     virtual bool setExposure(double v);
 	virtual bool setSharpness(double v);
@@ -310,19 +309,19 @@ public:
 	virtual bool setShutter(double v);
     virtual bool setGain(double v);
     virtual bool setIris(double v);
-    
+
     // GET
 
 	virtual double getBrightness();
-	virtual double getExposure();	
+	virtual double getExposure();
 	virtual double getSharpness();
-    virtual bool getWhiteBalance(double &blue, double &red);	
-	virtual double getHue();	
+    virtual bool getWhiteBalance(double &blue, double &red);
+	virtual double getHue();
 	virtual double getSaturation();
 	virtual double getGamma();
     virtual double getShutter();
     virtual double getGain();
     virtual double getIris();
 };
- 
+
 #endif

--- a/src/tools/frameGrabberGui2/dc1394SliderBase.h
+++ b/src/tools/frameGrabberGui2/dc1394SliderBase.h
@@ -3,7 +3,8 @@
 
 #include <QWidget>
 #include <mainwindow.h>
-#include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/dev/IFrameGrabberControls.h>
+#include <yarp/dev/IFrameGrabberControlsDC1394.h>
 
 
 #define SLIDER      0

--- a/src/tools/frameGrabberGui2/dc1394thread.h
+++ b/src/tools/frameGrabberGui2/dc1394thread.h
@@ -2,7 +2,8 @@
 #define DC1394THREAD_H
 
 #include <QThread>
-#include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/dev/IFrameGrabberControls.h>
+#include <yarp/dev/IFrameGrabberControlsDC1394.h>
 #include <yarp/dev/PolyDriver.h>
 #include <QMutex>
 #include <QWaitCondition>


### PR DESCRIPTION
It fixes #864

In YARP 3.5.0 the `FrameGrabberInterfaces` header has been deprecated, but the interfaces included not, except for very old interfaces such as `IFrameGrabber` and `iFrameGrabberRgb`, that were implemented but not used by anyone. The `frameGrabber_nws_yarp` uses the "new" interfaces.