### PR TITLE
Set verbose elective option in 2FOC group to zero by defualt

### DIFF
--- a/src/libraries/icubmod/embObjLib/ethBoards.cpp
+++ b/src/libraries/icubmod/embObjLib/ethBoards.cpp
@@ -219,10 +219,8 @@ bool eth::EthBoards::rem(eth::AbstractEthResource* res)
         return false;
     }
 
-    for (auto& l : LUT) 
-    { 
-        l.clear(); 
-    }
+    auto& l = LUT[index];
+    l.clear();
 
     sizeofLUT--;
 

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -1467,9 +1467,9 @@ bool Parser::parseFocGroup(yarp::os::Searchable &config, eomc::focBasedSpecificI
     if (!extractGroup(focGroup, xtmp, "Verbose", "Verbose 0/1 ", _njoints, false))
     {
         //return false;
-        yWarning() << "In " << _boardname << " there isn't " << groupName << ". Verbose filed. For default it is enabled" ;
+        yWarning() << "In " << _boardname << " there isn't " << groupName << ". Verbose failed. By default it is disabled" ;
         for (i = 0; i < (unsigned)_njoints; i++)
-            foc_based_info[i].verbose = 1;
+            foc_based_info[i].verbose = 0;
     }
     else
     {
@@ -1481,7 +1481,7 @@ bool Parser::parseFocGroup(yarp::os::Searchable &config, eomc::focBasedSpecificI
     if (!extractGroup(focGroup, xtmp, "AutoCalibration", "AutoCalibration 0/1 ", _njoints, false))
     {
         //return false;
-        yWarning() << "In " << _boardname << " there isn't " << groupName << ". AutoCalibration filed. For default it is disabled" ;
+        yWarning() << "In " << _boardname << " there isn't " << groupName << ". AutoCalibration failed. By default it is disabled" ;
         for (i = 0; i < (unsigned)_njoints; i++)
             AutoCalibration[i] = 0;
     }


### PR DESCRIPTION
This PR related to the issue https://github.com/robotology/icub-firmware/issues/497, changes the default option for the `verbose` option in `eomcParser.cpp` from the value of `1` to `0`.
In this manner when the option is not defined in the `2FOC` group in the robot configuration files the CAN and the YRI are not flooded with debug messages as shown in the mentioned issue.

