### PR TITLE
Fix/diagnostic gen error

### DIFF
--- a/src/libraries/icubmod/embObjLib/CMakeLists.txt
+++ b/src/libraries/icubmod/embObjLib/CMakeLists.txt
@@ -109,6 +109,7 @@ install(TARGETS ${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME} YARP::YARP_os
                                       YARP::YARP_dev
                                       icub_firmware_shared::embobj
+                                      icub_firmware_shared::embot
                                       ACE::ACE)
 
 icub_export_library(${PROJECT_NAME})

--- a/src/libraries/icubmod/embObjLib/diagnosticLowLevelFormatter_hid.h
+++ b/src/libraries/icubmod/embObjLib/diagnosticLowLevelFormatter_hid.h
@@ -11,7 +11,9 @@
 #define __diagnosticLowLevelFormatter_hid_h__
 
 #include <string>
+#include <string_view>
 #include <memory>
+#include <array>
 #include <yarp/os/LogStream.h>
 #include "diagnosticLowLevelFormatter.h"
 #include "EoError.h"
@@ -116,7 +118,8 @@ public:
 
     void parseInfo();
 
-
+private:
+std::string motorStatusBitsToString(eOmc_motorFaultState_t motorstatus);
 };
 
 class Diagnostic::LowLevel::SkinParser : public Diagnostic::LowLevel::DefaultParser


### PR DESCRIPTION
Updates for generic error translation from bits to string  using this method `motorStatusBitsToString`

correlated to: https://github.com/robotology/icub-main/pull/941 since it's rebased on that and it should be merged after
and it is directly related to: https://github.com/robotology/icub-firmware/pull/472


Related to:
https://github.com/robotology/icub-firmware-shared/pull/94
https://github.com/robotology/icub-firmware/pull/472