### PR TITLE
Fix bug when removing ethResource from LUT in clear method

### DIFF
--- a/src/libraries/icubmod/embObjLib/ethBoards.cpp
+++ b/src/libraries/icubmod/embObjLib/ethBoards.cpp
@@ -219,10 +219,8 @@ bool eth::EthBoards::rem(eth::AbstractEthResource* res)
         return false;
     }
 
-    for (auto& l : LUT) 
-    { 
-        l.clear(); 
-    }
+    auto& l = LUT[index];
+    l.clear();
 
     sizeofLUT--;
 


### PR DESCRIPTION
This PR fix the bug described here: https://github.com/robotology/icub-main/issues/962 that caused a core dumping when closing the resources for a specific device (when multiple devices are enabled)
 Basically, at the removal of the first resource we were basically going to remove all the open resources. 