### PR TITLE
Replace SWIG_Python_AppendOutput with SWIG_AppendOutput for SWIG 4.3.0 compatibility

### DIFF
--- a/bindings/icub.i
+++ b/bindings/icub.i
@@ -111,9 +111,9 @@ using namespace yarp::sig;
     yarp::sig::Matrix* t_out1 = new yarp::sig::Matrix(*$1);
     yarp::sig::Vector* t_out2 = new yarp::sig::Vector(*$2);
 
-    $result= SWIG_Python_AppendOutput ($result, SWIG_NewPointerObj(t_out1, SWIGTYPE_p_yarp__sig__Matrix, 0 |  0 ));
-    $result= SWIG_Python_AppendOutput ($result, SWIG_NewPointerObj(t_out2, SWIGTYPE_p_yarp__sig__VectorOfT_double_t, 0 |  0 ));
-    $result= SWIG_Python_AppendOutput ($result, PyFloat_FromDouble(*$3));
+    $result= SWIG_AppendOutput ($result, SWIG_NewPointerObj(t_out1, SWIGTYPE_p_yarp__sig__Matrix, 0 |  0 ));
+    $result= SWIG_AppendOutput ($result, SWIG_NewPointerObj(t_out2, SWIGTYPE_p_yarp__sig__VectorOfT_double_t, 0 |  0 ));
+    $result= SWIG_AppendOutput ($result, PyFloat_FromDouble(*$3));
 }
 #endif
 


### PR DESCRIPTION
`SWIG_Python_AppendOutput` was never meant to be used and changed the signature in SWIG 4.3.0, `SWIG_AppendOutput` is the function that should be used and is also present in older SWIG releases, see https://sourceforge.net/p/swig/mailman/message/58825934/ and https://github.com/numpy/numpy/pull/27579 for context.
