### PR TITLE
Remove IAnalogSensor interface from the devices ported to the new interfaces

### DIFF
--- a/src/libraries/icubmod/canBusFtSensor/CanBusFtSensor.cpp
+++ b/src/libraries/icubmod/canBusFtSensor/CanBusFtSensor.cpp
@@ -312,55 +312,6 @@ bool CanBusFtSensor::close()
     return true;
 }
 
-int CanBusFtSensor::read(yarp::sig::Vector &out)
-{
-    mtx.lock();
-    out=data;
-    mtx.unlock();
-
-    if( this->diagnostic )
-        return status;
-    else
-        return IAnalogSensor::AS_OK;
-}
-
-int CanBusFtSensor::getState(int ch)
-{
-    if( this->diagnostic )
-        return status;
-    else
-        return IAnalogSensor::AS_OK;
-}
-
-int CanBusFtSensor::getChannels()
-{
-    return channelsNum;
-}
-
-int CanBusFtSensor::calibrateSensor()
-{
-    //NOT YET IMPLEMENTED
-    return 0;
-}
-
-int CanBusFtSensor::calibrateChannel(int ch, double v)
-{
-    //NOT YET IMPLEMENTED
-    return 0;
-}
-
-int CanBusFtSensor::calibrateSensor(const yarp::sig::Vector& v)
-{
-    //NOT YET IMPLEMENTED
-    return 0;
-}
-
-int CanBusFtSensor::calibrateChannel(int ch)
-{
-    //NOT YET IMPLEMENTED
-    return 0;
-}
-
 bool CanBusFtSensor::threadInit()
 {
     return true;
@@ -476,7 +427,7 @@ void CanBusFtSensor::run()
         const char   type     = ((msgid&0x700)>>8);
 
         //parse data here
-        status=IAnalogSensor::AS_OK;
+        status=MAS_status::MAS_OK;
 
         if (type==0x03) //analog data
         {
@@ -487,29 +438,29 @@ void CanBusFtSensor::run()
                 {
                     case ANALOG_FORMAT_8_BIT:
                         ret=decode8(buff, msgid, data.data());
-                        status=IAnalogSensor::AS_OK;
+                        status=MAS_status::MAS_OK;
                         break;
                     case ANALOG_FORMAT_16_BIT:
                         if (len==6)
                         {
                             ret=decode16(buff, msgid, data.data());
-                            status=IAnalogSensor::AS_OK;
+                            status=MAS_status::MAS_OK;
                         }
                         else
                         {
-                            if ((len==7) && (buff[6] != 0)) // changed from "== 1" in order to maintain compatibility with extra overflow information in byte 6. 
+                            if ((len==7) && (buff[6] != 0)) // changed from "== 1" in order to maintain compatibility with extra overflow information in byte 6.
                             {
-                                status=IAnalogSensor::AS_OVF;
+                                status=MAS_status::MAS_OVF;
                             }
                             else
                             {
-                                status=IAnalogSensor::AS_ERROR;
+                                status=MAS_status::MAS_ERROR;
                             }
                             ret=decode16(buff, msgid, data.data());
                         }
                         break;
                     default:
-                        status=IAnalogSensor::AS_ERROR;
+                        status=MAS_status::MAS_ERROR;
                         ret=false;
                 }
             }
@@ -519,7 +470,7 @@ void CanBusFtSensor::run()
     //if 100ms have passed since the last received message
     if (timeStamp+0.1<timeNow)
     {
-        status=IAnalogSensor::AS_TIMEOUT;
+        status=MAS_status::MAS_TIMEOUT;
     }
 }
 
@@ -553,10 +504,10 @@ bool CanBusFtSensor::getSixAxisForceTorqueSensorFrameName(size_t sens_index, std
 
 bool CanBusFtSensor::getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
-    std::lock_guard<std::mutex> lck(mtx);    
+    std::lock_guard<std::mutex> lck(mtx);
     out = data;
     timestamp = timeStamp;
-    
+
     return true;
 }
 

--- a/src/libraries/icubmod/canBusFtSensor/CanBusFtSensor.h
+++ b/src/libraries/icubmod/canBusFtSensor/CanBusFtSensor.h
@@ -9,7 +9,6 @@
 
 #include <mutex>
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/CanBusInterface.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
@@ -38,12 +37,11 @@ using namespace yarp::dev;
 * | period         | int    | ms    | - | Yes | Publication period (in ms) of the sensor reading on the Can Bus | - |
 * | channels       | int    | -     | - | Yes | Number of output channels of the sensor (6 for STRAIN board, 16 for MAIS board) | - |
 * | useCalibration | int    | -     | - | No  | If useCalibration is present and set to 1 output the calibrated readings, otherwise output the raw values | - |
