### PR TITLE
Fix missing cstdint include in headers that use uint16_t and uint32_t types

### DIFF
--- a/src/libraries/icubmod/embObjLib/diagnosticInfo.h
+++ b/src/libraries/icubmod/embObjLib/diagnosticInfo.h
@@ -10,6 +10,7 @@
 #ifndef __diagnosticInfo_h__
 #define __diagnosticInfo_h__
 
+#include <cstdint>
 #include <string>
 
 

--- a/src/libraries/icubmod/embObjLib/ethParser.h
+++ b/src/libraries/icubmod/embObjLib/ethParser.h
@@ -23,6 +23,7 @@
 #ifndef _ETHPARSER_H_
 #define _ETHPARSER_H_
 
+#include <cstdint>
 #include <string>
 
 #include "EoProtocol.h"


### PR DESCRIPTION
This fix compilation of icub-main on Ubuntu 24.04 with compilers and libraries provided by apt (see https://github.com/robotology/robotology-superbuild/issues/1641#issuecomment-2081181207). Probably everything worked in earlier distributions due to transitive includes.