### PR TITLE
Update eomcParser and embObjMotionControl to support the new velocityThresh param

### DIFF
--- a/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.h
+++ b/src/libraries/icubmod/canBusMotionControl/CanBusMotionControl.h
@@ -169,7 +169,6 @@ public:
     DebugParameters *_debug_params;             /** debug parameters */
     ImpedanceParameters *_impedance_params;     /** impedance parameters */
     ImpedanceLimits     *_impedance_limits;     /** impedancel imits */
-    double *_bemfGain;                          /** bemf compensation gain */
     double *_ktau;                              /** motor torque constant */
     int    *_filterType;
     double *_limitsMin;                         /** joint limits, max*/

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -1346,6 +1346,7 @@ bool embObjMotionControl::init()
         jconfig.motor_params.friction.viscous_neg_val = _measureConverter->viscousNeg_user2raw(_trq_pids[logico].viscousNeg, fisico);
         jconfig.motor_params.friction.coulomb_pos_val = _measureConverter->coulombPos_user2raw(_trq_pids[logico].coulombPos, fisico);
         jconfig.motor_params.friction.coulomb_neg_val = _measureConverter->coulombNeg_user2raw(_trq_pids[logico].coulombNeg, fisico);
+        jconfig.motor_params.friction.velocityThres_val = _measureConverter->velocityThres_user2raw(_trq_pids[logico].velocityThres, fisico);
 
         jconfig.gearbox_E2J = _gearbox_E2J[logico];
         
@@ -3678,7 +3679,7 @@ bool embObjMotionControl::getRemoteVariableRaw(std::string key, yarp::os::Bottle
             MotorTorqueParameters params;
             getMotorTorqueParamsRaw(i, &params);
             char buff[1000];
-            snprintf(buff, 1000, "J %d : bemf %+3.3f bemf_scale %+3.3f ktau %+3.3f ktau_scale %+3.3f viscousPos %+3.3f viscousNeg %+3.3f coulombPos %+3.3f coulombNeg %+3.3f", i, params.bemf, params.bemf_scale, params.ktau, params.ktau_scale, params.viscousPos, params.viscousNeg, params.coulombPos, params.coulombNeg);
+            snprintf(buff, 1000, "J %d : bemf %+3.3f bemf_scale %+3.3f ktau %+3.3f ktau_scale %+3.3f viscousPos %+3.3f viscousNeg %+3.3f coulombPos %+3.3f coulombNeg %+3.3f velocityThres %+3.3f", i, params.bemf, params.bemf_scale, params.ktau, params.ktau_scale, params.viscousPos, params.viscousNeg, params.coulombPos, params.coulombNeg, params.velocityThres);
             r.addString(buff);
         }
         return true;
@@ -4102,8 +4103,9 @@ bool embObjMotionControl::getMotorTorqueParamsRaw(int j, MotorTorqueParameters *
     params->viscousNeg = eo_params.friction.viscous_neg_val ;
     params->coulombPos = eo_params.friction.coulomb_pos_val;
     params->coulombNeg = eo_params.friction.coulomb_neg_val;
+    params->velocityThres  = eo_params.friction.velocityThres_val;
 
-    //printf("debug getMotorTorqueParamsRaw %f %f %f %f %f %f %f %f\n",  params->bemf, params->bemf_scale, params->ktau,params->ktau_scale, params->viscousPos, params->viscousNeg, params->coulombPos, params->coulombNeg);
+    //printf("debug getMotorTorqueParamsRaw %f %f %f %f %f %f %f %f\n",  params->bemf, params->bemf_scale, params->ktau,params->ktau_scale, params->viscousPos, params->viscousNeg, params->coulombPos, params->coulombNeg, params->threshold);
 
     return true;
 }
