### PR TITLE
CMake: Use OpenCV_LIBS instead of OpenCV_LIBRARIES as documented in official OpenCV docs

### DIFF
--- a/src/doc/cmake_usage.dox
+++ b/src/doc/cmake_usage.dox
@@ -72,7 +72,7 @@ if you need OpenCV, do:
 \verbatim
 FIND_PACKAGE(OpenCV REQUIRED)
 INCLUDE_DIRECTORIES(${OPENCV_INCLUDE_DIR})
-LINK_LIBRARIES(${OPENCV_LIBRARIES})
+LINK_LIBRARIES(${OpenCV_LIBS})
 \endverbatim
 Note that capitalization and pluralization is a bit inconsistent in
 this case.  To figure this out, look for a file called "FindOpenCV.cmake" 

--- a/src/modules/actionsRenderingEngine/CMakeLists.txt
+++ b/src/modules/actionsRenderingEngine/CMakeLists.txt
@@ -27,7 +27,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE ${IPOPT_DEFINITIONS} _USE_MAT
 
 set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS " ${IPOPT_LINK_FLAGS}")
 target_link_libraries(${PROJECT_NAME} iKin actionPrimitives ${YARP_LIBRARIES}
-                                      ${OpenCV_LIBRARIES} ${IPOPT_LIBRARIES})
+                                      ${OpenCV_LIBS} ${IPOPT_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 

--- a/src/modules/camCalib/CMakeLists.txt
+++ b/src/modules/camCalib/CMakeLists.txt
@@ -22,6 +22,6 @@ set(folder_header include/iCub/spherical_projection.h
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 add_executable(${PROJECT_NAME} ${folder_source} ${folder_header})
-target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES} ${YARP_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBS} ${YARP_LIBRARIES})
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 

--- a/src/modules/camCalibWithPose/CMakeLists.txt
+++ b/src/modules/camCalibWithPose/CMakeLists.txt
@@ -23,6 +23,6 @@ set(folder_header include/iCub/spherical_projection.h
 include_directories(${PROJECT_SOURCE_DIR}/include)
 add_executable(${PROJECT_NAME} ${folder_source} ${folder_header})
 target_compile_definitions(${PROJECT_NAME} PRIVATE _USE_MATH_DEFINES)
-target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES} ${YARP_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBS} ${YARP_LIBRARIES})
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 

--- a/src/modules/dualCamCalib/CMakeLists.txt
+++ b/src/modules/dualCamCalib/CMakeLists.txt
@@ -22,6 +22,6 @@ set(folder_header include/iCub/spherical_projection.h
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 add_executable(${PROJECT_NAME} ${folder_source} ${folder_header})
-target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES} ${YARP_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBS} ${YARP_LIBRARIES})
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 

--- a/src/modules/motionCUT/CMakeLists.txt
+++ b/src/modules/motionCUT/CMakeLists.txt
@@ -12,6 +12,6 @@ set(doc_files ${PROJECT_NAME}.xml)
 source_group("DOC Files" FILES ${doc_files})
 
 add_executable(${PROJECT_NAME} ${source_files} ${doc_files})
-target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES} ${YARP_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBS} ${YARP_LIBRARIES})
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 yarp_install(FILES ${doc_files} DESTINATION ${ICUB_MODULES_INSTALL_DIR})

--- a/src/modules/templatePFTracker/CMakeLists.txt
+++ b/src/modules/templatePFTracker/CMakeLists.txt
@@ -12,6 +12,6 @@ file(GLOB folder_source src/*.cpp src/*.cc src/*.c)
 
 include_directories(${PROJECT_SOURCE_DIR}/include ${GSL_INCLUDE_DIRS})
 add_executable(${PROJECT_NAME} ${folder_header} ${folder_source})
-target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES} ${GSL_LIBRARIES} ${YARP_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBS} ${GSL_LIBRARIES} ${YARP_LIBRARIES})
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 

--- a/src/tools/depth2kin/CMakeLists.txt
+++ b/src/tools/depth2kin/CMakeLists.txt
@@ -24,7 +24,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE ${IPOPT_DEFINITIONS} _USE_MAT
 set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS " ${IPOPT_LINK_FLAGS}")
 target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES}
                                       ${IPOPT_LIBRARIES}
-                                      ${OpenCV_LIBRARIES}
+                                      ${OpenCV_LIBS}
                                       ctrlLib
                                       iKin
                                       optimization

--- a/src/tools/stereoCalib/CMakeLists.txt
+++ b/src/tools/stereoCalib/CMakeLists.txt
@@ -14,6 +14,6 @@ add_executable(${PROJECT_NAME} ${source} ${header})
 if(OpenCV_VERSION_MAJOR GREATER 2)
   target_compile_definitions(${PROJECT_NAME} PRIVATE OPENCV_GREATER_2)
 endif()
-target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES} ${OpenCV_LIBRARIES} iKin)
+target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES} ${OpenCV_LIBS} iKin)
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 


### PR DESCRIPTION
`OpenCV_LIBS` is the variable documented in official OpenCV docs (https://docs.opencv.org/4.x/db/df5/tutorial_linux_gcc_cmake.html). `OpenCV_LIBRARIES` was a YCM extension, that is going to be deprecated (see https://github.com/robotology/ycm/pull/434).