### PR TITLE
Add to diagnostic parser overheating error and Update embObjBattery

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -64,7 +64,7 @@ checkandset_dependency(IPOPT)
 checkandset_dependency(OpenCV)
 checkandset_dependency(Qt5)
 
-set(MINIMUM_REQUIRED_icub_firmware_shared_VERSION 1.38.1)
+set(MINIMUM_REQUIRED_icub_firmware_shared_VERSION 1.38.2)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
   if(icub_firmware_shared_VERSION VERSION_LESS ${MINIMUM_REQUIRED_icub_firmware_shared_VERSION})

--- a/src/libraries/icubmod/embObjBattery/embObjBattery.h
+++ b/src/libraries/icubmod/embObjBattery/embObjBattery.h
@@ -35,10 +35,12 @@ class CanBatteryData
     float32_t voltage_{0};
     float32_t current_{0};
     float32_t charge_{0};
-    uint32_t status_{0};
-    uint32_t prevStatus_{0};
+    uint16_t status_{0};
+    uint16_t prevStatus_{0};
     double timeStamp_{0};
-    std::string sensorName_;
+    std::string sensorName_{};
+    eObrd_type_t sensorType_{eobrd_unknown};
+    
 
     void decode(eOas_battery_timedvalue_t *data, double timestamp);
     bool operator==(const CanBatteryData &other) const;
@@ -81,7 +83,7 @@ class yarp::dev::embObjBattery : public yarp::dev::DeviceDriver, public eth::Iet
     bool initRegulars(ServiceParserCanBattery &parser, eth::AbstractEthResource *deviceRes);
     void cleanup(void);
     bool checkUpdateTimeout(eOprotID32_t id32, eOabstime_t current);
-    bool updateStatusStringStream(const uint32_t &currStatus, const uint32_t &prevStatus, bool isFirstLoop);
+    std::string updateStatusStringStream(const uint16_t &currStatus, const uint16_t &prevStatus, bool isFirstLoop);
     static constexpr eOabstime_t updateTimeout_{11000};
     std::vector<yarp::dev::MAS_status> masStatus_{MAS_OK, MAS_OK, MAS_OK, MAS_OK};
 
@@ -93,9 +95,6 @@ class yarp::dev::embObjBattery : public yarp::dev::DeviceDriver, public eth::Iet
 
     double firstYarpTimestamp_{0};
     eOabstime_t firstCanTimestamp_{0};
-
-    std::stringstream statusStreamBMS = {};
-    std::stringstream statusStreamBAT = {};
 };
 
 #endif

--- a/src/libraries/icubmod/embObjLib/diagnosticInfoParsers.cpp
+++ b/src/libraries/icubmod/embObjLib/diagnosticInfoParsers.cpp
@@ -685,6 +685,19 @@ void MotionControlParser::parseInfo()
             m_dnginfo.baseInfo.finalMessage.append(str);
         } break;
 
+        case eoerror_value_MC_motor_overheating:
+        {
+            uint16_t joint_num = m_dnginfo.param16;
+            int16_t temp_raw_value = m_dnginfo.param64 & 0xffff;
+
+            m_entityNameProvider.getAxisName(joint_num, m_dnginfo.baseInfo.axisName);
+            
+            snprintf(str, sizeof(str), " %s (Joint=%s (NIB=%d), Raw_temperature_value=%d)",
+                                        m_dnginfo.baseMessage.c_str(), m_dnginfo.baseInfo.axisName.c_str(), joint_num, temp_raw_value
+                                        );
+            m_dnginfo.baseInfo.finalMessage.append(str);
+        } break;
+
         case EOERROR_VALUE_DUMMY:
         {
             m_dnginfo.baseInfo.finalMessage.append(": unrecognised eoerror_category_MotionControl error value.");


### PR DESCRIPTION
Changes in this PR:
- Add to diagnostic parser overheating error
- Update embObjBattery
- Re-elaborate status bat-bms using uint16_t as datatype and using string_view instead of string for status messages 
- Update bat reading values adding total absorbed current in BAT and adjusting limits for BAT SoC calculation
- Fix datatype in diagnostic to be aligned by raw value datatype Set value of battery charge to NaN if equal to zero 
- Update MINIMUM_REQUIRED_icub_firmware_shared_VERSION to 1.38.2

Related to:
- https://github.com/robotology/icub-firmware-build/pull/146
- https://github.com/robotology/icub-firmware/pull/487
- https://github.com/robotology/icub-firmware-shared/pull/95