### PR TITLE
The `amc` board uses `ICC` and `CAN` to move the wrist of `ergoCub`

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -64,7 +64,7 @@ checkandset_dependency(IPOPT)
 checkandset_dependency(OpenCV)
 checkandset_dependency(Qt5)
 
-set(MINIMUM_REQUIRED_icub_firmware_shared_VERSION 1.38.0)
+set(MINIMUM_REQUIRED_icub_firmware_shared_VERSION 1.38.1)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
   if(icub_firmware_shared_VERSION VERSION_LESS ${MINIMUM_REQUIRED_icub_firmware_shared_VERSION})

--- a/src/libraries/icubmod/embObjLib/serviceParser.h
+++ b/src/libraries/icubmod/embObjLib/serviceParser.h
@@ -215,6 +215,7 @@ typedef struct
 {
     eOmc_actuator_t                 type;
     eOmc_actuator_descriptor_t      desc;
+    eOmc_adv_actuator_descriptor_t  advdescr;
 } servMC_actuator_t;
 
 
@@ -335,9 +336,11 @@ public:
     bool convert(std::string const &fromstring, std::string &str, bool &formaterror);
     bool convert(std::string const &fromstring, const uint8_t strsize, char *str, bool &formaterror);
     bool convert(std::string const &fromstring, eObrd_location_t &location, bool &formaterror);
+    bool convert(std::string const &fromstring, eOlocation_t &location, bool &formaterror);
 
 
     bool convert(eObrd_location_t const &loc, char *str, int len);
+    bool convert(eOlocation_t const &loc, char *str, int len);
     bool convert(eObrd_canlocation_t const &canloc, char *str, int len);
 
     bool convert(eObrd_protocolversion_t const &prot, char *str, int len);


### PR DESCRIPTION
This PR belongs to a set of five PRs on `icub-firmware`, `icub-firmware-shared`, `icub-firmware-build`, `icub-main` and `robots-configuration`.

They introduce a new MC service  that supports  actuators located on the second core of the new dual core ETH boards that run the outer control loop at 1 ms.  So far the only dual core board we use is the `amc` which runs on the first CM7 core and uses an actuator board on its CM4 core: the `amc2c`. 

See https://github.com/robotology/icub-firmware/pull/474 for details

## Linked PRs
- https://github.com/robotology/icub-firmware/pull/474
- https://github.com/robotology/icub-firmware-shared/pull/93
- https://github.com/robotology/icub-firmware-build/pull/141
- https://github.com/robotology/robots-configuration/pull/623
