### PR TITLE
embObjLib: in ethReceiver set receiving thread as non-blocking also on Windows

### DIFF
--- a/src/libraries/icubmod/embObjLib/ethReceiver.cpp
+++ b/src/libraries/icubmod/embObjLib/ethReceiver.cpp
@@ -132,6 +132,12 @@ bool EthReceiver::config(ACE_SOCK_Dgram *pSocket, TheEthManager* _ethManager)
 
     yWarning() << "in EthReceiver::config() the config socket has queue size = "<< sock_input_buf_size<< "; you request ETHRECEIVER_BUFFER_SIZE=" << _dgram_buffer_size;
 
+    // On Windows the MSG_DONTWAIT flag set in EthReceiver::run(), so the recv is actually blocking, and this prevents
+    // the clean close. So, we instead use ACE_NONBLOCK that works also on Windows
+#ifdef WIN32
+    recv_socket->enable(ACE_NONBLOCK);
+#endif
+
     return true;
 }
 


### PR DESCRIPTION
In the `embObjLib`, the `ethReceiver` is the thread dedicated to receive the UDP messages sent by the ETH boards (such as EMS, MC4_PLUS). 

On Linux and macOS, this socket is set in non-blocking mode by the code:

~~~cxx
    int flags = 0;
#ifndef WIN32
    flags |= MSG_DONTWAIT;
#endif
~~~

in https://github.com/robotology/icub-main/blob/v2.6.2/src/libraries/icubmod/embObjLib/ethReceiver.cpp#L177-L180 .

However, there is no such flag on Windows, so in the Windows case the `recv` call in https://github.com/robotology/icub-main/blob/v2.6.2/src/libraries/icubmod/embObjLib/ethReceiver.cpp#L200 was actually blocking. I am not super-expert of this part of code, so I am not sure what was the effect of the code being non-blocking there on Windows, but for sure I experienced a related problem: when I was launching a `yarprobotinterface` with a `embObjMotionControl` device, during the close of the robotinterface, the close was hanging with message:

~~~
[INFO] |yarp.os.RFModule| [try 1 of 3] Trying to shut down.
[WARNING] Interrupt # 1 # received.
[INFO] Interrupt received. Stopping all running threads.
[INFO] |yarp.os.RFModule| RFModule closing.
[INFO] interrupt1 phase starting...
[INFO] interrupt1 phase finished.
[INFO] shutdown phase starting...
[INFO] Closing device iiv-x-lm1_mc
~~~

Instead, by making the socket non-blocking also on Windows, the program exists correctly. In theory we may want to use the `recv_socket->enable(ACE_NONBLOCK);` also on Linux and macOS in place of `flags |= MSG_DONTWAIT;` for uniformity and cleaning the code, but as I can't extensively test this part of the code and as it is of critical importance, for now I just made the modification on Windows, without any change for Linux and macOS.