### PR TITLE
Runtime configuration of diagnostics related to the RX-DO-TX phases

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -64,7 +64,7 @@ checkandset_dependency(IPOPT)
 checkandset_dependency(OpenCV)
 checkandset_dependency(Qt5)
 
-set(MINIMUM_REQUIRED_icub_firmware_shared_VERSION 1.39.0)
+set(MINIMUM_REQUIRED_icub_firmware_shared_VERSION 1.39.1)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
   if(icub_firmware_shared_VERSION VERSION_LESS ${MINIMUM_REQUIRED_icub_firmware_shared_VERSION})

--- a/src/libraries/icubmod/embObjLib/diagnosticInfoParsers.cpp
+++ b/src/libraries/icubmod/embObjLib/diagnosticInfoParsers.cpp
@@ -1027,67 +1027,46 @@ void SysParser::parseInfo()
 
         }break;
 
+        case eoerror_value_SYS_ctrloop_rxphasemin:
+        case eoerror_value_SYS_ctrloop_dophasemin:
+        case eoerror_value_SYS_ctrloop_txphasemin:
         case eoerror_value_SYS_ctrloop_rxphaseaverage:
-        {
-            snprintf(str, sizeof(str), " %s %d ", m_dnginfo.baseMessage.c_str(), m_dnginfo.param16);
-            m_dnginfo.baseInfo.finalMessage.append(str);
-
-        }break;
-       
         case eoerror_value_SYS_ctrloop_dophaseaverage:
-        {
-            snprintf(str, sizeof(str), " %s %d ", m_dnginfo.baseMessage.c_str(), m_dnginfo.param16);
-            m_dnginfo.baseInfo.finalMessage.append(str);
-
-        }break;
-
         case eoerror_value_SYS_ctrloop_txphaseaverage:
-        {
-            snprintf(str, sizeof(str), " %s %d ", m_dnginfo.baseMessage.c_str(), m_dnginfo.param16);
-            m_dnginfo.baseInfo.finalMessage.append(str);
-
-        }break;
-
         case eoerror_value_SYS_ctrloop_rxphasemax:
-        {
-            snprintf(str, sizeof(str), " %s %d ", m_dnginfo.baseMessage.c_str(), m_dnginfo.param16);
-            m_dnginfo.baseInfo.finalMessage.append(str);
-
-        }break;
-
         case eoerror_value_SYS_ctrloop_dophasemax:
-        {
-            snprintf(str, sizeof(str), " %s %d ", m_dnginfo.baseMessage.c_str(), m_dnginfo.param16);
-            m_dnginfo.baseInfo.finalMessage.append(str);
-
-        }break;
         case eoerror_value_SYS_ctrloop_txphasemax:
         {
-            snprintf(str, sizeof(str), " %s %d ", m_dnginfo.baseMessage.c_str(), m_dnginfo.param16);
+            snprintf(str, sizeof(str), " %s, monitored over %f sec is %d microsec", m_dnginfo.baseMessage.c_str(),
+                     0.01*static_cast<float>(m_dnginfo.param64 & 0xffff),
+                     m_dnginfo.param16
+                     );
             m_dnginfo.baseInfo.finalMessage.append(str);
+        } break;
 
