### PR TITLE
Fix `BATTERY_OK_STANDBY` typo

### DIFF
--- a/src/libraries/icubmod/bcbBattery/bcbBattery.h
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.h
@@ -45,7 +45,7 @@ class batteryReaderThread : public PeriodicThread
     double             battery_current = 0;
     std::string        battery_info = "icub battery system v1.0";
     int                backpack_status = 0;
-    IBattery::Battery_status     battery_status = IBattery::Battery_status::BATTERY_OK_STANBY;
+    IBattery::Battery_status     battery_status = IBattery::Battery_status::BATTERY_OK_STANDBY;
 
     batteryReaderThread (ISerialDevice *_iSerial, double period) :
     PeriodicThread((double)period),


### PR DESCRIPTION
See https://github.com/robotology/robotology-superbuild/issues/1536.

Requires a yarp tag > 3.8.1 and that #903 is merged beforehand.
Put in draft until the conditions are met.