### PR TITLE
Bump policy_max argument of cmake_minimum_required to 3.28

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors: Lorenzo Natale
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.28)
 
 set(ROOT_PROJECT_NAME ICUB)
 project(${ROOT_PROJECT_NAME} LANGUAGES C CXX


### PR DESCRIPTION
I recently had problem in compiling icub-main in a conda environment with Python 3.10 installed while the system (Ubuntu 24.04) had Python 3.12 installed. This happened as the old (pre-3.15) behaviour of CMake was to always  find the most recent Python version, instead of getting the highest in the path (see https://cmake.org/cmake/help/latest/policy/CMP0094.html).

The problem can be solved without raising the minimum required CMake by setting the `CMP0094` policy to `NEW`, but I think it was good idea to directly raise the policy_max (i.e. the version used for the policies of CMake) argument of `cmake_minimum_required` to 3.28.