### PR TITLE
Update firmwareupdater to handle calibration functions for strain2

### DIFF
--- a/src/tools/FirmwareUpdater/.vscode/settings.json
+++ b/src/tools/FirmwareUpdater/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.associations": {
-        "*.m": "matlab",
-        "condition_variable": "cpp"
-    }
-}

--- a/src/tools/FirmwareUpdater/.vscode/settings.json
+++ b/src/tools/FirmwareUpdater/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "*.m": "matlab",
+        "condition_variable": "cpp"
+    }
+}

--- a/src/tools/FirmwareUpdater/calibrationwindow.cpp
+++ b/src/tools/FirmwareUpdater/calibrationwindow.cpp
@@ -404,7 +404,7 @@ void CalibrationWindow::onParametersClear(bool click)
     for(int i=0; i<CHANNEL_COUNT;i++){
         CustomComboBox *combo = ((CustomComboBox*)ui->tableParamters->cellWidget(i,COL_GAIN));
 
-        if(icubCanProto_boardType__strain2 == boardtype)
+        if(icubCanProto_boardType__strain2 == boardtype || icubCanProto_boardType__strain2c == boardtype)
         {
             combo->setIndexFromAmpGain(defaultStrain2AmplGains[i]);
             ((CustomSpinBox*)ui->tableParamters->cellWidget(i,COL_OFFSET))->setValue(defaultStrain2AmplOffsets[i]);
@@ -560,7 +560,7 @@ void CalibrationWindow::applyParameters()
         QComboBox *combo = (QComboBox*)ui->tableParamters->cellWidget(i,COL_GAIN);
         CustomSpinBox *spin = (CustomSpinBox*)ui->tableParamters->cellWidget(i,COL_OFFSET);
 
-        if(icubCanProto_boardType__strain2 == boardtype)
+        if(icubCanProto_boardType__strain2 == boardtype || icubCanProto_boardType__strain2c == boardtype)
         {
             int lastOffset = spin->value();
             uint16_t offset = lastOffset; // 32*1024 - 1;
@@ -625,7 +625,7 @@ void CalibrationWindow::Clear_AllRegulations()
     mutex.lock();
 
     const bool alsoserialnumber = true;
-    if((icubCanProto_boardType__strain2 == boardtype))
+    if((icubCanProto_boardType__strain2 == boardtype) || (icubCanProto_boardType__strain2c == boardtype))
     {
         SetDefaultRegulationSet(cDownloader::strain_regset_one, alsoserialnumber);
         SetDefaultRegulationSet(cDownloader::strain_regset_two);
@@ -859,7 +859,7 @@ void CalibrationWindow::saveCalibrationFile(QString filePath)
     char buffer[256];
 
 
-    if(icubCanProto_boardType__strain2 == boardtype)
+    if((icubCanProto_boardType__strain2 == boardtype || icubCanProto_boardType__strain2c == boardtype))
     {
         // file version
         filestr<<"File version:"<<endl;
@@ -1479,7 +1479,7 @@ void CalibrationWindow::onTimeout()
 
 #else
 
-        if(icubCanProto_boardType__strain2 == boardtype)
+        if((icubCanProto_boardType__strain2 == boardtype) || (icubCanProto_boardType__strain2c == boardtype))
         {
             int regsetInUseTMP = cDownloader::strain_regset_one;
 
@@ -1730,7 +1730,7 @@ void CalibrationWindow::onTimeout()
 
         for (int i=0;i<CHANNEL_COUNT;i++){
 
-            if(icubCanProto_boardType__strain2 == boardtype)
+            if((icubCanProto_boardType__strain2 == boardtype) || (icubCanProto_boardType__strain2c == boardtype))
             {
                 core->getDownloader()->strain_get_amplifier_regs(core->getDownloader()->board_list[selected].bus,
                                                                  core->getDownloader()->board_list[selected].pid, i,
@@ -1918,7 +1918,7 @@ bool CalibrationWindow::calibration_load_v3 (char* filename, int selected_bus, i
     sscanf (buffer,"%d",&file_version);
 
 
-    if((icubCanProto_boardType__strain2 == boardtype) && (3 != file_version))
+    if( ( (icubCanProto_boardType__strain2 == boardtype) || (icubCanProto_boardType__strain2c == boardtype) ) && (3 != file_version))
     {
         yError("Wrong file. Calibration version not supported for strain2: %d\n", file_version);
         appendLogMsg("Wrong file. Calibration version not supported for strain2");
@@ -2285,7 +2285,7 @@ bool CalibrationWindow::SetDefaultRegulationSet(int regset, bool alsoserialnumbe
         core->getDownloader()->strain_set_serial_number(bus,id, my_serial_no);
     }
 
-    if((icubCanProto_boardType__strain2 == boardtype))
+    if((icubCanProto_boardType__strain2 == boardtype) || (icubCanProto_boardType__strain2c == boardtype))
     {
         // amplifier registers:
         for (i=0;i<CHANNEL_COUNT; i++)

--- a/src/tools/FirmwareUpdater/customspinbox.cpp
+++ b/src/tools/FirmwareUpdater/customspinbox.cpp
@@ -3,7 +3,7 @@
 CustomSpinBox::CustomSpinBox(icubCanProto_boardType_t boardType,QWidget *parent) : QSpinBox(parent)
 {
     setMinimum(0);
-    if(boardType == icubCanProto_boardType__strain2){
+    if(boardType == icubCanProto_boardType__strain2 || boardType == icubCanProto_boardType__strain2c){
         setMaximum(0xFFFF);
     } else {
         setMaximum(0x3FF);

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -888,7 +888,7 @@ int getCanBoardVersion(FirmwareUpdaterCore *core,QString device,QString id,QStri
         canBoards = core->getCanBoardsFromEth(board,&result,canLine.toInt(),true);
     }
 
-    if(canBoards.count() > 0 && icubCanProto_boardType__strain2 == canBoards[0].type)
+    if(canBoards.count() > 0 && ( (icubCanProto_boardType__strain2 == canBoards[0].type) || (icubCanProto_boardType__strain2c == canBoards[0].type) ) )
     {
         ofstream myfile;
         string prefix = "Application ";
@@ -980,13 +980,23 @@ int setStrainGainsOffsets(FirmwareUpdaterCore *core,QString device,QString id,QS
         canBoards = core->getCanBoardsFromEth(board,&result,canLine.toInt(),true);
     }
 
-        if(canBoards.count() > 0 && icubCanProto_boardType__strain2 == canBoards[0].type)
+        if(canBoards.count() > 0 && ( (icubCanProto_boardType__strain2 == canBoards[0].type) || (icubCanProto_boardType__strain2c == canBoards[0].type) ) )
         {
             string error = "e";
 
             yDebug() << "strain2-amplifier-tuning: STEP-1. imposing gains which are different of each channel";
 
-            core->getDownloader()->strain_calibrate_offset2(canLine.toInt(), canId.toInt(), icubCanProto_boardType__strain2, gains, targets, &msg);
+            #warning TODO cannot pass canBoards[0].type because the type conversion is invalid
+
+            if(icubCanProto_boardType__strain2 == canBoards[0].type) 
+            {
+                core->getDownloader()->strain_calibrate_offset2(canLine.toInt(), canId.toInt(), icubCanProto_boardType__strain2, gains, targets, &msg);
+            }
+            else
+            {
+                core->getDownloader()->strain_calibrate_offset2(canLine.toInt(), canId.toInt(), icubCanProto_boardType__strain2c, gains, targets, &msg);
+            } 
+            
             yarp::os::Time::delay(0.2);
             core->getDownloader()->strain_save_to_eeprom(canLine.toInt(),canId.toInt(), &msg);
             yInfo() << "Gains Saved!"; 
@@ -1067,7 +1077,7 @@ int setStrainSn(FirmwareUpdaterCore *core,QString device,QString id,QString boar
     }
     
 
-    if(canBoards.count() > 0 && icubCanProto_boardType__strain2 == canBoards[0].type)
+    if(canBoards.count() > 0 && ( (icubCanProto_boardType__strain2 == canBoards[0].type) || (icubCanProto_boardType__strain2c == canBoards[0].type) ) )
         {
             
             
@@ -1142,7 +1152,7 @@ int loadDatFileStrain2(FirmwareUpdaterCore *core,QString device,QString id,QStri
     }
     
     //Flash the .dat file   
-    if(canBoards.count() > 0 && icubCanProto_boardType__strain2 == canBoards[0].type)
+    if(canBoards.count() > 0 && ( (icubCanProto_boardType__strain2 == canBoards[0].type) || (icubCanProto_boardType__strain2c == canBoards[0].type) ) )
         {
             int ret = core->getDownloader()->get_serial_no(canLine.toInt(),canId.toInt(),sn);
             if(canBoards.count() > 0)
@@ -1167,7 +1177,7 @@ int loadDatFileStrain2(FirmwareUpdaterCore *core,QString device,QString id,QStri
                 sscanf (buffer,"%d",&file_version);
 
 
-                if((icubCanProto_boardType__strain2 == boardtype) && (3 != file_version))
+                if( ( (icubCanProto_boardType__strain2 == boardtype) ||  (icubCanProto_boardType__strain2c == boardtype) ) && (3 != file_version))
                 {
                     yError("Wrong file. Calibration version not supported for strain2: %d\n", file_version);
                     return false;
@@ -1350,7 +1360,7 @@ int saveDatFileStrain2(FirmwareUpdaterCore *core,QString device,QString id,QStri
     }
     
     //Flash the .dat file   
-    if(canBoards.count() > 0 && icubCanProto_boardType__strain2 == canBoards[0].type)
+    if(canBoards.count() > 0 && ( (icubCanProto_boardType__strain2 == canBoards[0].type) || (icubCanProto_boardType__strain2c == canBoards[0].type) ) )
     {
         core->getDownloader()->strain_get_serial_number(canLine.toInt(),canId.toInt(), serial_no);
 
@@ -1377,7 +1387,7 @@ int saveDatFileStrain2(FirmwareUpdaterCore *core,QString device,QString id,QStri
             }
         }
     
-        if(icubCanProto_boardType__strain2 == canBoards[0].type)
+        if(icubCanProto_boardType__strain2 == canBoards[0].type || icubCanProto_boardType__strain2c == canBoards[0].type)
         {
                 // file version
                 filestr<<"File version:"<<endl;

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -986,17 +986,10 @@ int setStrainGainsOffsets(FirmwareUpdaterCore *core,QString device,QString id,QS
 
             yDebug() << "strain2-amplifier-tuning: STEP-1. imposing gains which are different of each channel";
 
-            #warning TODO cannot pass canBoards[0].type because the type conversion is invalid
+            core->getDownloader()->strain_calibrate_offset2(canLine.toInt(), canId.toInt(), 
+                                                            static_cast<icubCanProto_boardType_t>(canBoards[0].type), 
+                                                            gains, targets, &msg);
 
-            if(icubCanProto_boardType__strain2 == canBoards[0].type) 
-            {
-                core->getDownloader()->strain_calibrate_offset2(canLine.toInt(), canId.toInt(), icubCanProto_boardType__strain2, gains, targets, &msg);
-            }
-            else
-            {
-                core->getDownloader()->strain_calibrate_offset2(canLine.toInt(), canId.toInt(), icubCanProto_boardType__strain2c, gains, targets, &msg);
-            } 
-            
             yarp::os::Time::delay(0.2);
             core->getDownloader()->strain_save_to_eeprom(canLine.toInt(),canId.toInt(), &msg);
             yInfo() << "Gains Saved!"; 

--- a/src/tools/FirmwareUpdater/mainwindow.cpp
+++ b/src/tools/FirmwareUpdater/mainwindow.cpp
@@ -1233,7 +1233,7 @@ void MainWindow::onAppendInfo(sBoard canboard)
     QTreeWidgetItem *inf = new QTreeWidgetItem(boardNode, QStringList() << "Info" << str);
     boardNode->addChild(inf);
 
-    if((eobrd_strain == canboard.type) || (eobrd_strain2 == canboard.type))
+    if((eobrd_strain == canboard.type) || (eobrd_strain2 == canboard.type) || (eobrd_strain2c == canboard.type))
     {
         QTreeWidgetItem *sn = new QTreeWidgetItem(boardNode, QStringList() << "Serial Number" << canboard.serial);
         boardNode->addChild(sn);
@@ -1471,12 +1471,12 @@ void MainWindow::checkEnableButtons()
             ui->btnCahngeInfo->setEnabled(true);
 
             sBoard canBoard = ((EthTreeWidgetItem*)selectedNodes.first()->getParentNode())->getCanBoard(selectedNodes.first()->getIndexOfBoard());
-            if(/*core->strainCalibMode && */(canBoard.type == icubCanProto_boardType__strain) || (canBoard.type == icubCanProto_boardType__strain2)){
+            if(/*core->strainCalibMode && */(canBoard.type == icubCanProto_boardType__strain) || (canBoard.type == icubCanProto_boardType__strain2) || (canBoard.type == icubCanProto_boardType__strain2c)){
                 ui->btnStrainCalib->setEnabled(true);
             }else{
                 ui->btnStrainCalib->setEnabled(false);
             }
-            if(((canBoard.type == icubCanProto_boardType__strain) || (canBoard.type == icubCanProto_boardType__strain2) || (canBoard.type == icubCanProto_boardType__6sg)) && (canBoard.status == BOARD_RUNNING) ){
+            if(((canBoard.type == icubCanProto_boardType__strain) || (canBoard.type == icubCanProto_boardType__strain2) || (canBoard.type == icubCanProto_boardType__strain2c) || (canBoard.type == icubCanProto_boardType__6sg)) && (canBoard.status == BOARD_RUNNING) ){
                 sgboardtype = static_cast<icubCanProto_boardType_t>(canBoard.type);
                 ui->btnCalibrate->setEnabled(true);
                 //ui->btnEraseEeprom->setEnabled(true);


### PR DESCRIPTION
As per title, this PR updates the checks during the firmwareupdater execution to allow for the `Calibrate` functions to work.