### PR TITLE
Temporary workaround for MAIS finger problem

### DIFF
--- a/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.cpp
+++ b/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.cpp
@@ -578,8 +578,13 @@ bool parametricCalibratorEth::calibrate()
     }
 
     //before starting the calibration, checks for joints in hardware fault, and clears them if the user set the clearHwFaultBeforeCalibration option
-    if(!checkHwFault())
-        return false;
+    // if(!checkHwFault())
+    //     return false;
+    checkHwFault();         //TODO: reset the commented part --> TEMPORARY FIX necessary in order to avoid hw limit exceeded at YRI restart. Now error is almost inevitable w/ MAIS sensors because of error in position reading
+                            // as things now, even if the calibration seems fine for finger at restart the MAIS loose the set calibration on some fingers
+                            // the problem is that at every restrat the error could verify for a different joint and this things is almost aleatory and not repetable
+                            // Therefore, while we are working for releasing the hard fix, which will set the joint in NOT_CONFIGURED at restart of YRI, it is needed to DO NOT return even if a hw fault is found at restart
+                            // so that the joint can recalibrate at restart
 
     if (totJointsToCalibrate < n_joints)
     {


### PR DESCRIPTION
This PR introduces a temporary fix to the hw fault check in order to do not have problem with YRI restarting on joints that mounts encoders which are highly sensible to disturbances, such as the MAIS on the fingers of iCub.
The reason to introduce this change and to define it temporary are here defined:
- previously with [this PR](https://github.com/robotology/icub-main/pull/866) the check on the hw faults has been enabled. As a matter of fact we realized that in that code section mentioned in the PR the logic of the code was erroneous, because the check of the faults is never taken into account, but the operations can continue independently on the fact that a fault is present or not. Therefore, it has been decided to wrap the method in a if condition and stop the calibration procedure if a fault is present;
- however, that PR brought up some misbehavior of the code, which were previously hidden, such as the fact that if an encoder is sensible to errors, it could happen that it measure oscillates around zero at YRI start-up and if it goes towards negative values  there will be an hw limits error, which won't allow the code to go on with the calibration
- anyway, it should be underlined that the hw limit/boundaries exceed error happens because at YRI stopping the joints are set to IDLE instead of to NOT CONFIGURED, as when the YRI is started the first time. However, considering that modifying and test all the code of the motion controller for setting the joints to NOT CONFIGURED at YRI stop is planned for the upcoming release, as things now this fix is necessary to allow the users to work fine with MAIS joints.
- For sure this is not the best option but, after recalibrating the MAIS joints multiple times and having every time a different finger joint to go on fault, introduce the necessity to operates in this way