### PR TITLE
Update filtering of spikes in temp reading

### DIFF
--- a/src/libraries/icubmod/embObjLib/abstractEthResource.h
+++ b/src/libraries/icubmod/embObjLib/abstractEthResource.h
@@ -53,6 +53,7 @@ namespace eth {
             string              boardtypeString;
             string              boardnameString;
             string              firmwareString;
+            uint8_t             txROPratedivider;
         };
 
         //AbstractEthResource();

--- a/src/libraries/icubmod/embObjLib/diagnosticInfo.cpp
+++ b/src/libraries/icubmod/embObjLib/diagnosticInfo.cpp
@@ -34,6 +34,9 @@ void TimeOfInfo::toString(std::string &str_toi)
 
 void EmbeddedInfo::printMessage()
 {
+    if (finalMessage.size() == 0)
+        return;
+   
    std::string str_toi;
    timeOfInfo.toString(str_toi);
 

--- a/src/libraries/icubmod/embObjLib/ethResource.cpp
+++ b/src/libraries/icubmod/embObjLib/ethResource.cpp
@@ -129,6 +129,7 @@ bool EthResource::open2(eOipv4addr_t remIP, yarp::os::Searchable &cfgtotal)
     properties.ipv4addressingString = brddata.properties.ipv4addressingstring;
     properties.boardtypeString = brddata.properties.typestring;
     properties.boardnameString = brddata.settings.name;
+    properties.txROPratedivider = txconfig.txratedivider;
 
 
     eth::EthMonitorPresence::Config mpConfig;


### PR DESCRIPTION
Completing the work done in https://github.com/robotology/icub-main/issues/959, the spikes in the temperature readings are 
now filtered by software.
This means that if the delta between current and previous temperature is higher than a threshold (which is currently defined in sw and by default is 20 Celsius degree) that new temperature read is considered as a spike and therefore, even if its value is higher than the `warning temperature threshold` or the `error temperature threshold`, it is discarded and not considered and the previous temperature is not updated.
Moreover, we have added to the `Watchdog` class a method for setting the threshold, regarding the maximum number of erroneous values read before sending error or warning, depending on the transmission rate of the ethernet packets.
Therefore, depending on the transmission rate defined in the configuration of the robot, we are setting the watchdogs for overcoming the warning threshold on the temperature reading and for overcoming the limit on the negative temperature values (which means that we got an error in the reading) so that it is always constant and independent to the transmission rate of the ethernet packets.
By default, it is set so that we rise the warning or error when we are getting erroneous temperature values (which are not spikes) for at least 60 seconds.