### PR TITLE
icub.i: Fix compatibility with SWIG 4.2.1

### DIFF
--- a/bindings/icub.i
+++ b/bindings/icub.i
@@ -29,6 +29,8 @@ using namespace yarp::sig;
 #include <iCub/ctrl/adaptWinPolyEstimator.h>
 #include <iCub/ctrl/clustering.h>
 #include <iCub/ctrl/filters.h>
+// Workaround for https://github.com/swig/swig/issues/2828
+%ignore waveletIntegrand;
 #include <iCub/ctrl/functionEncoder.h>
 #include <iCub/ctrl/kalman.h>
 #include <iCub/ctrl/math.h>

--- a/bindings/icub.i
+++ b/bindings/icub.i
@@ -29,8 +29,6 @@ using namespace yarp::sig;
 #include <iCub/ctrl/adaptWinPolyEstimator.h>
 #include <iCub/ctrl/clustering.h>
 #include <iCub/ctrl/filters.h>
-// Workaround for https://github.com/swig/swig/issues/2828
-%ignore waveletIntegrand;
 #include <iCub/ctrl/functionEncoder.h>
 #include <iCub/ctrl/kalman.h>
 #include <iCub/ctrl/math.h>
@@ -81,6 +79,8 @@ using namespace yarp::sig;
 %include <iCub/ctrl/adaptWinPolyEstimator.h>
 %include <iCub/ctrl/clustering.h>
 %include <iCub/ctrl/filters.h>
+// Workaround for https://github.com/swig/swig/issues/2828
+%ignore waveletIntegrand;
 %include <iCub/ctrl/functionEncoder.h>
 %include <iCub/ctrl/kalman.h>
 %include <iCub/ctrl/math.h>


### PR DESCRIPTION
Without this, compilation with SWIG 4.2.1 fails with:

~~~
[100%] Building CXX object bindings/CMakeFiles/_icub_python.dir/CMakeFiles/_icub_python.dir/icubPYTHON_wrap.cxx.o
/home/traversaro/robotology-superbuild/build/src/ICUB/bindings/CMakeFiles/_icub_python.dir/icubPYTHON_wrap.cxx: In function ‘PyObject* _wrap_waveletIntegrand(PyObject*, PyObject*)’:
/home/traversaro/robotology-superbuild/build/src/ICUB/bindings/CMakeFiles/_icub_python.dir/icubPYTHON_wrap.cxx:26621:22: error: ‘waveletIntegrand’ was not declared in this scope; did you mean ‘_wrap_waveletIntegrand’?
26621 |     result = (double)waveletIntegrand(arg1,arg2);
      |                      ^~~~~~~~~~~~~~~~
      |                      _wrap_waveletIntegrand
make[2]: *** [bindings/CMakeFiles/_icub_python.dir/build.make:76: bindings/CMakeFiles/_icub_python.dir/CMakeFiles/_icub_python.dir/icubPYTHON_wrap.cxx.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:4786: bindings/CMakeFiles/_icub_python.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
~~~

This is a bit complicated. Basically, `waveletIntegrand` is a friend function of `icub::ctrl::WaveletEncoder` , see https://github.com/robotology/icub-main/blob/v2.5.0/src/libraries/ctrlLib/include/iCub/ctrl/functionEncoder.h#L126 . The reason why it is a friend function and not a method is that it needs to be passed to gsl in https://github.com/robotology/icub-main/blob/v2.5.0/src/libraries/ctrlLib/src/functionEncoder.cpp#L119 (I guess). For some reason, SWIG wants to wrap that function, even if it is not declared in the headers (it is directly defined in C++). I guess it is safe to simply ignore the function, that anyhow is not meant to be called by users outside of icub-main.

Related issues:
* https://github.com/robotology/robotology-superbuild/issues/1641#issuecomment-2081564195
* https://github.com/swig/swig/issues/2828 