### PR TITLE
Calibration type 14 update on calibration value parser

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -65,8 +65,8 @@ checkandset_dependency(OpenCV)
 checkandset_dependency(Qt5)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
-  if(icub_firmware_shared_VERSION VERSION_LESS 1.34.2)
-    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected: at least 1.34.2 is required")
+  if(icub_firmware_shared_VERSION VERSION_LESS 1.34.3)
+    message(FATAL_ERROR "An old version of icub-firmware-shared has been detected: at least 1.34.3 is required")
   endif()
 endif()
 

--- a/src/libraries/icubmod/embObjLib/serviceParser.cpp
+++ b/src/libraries/icubmod/embObjLib/serviceParser.cpp
@@ -2076,7 +2076,7 @@ bool ServiceParser::parse_encoder_port(std::string const &fromstring, eObrd_etht
 
             if(len > 15)
             {
-                yWarning() << "SServiceParser::parse_encoder_port():" << t << "is not a legal string for a encoder port because it is too long with size =" << len;
+                yWarning() << "ServiceParser::parse_encoder_port():" << t << "is not a legal string for a encoder port because it is too long with size =" << len;
                 formaterror = true;
                 return false;
             }

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -342,8 +342,8 @@ private:
     bool helper_setSpdPidRaw(int j, const Pid &pid);
     bool helper_getSpdPidRaw(int j, Pid *pid);
     bool helper_getSpdPidsRaw(Pid *pid);
-
-    bool convertCalib14RotationParam(double calib_param4, eoas_pos_ROT_t & rotationparam);
+    
+    bool checkCalib14RotationParam(int32_t calib_param4);
     
 public:
 


### PR DESCRIPTION
This PR brings an update to the current version of `calibration type 14`. Specifically the following things have changed:
- FAP calibration data are not passed anymore only through the `CALIBRATION` group in the `POS` service configuration file but the final correct values should be defined at `parameters 3, 4 and 5 ` of the calibration configuration file as defined in the documentation. Moreover in this file `offset` and `rotation` values should be passed in `icubDegrees`. 
- Anyway, `CALIBRATION` group in MC and POS is still kept for debugging reasons. Values in calibrators will override the one configured initially by the POS service.
- Then, with this update the calibration will do the following steps:
    - calibrate the FAP absolute encoder
    - bring the motor pulley to the hard stop
- New data structure have been introduced to simplify the conversion between eoThePOS datatype and icubDegrees to be used by both `icub-main` and `icub-firmware`
- Add check for `calib.params.type14.invertdirection` value, which must be a boolean value
- Further specification can be found in the [documentation ](https://icub-tech-iit.github.io/documentation/icub_r1_icub3_calibration_types/icub_r1_calibration_types/?h=calibrations#the-available-calibrations-in-details)