@@ -4113,16 +4115,17 @@ bool embObjMotionControl::setMotorTorqueParamsRaw(int j, const MotorTorqueParame
     eOprotID32_t id32 = eoprot_ID_get(eoprot_endpoint_motioncontrol, eoprot_entity_mc_joint, j, eoprot_tag_mc_joint_config_motor_params);
     eOmc_motor_params_t eo_params = {0};
 
-    //printf("setMotorTorqueParamsRaw for j %d(INPUT): benf=%f ktau=%f viscousPos=%f viscousNeg=%f coulombPos=%f coulombNeg=%f\n",j, params.bemf, params.ktau, params.viscousPos, params.viscousNeg, params.coulombPos, params.coulombNeg);
+    //printf("setMotorTorqueParamsRaw for j %d(INPUT): benf=%f ktau=%f viscousPos=%f viscousNeg=%f coulombPos=%f coulombNeg=%f\n",j, params.bemf, params.ktau, params.viscousPos, params.viscousNeg, params.coulombPos, params.coulombNeg, params.threshold);
 
     eo_params.bemf_value  = (float)   params.bemf;
     eo_params.bemf_scale  = (uint8_t) params.bemf_scale;
     eo_params.ktau_value  = (float)   params.ktau;
     eo_params.ktau_scale  = (uint8_t) params.ktau_scale;
-    eo_params.friction.viscous_pos_val   = static_cast<float32_t>(params.viscousPos);
+    eo_params.friction.viscous_pos_val = static_cast<float32_t>(params.viscousPos);
     eo_params.friction.viscous_neg_val = static_cast<float32_t>(params.viscousNeg);
-    eo_params.friction.coulomb_pos_val   = static_cast<float32_t>(params.coulombPos);
+    eo_params.friction.coulomb_pos_val = static_cast<float32_t>(params.coulombPos);
     eo_params.friction.coulomb_neg_val = static_cast<float32_t>(params.coulombNeg);
+    eo_params.friction.velocityThres_val = static_cast<float32_t>(params.velocityThres);
 
 
     if(false == res->setRemoteValue(id32, &eo_params))

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -49,7 +49,6 @@ yarp::dev::eomc::Parser::Parser(int numofjoints, string boardname)
     _currentControlLaw.resize(0);
     _speedControlLaw.resize(0);
 
-    _kbemf=allocAndCheck<double>(_njoints);
     _ktau=allocAndCheck<double>(_njoints);
     _filterType=allocAndCheck<int>(_njoints);
     _viscousPos=allocAndCheck<double>(_njoints);
@@ -65,7 +64,6 @@ yarp::dev::eomc::Parser::Parser(int numofjoints, string boardname)
 
 Parser::~Parser()
 {
-    checkAndDestroy(_kbemf);
     checkAndDestroy(_ktau);
     checkAndDestroy(_filterType);
     checkAndDestroy(_viscousPos);
@@ -902,9 +900,6 @@ bool Parser::parsePidsGroupDeluxe(Bottle& pidsGroup, Pid myPid[])
     if (!parsePidsGroupExtended(pidsGroup, myPid)) return false;
 
     Bottle xtmp;
-
-    // if (!extractGroup(pidsGroup, xtmp, "kbemf", "kbemf parameter", _njoints, false)) return false; 
-    // for (int j = 0; j<_njoints; j++) _kbemf[j] = xtmp.get(j + 1).asFloat64();
     
     if (!extractGroup(pidsGroup, xtmp, "ktau", "ktau parameter", _njoints)) return false; 
     for (int j = 0; j<_njoints; j++) _ktau[j] = xtmp.get(j + 1).asFloat64();
@@ -1290,7 +1285,6 @@ bool Parser::getCorrectPidForEachJoint(PidInfo *ppids/*, PidInfo *vpids*/, TrqPi
             tpids[i].out_type = torqueAlgo_ptr->out_type;
             tpids[i].usernamePidSelected = _torqueControlLaw[i];
             tpids[i].enabled = true;
-            tpids[i].kbemf = _kbemf[i];
             tpids[i].ktau = _ktau[i];
             tpids[i].viscousPos = _viscousPos[i];
             tpids[i].viscousNeg = _viscousNeg[i];

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.h
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.h
@@ -191,7 +191,6 @@ public:
 class TrqPidInfo : public PidInfo
 {
 public:
-    double kbemf;                             /** back-emf compensation parameter */
     double ktau;                              /** motor torque constant */
     double viscousPos;
     double viscousNeg;
@@ -343,7 +342,6 @@ private:
     std::vector<std::string> _currentControlLaw;
     std::vector<std::string> _speedControlLaw;
 
-    double *_kbemf;                             /** back-emf compensation parameter */
     double *_ktau;                              /** motor torque constant */
     int *_filterType;
     double *_viscousPos;

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.h
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.h
@@ -197,6 +197,7 @@ public:
     double viscousNeg;
     double coulombPos;
     double coulombNeg;
+    double velocityThres;
     int    filterType;
 };
 
@@ -349,6 +350,7 @@ private:
     double *_viscousNeg;
     double *_coulombPos;
     double *_coulombNeg;
+    double *_velocityThres;
 
 
 

--- a/src/libraries/icubmod/embObjMotionControl/measuresConverter.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/measuresConverter.cpp
@@ -17,7 +17,6 @@ measureConvFactors::measureConvFactors(int numofjoints)
     dutycycleToPWM   = new double [numofjoints];
     ampsToSensor     = new double [numofjoints];
     newtonsToSensor  = new double [numofjoints];
-    bemf2raw         = new double [numofjoints];
     ktau2raw         = new double [numofjoints];
 }
 
@@ -27,7 +26,6 @@ measureConvFactors::~measureConvFactors()
     if (dutycycleToPWM)   delete [] dutycycleToPWM;
     if (ampsToSensor)     delete [] ampsToSensor;
     if (newtonsToSensor)  delete [] newtonsToSensor;
-    if (bemf2raw)         delete [] bemf2raw;
     if (ktau2raw)         delete [] ktau2raw;
 
     angleToEncoder = nullptr;
@@ -35,6 +33,5 @@ measureConvFactors::~measureConvFactors()
     ampsToSensor = nullptr;
     newtonsToSensor  = nullptr;
     ktau2raw = nullptr;
-    bemf2raw = nullptr;
 }
 

--- a/src/libraries/icubmod/embObjMotionControl/measuresConverter.h
+++ b/src/libraries/icubmod/embObjMotionControl/measuresConverter.h
@@ -50,7 +50,6 @@ public:
     double* dutycycleToPWM;
     double* ampsToSensor;
     double* newtonsToSensor;
-    double* bemf2raw;
     double* ktau2raw;
 
     measureConvFactors(int numofjoints);


### PR DESCRIPTION
**What's new:**
- The `eomcParser` now detects the presence of the new `velocityThresh` when it is written in the configuration files. If the `velocityThresh` is omitted its default value is 0.
- ⚠️ The `eomcParser` will not recognize the `kbemf` parameter. Hence, all the config files in robots-configuration have to be updated accordingly


> **Note**
> - This is connected to
>   - https://github.com/robotology/yarp/pull/3008
>   - https://github.com/robotology/icub-firmware-shared/pull/86