-        }break;
-
-        case eoerror_value_SYS_ctrloop_rxphasemin:
+        case eoerror_value_SYS_exec_time_stats:
         {
-            snprintf(str, sizeof(str), " %s %d ", m_dnginfo.baseMessage.c_str(), m_dnginfo.param16);
+            static constexpr const char * const names[4] = { "runner.RX()", "runner.DO()", "runner.TX()", "other.ID = " };
+            std::string actor = {};
+            if(m_dnginfo.param16 < 3)
+            {
+                actor = names[m_dnginfo.param16];
+            }
+            else
+            {
+                actor= names[3] + std::to_string(m_dnginfo.param16);
+            }
+
+            snprintf(str, sizeof(str), " %s: %s -> (%d, %d, %d) us over %f sec",
+                     m_dnginfo.baseMessage.c_str(),
+                     actor.c_str(),
+                     static_cast<uint16_t>((m_dnginfo.param64 >> 48) & 0xffff), // min
+                     static_cast<uint16_t>((m_dnginfo.param64 >> 32) & 0xffff), // average
+                     static_cast<uint16_t>((m_dnginfo.param64 >> 16) & 0xffff), // max
+                     0.01*static_cast<float>(m_dnginfo.param64 & 0xffff)        // period
+                     );
             m_dnginfo.baseInfo.finalMessage.append(str);
-
-        }break;
-
-        case eoerror_value_SYS_ctrloop_dophasemin:
-        {
-            snprintf(str, sizeof(str), " %s %d ", m_dnginfo.baseMessage.c_str(), m_dnginfo.param16);
-            m_dnginfo.baseInfo.finalMessage.append(str);
-
-        }break;
-
-        case eoerror_value_SYS_ctrloop_txphasemin:
-        {
-            snprintf(str, sizeof(str), " %s %d ", m_dnginfo.baseMessage.c_str(), m_dnginfo.param16);
-            m_dnginfo.baseInfo.finalMessage.append(str);
-
-        }break;
+        } break;
 
         case eoerror_value_SYS_proxy_forward_fails:
         {

--- a/src/libraries/icubmod/embObjLib/ethParser.cpp
+++ b/src/libraries/icubmod/embObjLib/ethParser.cpp
@@ -421,12 +421,28 @@ bool eth::parser::read(yarp::os::Searchable &cfgtotal, boardData &boarddata)
     Bottle groupEthBoardSettings_LoggingMode = Bottle(groupEthBoardSettings.findGroup("LOGGINGMODE"));
     if(groupEthBoardSettings_LoggingMode.isNull())
     {
+        boarddata.settings.txconfig.logging.flags = (0x0001 << eomn_appl_log_asynchro_exectime_overflow);
+        boarddata.settings.txconfig.logging.period = 0;
         yWarning() << "eth::parser::read(): cannot find ETH_BOARD_PROPERTIES/LOGGINGMODE group in config files for BOARD w/ IP" << boarddata.properties.ipv4string << " and will use default values";
-        yWarning() << "Default values for ETH_BOARD_PROPERTIES/LOGGINGMODE group: (RXDOTXbeyondbudget {enabled}, RXDOTXstatistics {period} } = " <<
-                      boarddata.settings.txconfig. << boarddata.settings.txconfig.maxtimeRX << boarddata.settings.txconfig.maxtimeDO << boarddata.settings.txconfig.maxtimeTX << boarddata.settings.txconfig.txratedivider;
+        yWarning() << "Default values for ETH_BOARD_PROPERTIES/LOGGINGMODE group: (period = 0, asynchroRXDOTXoverflow =  true, periodicRXDOTXstats = false";
     }
     else
     {
+        float tmp = groupEthBoardSettings_LoggingMode.find("period").asFloat32();
+        boarddata.settings.txconfig.logging.period = (tmp>0) ? static_cast<uint16_t>(1000.0*tmp) : 0;
+
+        boarddata.settings.txconfig.logging.flags = 0;
+
+        bool overflow = groupEthBoardSettings_LoggingMode.find("asynchroRXDOTXoverflow").asBool();
+        if(overflow)
+        {
+            boarddata.settings.txconfig.logging.flags |= (0x0001 << eomn_appl_log_asynchro_exectime_overflow);
+        }
+        bool stats = groupEthBoardSettings_LoggingMode.find("periodicRXDOTXstats").asBool();
+        if(stats)
+        {
+            boarddata.settings.txconfig.logging.flags |= (0x0001 << eomn_appl_log_periodic_exectime_statistics);
+        }
 
     }
 

--- a/src/libraries/icubmod/embObjLib/ethParser.cpp
+++ b/src/libraries/icubmod/embObjLib/ethParser.cpp
@@ -416,6 +416,19 @@ bool eth::parser::read(yarp::os::Searchable &cfgtotal, boardData &boarddata)
         }
 
     }
+    
+    
+    Bottle groupEthBoardSettings_LoggingMode = Bottle(groupEthBoardSettings.findGroup("LOGGINGMODE"));
+    if(groupEthBoardSettings_LoggingMode.isNull())
+    {
+        yWarning() << "eth::parser::read(): cannot find ETH_BOARD_PROPERTIES/LOGGINGMODE group in config files for BOARD w/ IP" << boarddata.properties.ipv4string << " and will use default values";
+        yWarning() << "Default values for ETH_BOARD_PROPERTIES/LOGGINGMODE group: (RXDOTXbeyondbudget {enabled}, RXDOTXstatistics {period} } = " <<
+                      boarddata.settings.txconfig. << boarddata.settings.txconfig.maxtimeRX << boarddata.settings.txconfig.maxtimeDO << boarddata.settings.txconfig.maxtimeTX << boarddata.settings.txconfig.txratedivider;
+    }
+    else
+    {
+
+    }
 
 
 

