### PR TITLE
Fix constructor and destructor of `eth::EthBoards` class

### DIFF
--- a/src/libraries/icubmod/embObjLib/diagnosticInfoFormatter.cpp
+++ b/src/libraries/icubmod/embObjLib/diagnosticInfoFormatter.cpp
@@ -6,7 +6,6 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#include <string>
 #include "diagnosticLowLevelFormatter.h"
 #include "diagnosticLowLevelFormatter_hid.h"
 

--- a/src/libraries/icubmod/embObjLib/diagnosticLowLevelFormatter_hid.h
+++ b/src/libraries/icubmod/embObjLib/diagnosticLowLevelFormatter_hid.h
@@ -11,8 +11,10 @@
 #define __diagnosticLowLevelFormatter_hid_h__
 
 #include <string>
+#include <string_view>
 #include <memory>
 #include <yarp/os/LogStream.h>
+#include <yarp/os/Log.h>
 #include "diagnosticLowLevelFormatter.h"
 #include "EoError.h"
 

--- a/src/libraries/icubmod/embObjLib/ethBoards.cpp
+++ b/src/libraries/icubmod/embObjLib/ethBoards.cpp
@@ -54,14 +54,31 @@
 
 eth::EthBoards::EthBoards()
 {
-    memset(LUT, 0, sizeof(LUT));
+    // memset(LUT, 0, sizeof(LUT));
+    // Changed memset with for loop initialization due to problem on Windows
+    // which was failing in updating correctly values to LUT vars
+    for (auto& lut : LUT)
+    {
+        lut.clear();
+    }
+    
     sizeofLUT = 0;
 }
 
 
 eth::EthBoards::~EthBoards()
 {
-    memset(LUT, 0, sizeof(LUT));
+    /**
+    * LUT has already been cleaned by the call to
+    * eth::EthBoards::rem(eth::AbstractEthResource* res, iethresType_t type) and
+    * eth::EthBoards::rem(eth::AbstractEthResource* res)
+    * so there's nothing to do here since LUT is already destroyed correctly
+    * but we can keep the clear for syntax reasons
+    */
+    for (auto& l : LUT) 
+    { 
+        l.clear(); 
+    } 
     sizeofLUT = 0;
 }
 
@@ -202,14 +219,9 @@ bool eth::EthBoards::rem(eth::AbstractEthResource* res)
         return false;
     }
 
-    LUT[index].resource = NULL;
-    LUT[index].ipv4 = 0;
-    LUT[index].boardnumber = 0;
-    LUT[index].name = "";
-    LUT[index].numberofinterfaces = 0;
-    for(int i=0; i<iethresType_numberof; i++)
-    {
-        LUT[index].interfaces[i] = NULL;
+    for (auto& l : LUT) 
+    { 
+        l.clear(); 
     }
 
     sizeofLUT--;

--- a/src/libraries/icubmod/embObjLib/ethBoards.h
+++ b/src/libraries/icubmod/embObjLib/ethBoards.h
@@ -81,15 +81,25 @@ namespace eth {
 
         // private types      
 
-        typedef struct
+        typedef struct ethboardProperties_t
         {
-            eOipv4addr_t            ipv4;
-            string                  name;
-            uint8_t                 numberofinterfaces;
-            uint8_t                 boardnumber;
-            AbstractEthResource*    resource;
-            IethResource*           interfaces[iethresType_numberof];
-        } ethboardProperties_t;
+            eOipv4addr_t            ipv4 {0};
+            string                  name {""};
+            uint8_t                 numberofinterfaces {0};
+            uint8_t                 boardnumber {0};
+            AbstractEthResource*    resource {nullptr};
+            IethResource*           interfaces[iethresType_numberof] {nullptr};
+
+            void clear()
+            {
+                ipv4 = 0;
+                name = "";
+                numberofinterfaces = 0;
+                boardnumber = 0;
+                resource = nullptr;
+                for (auto& itf : interfaces) {itf = nullptr;}
+            };
+        };
 
 
     private:
@@ -107,8 +117,8 @@ namespace eth {
                 
         inline static const string errorname[1] = {"wrong-unknown-board"};
 
-        int sizeofLUT;
-        ethboardProperties_t LUT[EthBoards::maxEthBoards];
+        int sizeofLUT {0};
+        ethboardProperties_t LUT[EthBoards::maxEthBoards] {};
 
     private:
 


### PR DESCRIPTION
This PR fix the problem seen on windows when launching the `yarprobotinterface` where weird characters were shown on the logs. 
This was due due to a not correct initialization of the variables of the struct `ethboardProperties_t` used by the `LUT` array in `ethBoards.h`. This bad initialization was breaking the copying of new `std::string` vars in the variable `name` of that struct.

Now as shown in the related issue here: https://github.com/robotology/icub-main/issues/913, the prints are fine.

