### PR TITLE
Remove cmake_minimum_required calls in non-root directories

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Authors: Paul Fitzpatrick
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 3.12)
-
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR})
 
 # Find YARP for bindings-only builds

--- a/src/libraries/learningMachine/standalone/CMakeLists.txt
+++ b/src/libraries/learningMachine/standalone/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Authors: Arjan Gijsberts
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 3.12)
-
 set(PROJECTNAME learningMachine)
 project(${PROJECTNAME})
 

--- a/src/modules/learningMachine/standalone/CMakeLists.txt
+++ b/src/modules/learningMachine/standalone/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Authors:  Arjan Gijsberts
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 3.12)
-
 set(PROJECTNAME learningMachine)
 
 find_package(YARP)

--- a/src/tools/embObjProtoTools/boardTransceiver/CMakeLists.txt
+++ b/src/tools/embObjProtoTools/boardTransceiver/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Authors: Alberto Cardellino
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 3.12)
-
 # Name of the project must correspond to the class name that needs to be
 # instantiated by the factory - so embObjLib is not ok
 SET(PROJECTNAME boardTransceiver)

--- a/src/tools/embObjProtoTools/embObjProto_debugParser/CMakeLists.txt
+++ b/src/tools/embObjProtoTools/embObjProto_debugParser/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Authors: Valentina Gaggero
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 3.12)
-
 set(PROJECTNAME embObjProto_debugParser)
 
 project(${PROJECTNAME})

--- a/src/tools/embObjProtoTools/nvListPrinter/CMakeLists.txt
+++ b/src/tools/embObjProtoTools/nvListPrinter/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Authors: Valentina Gaggero
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 3.12)
-
 set(PROJECTNAME nvid_printer)
 
 file(GLOB folder_header *.h)

--- a/src/tools/emsBackDoorManager/CMakeLists.txt
+++ b/src/tools/emsBackDoorManager/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Authors: Valentina Gaggero
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 3.12)
-
 set(PROJECTNAME emsBackDoorManager)
 
 file(GLOB folder_header *.h)

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -4,8 +4,6 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license. See the accompanying LICENSE file for details.
 
-cmake_minimum_required(VERSION 3.12)
-
 include(FetchContent)
 
 #GTEST


### PR DESCRIPTION
All these calls in sub-folders only make sense if the subfolder could be built as an indipendent project (i.e. creating a build folder in just the subfolder), but that is not the case, so they only create possible confusion if one wanted to change the arguments passed to `cmake_minimum_required`, so I think it is better to just remove them.

