### PR TITLE
CI: Enable compilation of bcbBattery device

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
               -DICUB_USE_icub_firmware_shared:BOOL=ON \
               -DENABLE_icubmod_skinWrapper:BOOL=ON \
               -DENABLE_icubmod_sharedcan:BOOL=ON \
+              -DENABLE_icubmod_bcbBattery:BOOL=ON \
               -DENABLE_icubmod_canmotioncontrol:BOOL=ON \
               -DENABLE_icubmod_canBusAnalogSensor:BOOL=ON \
               -DENABLE_icubmod_canBusInertialMTB:BOOL=ON \

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.h
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.h
@@ -8,6 +8,7 @@
 #define __BCBBATTERY_H__
 
 #include <mutex>
+#include <yarp/conf/version.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/IBattery.h>
 #include <yarp/dev/PolyDriver.h>


### PR DESCRIPTION
I suspect https://github.com/robotology/icub-main/pull/920 actually broke compilation with YARP 3.8.1 (based on robotology-superbuild CI), but we did not realized this as the CI does not actually compile the bcbBattery device. 