### PR TITLE
embObjMultipleFTsensors: Set the status to MAS_OK even if the timeout check is disabled

### DIFF
--- a/src/libraries/icubmod/embObjMultipleFTsensors/embObjMultipleFTsensors.cpp
+++ b/src/libraries/icubmod/embObjMultipleFTsensors/embObjMultipleFTsensors.cpp
@@ -268,6 +268,7 @@ bool embObjMultipleFTsensors::update(eOprotID32_t id32, double timestamp, void *
         ftSensorsData_[eoprotIndex].data_[index] = data->values[index];
     }
     ftSensorsData_[eoprotIndex].timeStamp_ = data->age;
+    masStatus_[eoprotIndex] = MAS_OK;
 
     temperaturesensordata_[eoprotIndex].data_ = data->temperature;
     temperaturesensordata_[eoprotIndex].timeStamp_ = calculateBoardTime(data->age);
@@ -399,7 +400,6 @@ bool embObjMultipleFTsensors::checkUpdateTimeout(eOprotID32_t id32, eOabstime_t 
         masStatus_[eoprot_ID2index(id32)] = MAS_TIMEOUT;
         return false;
     }
-    masStatus_[eoprot_ID2index(id32)] = MAS_OK;
     timeoutUpdate_[id32] = current;
     return true;
 }


### PR DESCRIPTION
https://github.com/robotology/icub-main/pull/871 introduce one critical bug in the `embObjMultipleFTsensors` YARP device: as for some reason the default value of [checkUpdateTimeoutFlag_](https://github.com/robotology/icub-main/blob/v2.2.0/src/libraries/icubmod/embObjMultipleFTsensors/embObjMultipleFTsensors.h#L93) is false, no check if the sensor is in timeout is done. As the assigned of the status to `MAS_OK` only happens if the check for timeout is done, what happened since https://github.com/robotology/icub-main/pull/871 is that the sensor always returned the initial status `MAS_WAITING_FOR_FIRST_READ`, even if a first read already arrived.

This resulted in yarprobotinterface logs flooded by messages like:
~~~
	4631,378732	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor l_arm_ft_sensor, no data will be sent on the port.
	4631,378766	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor r_arm_ft_sensor, no data will be sent on the port.
	4631,388679	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor l_foot_rear_ft_sensor, no data will be sent on the port.
	4631,388760	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor r_foot_rear_ft_sensor, no data will be sent on the port.
	4631,388792	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor l_arm_ft_sensor, no data will be sent on the port.
	4631,388818	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor r_arm_ft_sensor, no data will be sent on the port.
	4631,398750	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor l_foot_rear_ft_sensor, no data will be sent on the port.
	4631,398846	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor r_foot_rear_ft_sensor, no data will be sent on the port.
	4631,398882	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor l_arm_ft_sensor, no data will be sent on the port.
	4631,398911	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor r_arm_ft_sensor, no data will be sent on the port.
	4631,398938	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor l_foot_rear_ft_sensor, no data will be sent on the port.
	4631,409028	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor r_foot_rear_ft_sensor, no data will be sent on the port.
	4631,409121	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor l_arm_ft_sensor, no data will be sent on the port.
	4631,409155	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor r_arm_ft_sensor, no data will be sent on the port.
	4631,409178	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor r_foot_rear_ft_sensor, no data will be sent on the port.
	4631,409201	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor l_foot_rear_ft_sensor, no data will be sent on the port.
	4631,419213	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor l_arm_ft_sensor, no data will be sent on the port.
	4631,419313	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor r_arm_ft_sensor, no data will be sent on the port.
	4631,419350	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor r_foot_rear_ft_sensor, no data will be sent on the port.
	4631,419379	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor l_foot_rear_ft_sensor, no data will be sent on the port.
	4631,429435	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor l_arm_ft_sensor, no data will be sent on the port.
	4631,429471	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor r_foot_rear_ft_sensor, no data will be sent on the port.
	4631,429488	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor l_foot_rear_ft_sensor, no data will be sent on the port.
	4631,429497	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor l_arm_ft_sensor, no data will be sent on the port.
	4631,429505	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor r_arm_ft_sensor, no data will be sent on the port.
	4631,439689	ERROR	yarp.device.multipleanalogsensorsserver		Failure in reading data from sensor l_foot_rear_ft_sensor, no data will be sent on the port.
~~~

and no FT measure was published on the YARP port.

This PR fixes the bug by setting the `MAS_OK` status whenever a new data is read, so that the status is correctly set even if no timeout is ever checked.

There could be more  have been left out as it is more important to provide a bugfix as soon as possible:
* Enable timeout check, by setting `checkUpdateTimeoutFlag_` to `true`
* Provide a different status for temperature readings and for FT readings, as given that the period of the two sensors is different, it is possible that while an FT sensor reading is available, for the temperature the first read has not been done.  