-* | diagnostic     | int    | -     | - | No  | If diagnostic is present and set to 1 properly return the state of the sensor, otherwise always return IAnalogSensor::AS_OK | - |
+* | diagnostic     | int    | -     | - | No  | If diagnostic is present and set to 1 properly return the state of the sensor, otherwise always return MAS_status::MAS_OK | - |
 * | sensorName     | string | -     | - | Yes | Unique name of the sensor  | - |
 * | frameName      | string | -     | unknown_frame_name | No  | Name of the robot link to which the sensor is attached | Many sensors can be attached to the same frame link. The parameter is typically used in ROS message headers and should match a valid frame link name defined in the robot model (.sdf / .urdf). If wrongly assigned, ROS will not work properly. |
 */
-class CanBusFtSensor : public PeriodicThread, 
-                           public yarp::dev::IAnalogSensor, 
+class CanBusFtSensor : public PeriodicThread,
                            public DeviceDriver,
                            public yarp::dev::ISixAxisForceTorqueSensors
 {
@@ -96,17 +94,6 @@ public:
 
     virtual bool open(yarp::os::Searchable& config);
     virtual bool close();
-
-
-    //IAnalogSensor interface
-    virtual int read(yarp::sig::Vector &out);
-    virtual int getState(int ch);
-    virtual int getChannels();
-    int calibrateSensor();
-    virtual int calibrateChannel(int ch, double v);
-
-    virtual int calibrateSensor(const yarp::sig::Vector& v);
-    virtual int calibrateChannel(int ch);
 
     virtual bool threadInit();
     virtual void threadRelease();

--- a/src/libraries/icubmod/embObjFTsensor/embObjFTsensor.cpp
+++ b/src/libraries/icubmod/embObjFTsensor/embObjFTsensor.cpp
@@ -324,77 +324,10 @@ bool embObjFTsensor::updateTemperatureValues(eOprotID32_t id32, double timestamp
     return true;
 }
 
-
-// -----------------------------  yarp::dev::IAnalogSensor --------------------------------------
-
-
-/*! Read a vector from the sensor.
- * @param out a vector containing the sensor's last readings.
- * @return AS_OK or return code. AS_TIMEOUT if the sensor timed-out.
- **/
-int embObjFTsensor::read(yarp::sig::Vector &out)
-{
-    // This method gives analogdata to the analogServer
-
-    if(false == GET_privData(mPriv).isOpen())
-    {
-        return false;
-    }
-
-    std::lock_guard<std::mutex> lck(GET_privData(mPriv).mtx);
-
-    out.resize(GET_privData(mPriv).analogdata.size());
-    for (size_t k = 0; k<GET_privData(mPriv).analogdata.size(); k++)
-    {
-        out[k] = GET_privData(mPriv).analogdata[k] + GET_privData(mPriv).offset[k];
-    }
-
-    return IAnalogSensor::AS_OK;;
-}
-
-int embObjFTsensor::getState(int ch)
-{
-    return AS_OK;
-}
-
-
-int embObjFTsensor::getChannels()
-{
-    return GET_privData(mPriv).strain_Channels;
-}
-
-
-int embObjFTsensor::calibrateSensor()
-{
-    std::lock_guard<std::mutex> lck(GET_privData(mPriv).mtx);
-    for (size_t i = 0; i <  GET_privData(mPriv).analogdata.size(); i++)
-    {
-        GET_privData(mPriv).offset[i] = - GET_privData(mPriv).analogdata[i];
-    }
-    return AS_OK;
-}
-
-int embObjFTsensor::calibrateSensor(const yarp::sig::Vector& value)
-{
-    return AS_OK;
-}
-
-int embObjFTsensor::calibrateChannel(int ch)
-{
-    return AS_OK;
-}
-
-int embObjFTsensor::calibrateChannel(int ch, double v)
-{
-    return AS_OK;
-}
-
 eth::iethresType_t embObjFTsensor::type()
 {
     return eth::iethres_analogstrain;
 }
-
-
 
 // ---------------------- ITemperatureSensors --------------------------------------------------------
 size_t embObjFTsensor::getNrOfTemperatureSensors() const

--- a/src/libraries/icubmod/embObjFTsensor/embObjFTsensor.h
+++ b/src/libraries/icubmod/embObjFTsensor/embObjFTsensor.h
@@ -24,7 +24,6 @@
 #define __embObjFTsensor_h__
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/IAnalogSensor.h>
 #include "IethResource.h"
 
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
@@ -43,7 +42,6 @@ namespace yarp {
 
 class yarp::dev::embObjFTsensor:    public yarp::dev::DeviceDriver,
                                     public eth::IethResource,
-                                    public yarp::dev::IAnalogSensor,
                                     public yarp::dev::ITemperatureSensors,
                                     public yarp::dev::ISixAxisForceTorqueSensors
 {
@@ -56,20 +54,11 @@ public:
     bool open(yarp::os::Searchable &config);
     bool close();
 
-    // IAnalogSensor interface
-    virtual int read(yarp::sig::Vector &out);
-    virtual int getState(int ch);
-    virtual int getChannels();
-    virtual int calibrateChannel(int ch, double v);
-    virtual int calibrateSensor();
-    virtual int calibrateSensor(const yarp::sig::Vector& value);
-    virtual int calibrateChannel(int ch);
-
     // IethResource interface
     virtual bool initialised();
     virtual eth::iethresType_t type();
     virtual bool update(eOprotID32_t id32, double timestamp, void* rxdata);
-    
+
     // ITemperatureSensors
     virtual size_t getNrOfTemperatureSensors() const override;
     virtual yarp::dev::MAS_status getTemperatureSensorStatus(size_t sens_index) const override;
@@ -77,7 +66,7 @@ public:
     virtual bool getTemperatureSensorFrameName(size_t sens_index, std::string &frameName) const override;
     virtual bool getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const override;
     virtual bool getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
-    
+
     // ISixAxisForceTorqueSensors
     virtual size_t getNrOfSixAxisForceTorqueSensors() const override;
     virtual yarp::dev::MAS_status getSixAxisForceTorqueSensorStatus(size_t sens_index) const override;

--- a/src/libraries/icubmod/embObjMais/embObjMais.cpp
+++ b/src/libraries/icubmod/embObjMais/embObjMais.cpp
@@ -129,7 +129,7 @@ embObjMais::embObjMais()
     counterError=0;
     counterTimeout=0;
 
-    status = IAnalogSensor::AS_OK;
+    status = MAS_status::MAS_OK;
 
 
     opened = false;
@@ -426,57 +426,6 @@ bool embObjMais::initRegulars()
 }
 
 
-/*! Read a vector from the sensor.
- * @param out a vector containing the sensor's last readings.
- * @return AS_OK or return code. AS_TIMEOUT if the sensor timed-out.
- **/
-
-int embObjMais::read(yarp::sig::Vector &out)
-{
-    // This method gives analogdata to the analogServer
-
-    if(false == opened)
-    {
-        return false;
-    }
-
-    std::lock_guard<std::mutex> lck(mtx);
-
-    // errors are not handled for now... it'll always be OK!!
-    if (status != IAnalogSensor::AS_OK)
-    {
-        switch (status)
-        {
-            case IAnalogSensor::AS_OVF:
-            {
-                counterSat++;
-            }  break;
-            case IAnalogSensor::AS_ERROR:
-            {
-                counterError++;
-            } break;
-            case IAnalogSensor::AS_TIMEOUT:
-            {
-                counterTimeout++;
-            } break;
-            default:
-            {
-                counterError++;
-            } break;
-        }
-        return status;
-    }
-
-    out.resize(analogdata.size());
-    for (size_t k = 0; k<analogdata.size(); k++)
-    {
-        out[k] = analogdata[k];
-    }
-
-    return status;
-}
-
-
 void embObjMais::resetCounters()
 {
     counterSat=0;
@@ -491,44 +440,6 @@ void embObjMais::getCounters(unsigned int &sat, unsigned int &err, unsigned int 
     err=counterError;
     to=counterTimeout;
 }
-
-
-int embObjMais::getState(int ch)
-{
-    printf("getstate\n");
-    return AS_OK;
-}
-
-
-int embObjMais::getChannels()
-{
-    return analogdata.size();
-}
-
-
-int embObjMais::calibrateSensor()
-{
-    return AS_OK;
-}
-
-
-int embObjMais::calibrateSensor(const yarp::sig::Vector& value)
-{
-    return AS_OK;
-}
-
-
-int embObjMais::calibrateChannel(int ch)
-{
-    return AS_OK;
-}
-
-
-int embObjMais::calibrateChannel(int ch, double v)
-{
-    return AS_OK;
-}
-
 
 size_t embObjMais::getNrOfEncoderArrays() const {
     return 1;

--- a/src/libraries/icubmod/embObjMais/embObjMais.h
+++ b/src/libraries/icubmod/embObjMais/embObjMais.h
@@ -5,7 +5,6 @@
 #define __embObjMais_h__
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/IAnalogSensor.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 #include <string>
@@ -37,8 +36,7 @@ namespace yarp {
 
 // -- class embObjMais
 
-class yarp::dev::embObjMais:            public yarp::dev::IAnalogSensor,
-                                        public yarp::dev::DeviceDriver,
+class yarp::dev::embObjMais:            public yarp::dev::DeviceDriver,
                                         public eth::IethResource,
                                         public yarp::dev::IEncoderArrays
 {
@@ -55,15 +53,6 @@ public:
     // An open function yarp factory compatible
     bool open(yarp::os::Searchable &config);
     bool close();
-
-    // IAnalogSensor interface
-    virtual int read(yarp::sig::Vector &out);
-    virtual int getState(int ch);
-    virtual int getChannels();
-    virtual int calibrateChannel(int ch, double v);
-    virtual int calibrateSensor();
-    virtual int calibrateSensor(const yarp::sig::Vector& value);
-    virtual int calibrateChannel(int ch);
 
     // IEncoderArrays interface
     virtual size_t getNrOfEncoderArrays() const override;


### PR DESCRIPTION
They are canBusFtSensor, embObjFTsensor, embObjMais

It fixes #919 