### PR TITLE
Fix parsing data dimension in lost can boards error

### DIFF
--- a/src/libraries/icubmod/embObjLib/diagnosticLowLevelFormatter_hid.h
+++ b/src/libraries/icubmod/embObjLib/diagnosticLowLevelFormatter_hid.h
@@ -32,7 +32,6 @@ namespace Diagnostic {
         class AnalogSensorParser;
         class AuxEmbeddedInfo;
         class EntityNameProvider;
-        
     }
 }
 


### PR DESCRIPTION
Fix added with this PR:

- Remove parsing time from justLOST canmonitor error, add parsing time to justFOUND and fix canmapping parsing Fix canmapping in can service errors
- Fix datatype and copy-paste typo
- Fix missing joint ID in motor generic error message