--- a/src/libraries/icubmod/embObjLib/ethParser.cpp
+++ b/src/libraries/icubmod/embObjLib/ethParser.cpp
@@ -422,14 +422,14 @@ bool eth::parser::read(yarp::os::Searchable &cfgtotal, boardData &boarddata)
     if(groupEthBoardSettings_LoggingMode.isNull())
     {
         boarddata.settings.txconfig.logging.flags = (0x0001 << eomn_appl_log_asynchro_exectime_overflow);
-        boarddata.settings.txconfig.logging.period = 0;
+        boarddata.settings.txconfig.logging.period10ms = 0;
         yWarning() << "eth::parser::read(): cannot find ETH_BOARD_PROPERTIES/LOGGINGMODE group in config files for BOARD w/ IP" << boarddata.properties.ipv4string << " and will use default values";
         yWarning() << "Default values for ETH_BOARD_PROPERTIES/LOGGINGMODE group: (period = 0, asynchroRXDOTXoverflow =  true, periodicRXDOTXstats = false";
     }
     else
     {
         float tmp = groupEthBoardSettings_LoggingMode.find("period").asFloat32();
-        boarddata.settings.txconfig.logging.period = (tmp>0) ? static_cast<uint16_t>(1000.0*tmp) : 0;
+        boarddata.settings.txconfig.logging.period10ms = (tmp<0) ? (0) : ( (tmp < 600) ? static_cast<uint16_t>(100.0*tmp) : 60000); // period is uint16_t and keeps units of 10 ms to be able to manage up to 10 minutes
 
         boarddata.settings.txconfig.logging.flags = 0;
 

--- a/src/libraries/icubmod/embObjLib/ethResource.cpp
+++ b/src/libraries/icubmod/embObjLib/ethResource.cpp
@@ -56,7 +56,7 @@ EthResource::EthResource()
     txconfig.maxtimeDO = defmaxtimeDO;
     txconfig.maxtimeTX = defmaxtimeTX;
     txconfig.logging.flags = (0x0001 << eomn_appl_log_asynchro_exectime_overflow);
-    txconfig.logging.period = 0;
+    txconfig.logging.period10ms = 0;
 
     memset(verifiedEPprotocol, 0, sizeof(verifiedEPprotocol));
 

--- a/src/libraries/icubmod/embObjLib/ethResource.cpp
+++ b/src/libraries/icubmod/embObjLib/ethResource.cpp
@@ -55,6 +55,8 @@ EthResource::EthResource()
     txconfig.maxtimeRX = defmaxtimeRX;
     txconfig.maxtimeDO = defmaxtimeDO;
     txconfig.maxtimeTX = defmaxtimeTX;
+    txconfig.logging.flags = (0x0001 << eomn_appl_log_asynchro_exectime_overflow);
+    txconfig.logging.period = 0;
 
     memset(verifiedEPprotocol, 0, sizeof(verifiedEPprotocol));
 


### PR DESCRIPTION
This PR introduces the xml parsing of configuration of the diagnostics associated to the execution loop and its transmission towards the `ETH` boards.


In particular, it will be possible to:
- enable / disable the diagnostics about execution overflow of the `RX`, `DO `and `TX `phases. The default is enabled.
- enable / disable the diagnostics about statistics of the  `RX`, `DO `and `TX `phases. It will be reported minimum, average and maximum durations of the phases over a period configurable between 1 and 600 seconds. The default is disabled.

This latter feature is particularly useful when one wants to measure the effective duration of `RX`, `DO` and `TX` phases for a particular board over a period of time. As shown later It is possible to activate the section `LOGGING.PERIODIC` and set `LOGGING.PERIODIC.emitRXDOTXstatistics` = true to achieve such a statistics (min, average and max duration) over a period of time = `LOGGING.PERIODIC.period` seconds.


### Format of xml file

The parsing will search for a group named `LOGGING` inside `ETH_BOARD.ETH_BOARD_SETTINGS.RUNNINGMODE`  that has the following format:

```xml
<group name="LOGGING">

    <!-- Contains enabling / disabling of logging that must be emitted immediately as soon as the condition appears --> 
    <group name="IMMEDIATE">
        <!-- enable / disable the emission of diagnostics related to the measured execution time of RX higher than the configured
             maxTimeOfRXactivity and similarly for DO and tx
          -->
        <param name="emitRXDOTXoverflow">       true        </param>
    </group>
    
    <!-- Contains enabling / disabling of logging that must be emitted periodically -->
    <group name="PERIODIC">
        <!-- the period expressed in seconds in the interval [1.0, 600.0] -->
        <param name="period">                   10          </param>
        <!-- enable / disable the periodic emission of diagnostics about to the statistics of teh execution time of the RX, DO and TX phase
             in the form of minimul, average and maximum values.
          -->                        
        <param name="emitRXDOTXstatistics">     true        </param>
    </group>

</group>

``` 

### Backwards compatibility

If the section `ETH_BOARD.ETH_BOARD_SETTINGS.RUNNINGMODE.LOGGING` is not present the following default values will be used that guarantee behavior as now:
- ` LOGGING.IMMADIATE.emitRXDOTXoverflow` = true;
- `LOGGING.PERIODIC.period` = 0; 
- ` LOGGING.PERIODIC.emitRXDOTXstatistics` = false;


### Associated PRs

- https://github.com/robotology/icub-firmware-shared/pull/96
- https://github.com/robotology/icub-firmware/pull/502
- https://github.com/robotology/icub-firmware-build/pull/154
- robots configuration (only template files)

### Tests

Performed on a dedicated setup. 

Example of output with `LOGGING.PERIODIC.period = 10.0` and  `LOGGING.PERIODIC.emitRXDOTXstatistics = true` are:

```bash

[INFO] from BOARD 10.0.1.1 (left_arm-eb1-j0_3) time=4146s 479m 144u : SYS: execution time statistics (min, average, max) us in a period: runner.RX() -> (15, 16, 841) us over 10.000000 sec
[INFO] from BOARD 10.0.1.1 (left_arm-eb1-j0_3) time=4146s 479m 541u : SYS: execution time statistics (min, average, max) us in a period: runner.DO() -> (11, 12, 20) us over 10.000000 sec
[INFO] from BOARD 10.0.1.1 (left_arm-eb1-j0_3) time=4146s 479m 922u : SYS: execution time statistics (min, average, max) us in a period: runner.TX() -> (16, 24, 94) us over 10.000000 sec
[INFO] from BOARD 10.0.1.1 (left_arm-eb1-j0_3) time=4156s 479m 162u : SYS: execution time statistics (min, average, max) us in a period: runner.RX() -> (15, 16, 36) us over 10.000000 sec
[INFO] from BOARD 10.0.1.1 (left_arm-eb1-j0_3) time=4156s 479m 541u : SYS: execution time statistics (min, average, max) us in a period: runner.DO() -> (12, 12, 15) us over 10.000000 sec
[INFO] from BOARD 10.0.1.1 (left_arm-eb1-j0_3) time=4156s 479m 917u : SYS: execution time statistics (min, average, max) us in a period: runner.TX() -> (16, 24, 94) us over 10.000000 sec

``` 

Similar results with different values of the period such as `LOGGING.PERIODIC.period = 60.0` 

```bash
[INFO] from BOARD 10.0.1.1 (left_arm-eb1-j0_3) time=4297s 3m 440u : SYS: execution time statistics (min, average, max) us in a period: runner.RX() -> (15, 16, 836) us over 60.000000 sec
[INFO] from BOARD 10.0.1.1 (left_arm-eb1-j0_3) time=4297s 3m 841u : SYS: execution time statistics (min, average, max) us in a period: runner.DO() -> (11, 11, 20) us over 60.000000 sec
[INFO] from BOARD 10.0.1.1 (left_arm-eb1-j0_3) time=4297s 4m 217u : SYS: execution time statistics (min, average, max) us in a period: runner.TX() -> (16, 23, 96) us over 60.000000 sec
[DEBUG] yarprobotinterface running happily
[ERROR] from BOARD 10.0.1.1 (left_arm-eb1-j0_3) time=4324s 840m 437u : HW: strain values saturation. 1 is the channel involved. In the last second, the lower saturation counts is 10000 and the upper one is 0
[INFO] from BOARD 10.0.1.1 (left_arm-eb1-j0_3) time=4357s 3m 440u : SYS: execution time statistics (min, average, max) us in a period: runner.RX() -> (15, 16, 145) us over 60.000000 sec
[INFO] from BOARD 10.0.1.1 (left_arm-eb1-j0_3) time=4357s 3m 839u : SYS: execution time statistics (min, average, max) us in a period: runner.DO() -> (11, 11, 15) us over 60.000000 sec
[INFO] from BOARD 10.0.1.1 (left_arm-eb1-j0_3) time=4357s 4m 217u : SYS: execution time statistics (min, average, max) us in a period: runner.TX() -> (16, 23, 96) us over 60.000000 sec
```

With no section on the xml file or with `LOGGING.PERIODIC.emitRXDOTXstatistics = false` the INFO messages are not sent. 