### PR TITLE
Add CMakePresets.json and robot preset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,28 +161,9 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
+        cmake --preset robot -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
               -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
               -DBUILD_SHARED_LIBS:BOOL=${{ matrix.build_shared_libs }} \
-              -DICUB_USE_icub_firmware_shared:BOOL=ON \
-              -DENABLE_icubmod_skinWrapper:BOOL=ON \
-              -DENABLE_icubmod_sharedcan:BOOL=ON \
-              -DENABLE_icubmod_bcbBattery:BOOL=ON \
-              -DENABLE_icubmod_canmotioncontrol:BOOL=ON \
-              -DENABLE_icubmod_canBusAnalogSensor:BOOL=ON \
-              -DENABLE_icubmod_canBusInertialMTB:BOOL=ON \
-              -DENABLE_icubmod_canBusSkin:BOOL=ON \
-              -DENABLE_icubmod_canBusVirtualAnalogSensor:BOOL=ON \
-              -DENABLE_icubmod_embObjFTsensor:BOOL=ON \
-              -DENABLE_icubmod_embObjIMU:BOOL=ON \
-              -DENABLE_icubmod_embObjInertials:BOOL=ON \
-              -DENABLE_icubmod_embObjMais:BOOL=ON \
-              -DENABLE_icubmod_embObjMotionControl:BOOL=ON \
-              -DENABLE_icubmod_embObjBattery:BOOL=ON \
-              -DENABLE_icubmod_embObjSkin:BOOL=ON \
-              -DENABLE_icubmod_embObjMultipleFTsensors:BOOL=ON \
-              -DENABLE_icubmod_parametricCalibrator:BOOL=ON \
-              -DENABLE_icubmod_parametricCalibratorEth:BOOL=ON \
               -DBUILD_TESTING:BOOL=ON \
               -DICUB_SHARED_LIBRARY=OFF \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
@@ -193,26 +174,9 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
+        cmake --preset robot
+              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
               -DBUILD_SHARED_LIBS:BOOL=${{ matrix.build_shared_libs }} \
-              -DICUB_USE_icub_firmware_shared:BOOL=ON \
-              -DENABLE_icubmod_skinWrapper:BOOL=ON \
-              -DENABLE_icubmod_sharedcan:BOOL=ON \
-              -DENABLE_icubmod_canmotioncontrol:BOOL=ON \
-              -DENABLE_icubmod_canBusAnalogSensor:BOOL=ON \
-              -DENABLE_icubmod_canBusInertialMTB:BOOL=ON \
-              -DENABLE_icubmod_canBusSkin:BOOL=ON \
-              -DENABLE_icubmod_canBusVirtualAnalogSensor:BOOL=ON \
-              -DENABLE_icubmod_embObjFTsensor:BOOL=ON \
-              -DENABLE_icubmod_embObjIMU:BOOL=ON \
-              -DENABLE_icubmod_embObjInertials:BOOL=ON \
-              -DENABLE_icubmod_embObjMais:BOOL=ON \
-              -DENABLE_icubmod_embObjMotionControl:BOOL=ON \
-              -DENABLE_icubmod_embObjBattery:BOOL=ON \
-              -DENABLE_icubmod_embObjSkin:BOOL=ON \
-              -DENABLE_icubmod_embObjMultipleFTsensors:BOOL=ON \
-              -DENABLE_icubmod_parametricCalibrator:BOOL=ON \
-              -DENABLE_icubmod_parametricCalibratorEth:BOOL=ON \
               -DBUILD_TESTING:BOOL=ON \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake --preset robot
+        cmake --preset robot \
               -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
               -DBUILD_SHARED_LIBS:BOOL=${{ matrix.build_shared_libs }} \
               -DBUILD_TESTING:BOOL=ON \

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,58 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 22,
+    "patch": 1
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Default Configuration",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "ENABLE_icubmod_cartesiancontrollerclient": "ON",
+        "ENABLE_icubmod_cartesiancontrollerserver": "ON",
+        "ENABLE_icubmod_gazecontrollerclient": "ON"
+      }
+    },
+    {
+      "name": "robot",
+      "inherits": "default",
+      "displayName": "Robot Configuration",
+      "cacheVariables": {
+        "ICUB_USE_icub_firmware_shared": "ON",
+        "ENABLE_icubmod_skinWrapper": "ON",
+        "ENABLE_icubmod_sharedcan": "ON",
+        "ENABLE_icubmod_bcbBattery": "ON",
+        "ENABLE_icubmod_canmotioncontrol": "ON",
+        "ENABLE_icubmod_canBusAnalogSensor": "ON",
+        "ENABLE_icubmod_canBusInertialMTB": "ON",
+        "ENABLE_icubmod_canBusSkin": "ON",
+        "ENABLE_icubmod_canBusFtSensor": "ON",
+        "ENABLE_icubmod_canBusVirtualAnalogSensor": "ON",
+        "ENABLE_icubmod_embObjBattery": "ON",
+        "ENABLE_icubmod_embObjFTsensor": "ON",
+        "ENABLE_icubmod_embObjMultipleFTsensors": "ON",
+        "ENABLE_icubmod_embObjIMU": "ON",
+        "ENABLE_icubmod_embObjMais": "ON",
+        "ENABLE_icubmod_embObjMotionControl": "ON",
+        "ENABLE_icubmod_embObjSkin": "ON",
+        "ENABLE_icubmod_embObjPOS": "ON",
+        "ENABLE_icubmod_parametricCalibrator": "ON",
+        "ENABLE_icubmod_parametricCalibratorEth": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    },
+    {
+      "name": "robot",
+      "configurePreset": "robot"
+    }
+  ]
+}


### PR DESCRIPTION
I recently heard about a failure mode of an installation that failed as the required option `ENABLE_icubmod_embObjPOS` was not enabled. While the corresponding option was indeed enabled in the superbuild (see https://github.com/robotology/robotology-superbuild/pull/1340), I realized that the long list of devices that should be enabled when icub-main is used on a robot (iCub, ergoCub, R1) was indeed hardcoded in several places:
* https://github.com/robotology/robots-configuration/blob/d7dd20a2ae04fdd7f83046bb96ff7e6a1b1e2bdb/tests/dockerfiles/Dockerfile#L102
* https://github.com/icub-tech-iit/documentation/blob/98ca2cb07e0d9bc07990d438e15a73b328736e61/docs/sw_installation/icub_head_manual.md?plain=1#L242
* https://github.com/robotology/robotology-vcpkg-ports/blob/efd91793e121185c1c67e49fe7d3e4b2860c5342/icub-main/portfile.cmake#L54
* https://github.com/conda-forge/icub-main-feedstock/blob/6576638d43ffa8ecd2eab77f7a9a0c033f15e8c9/recipe/build_cxx.sh#L31
* https://github.com/robotology/robotology-superbuild/blob/master/cmake/BuildICUB.cmake#L73

To simplify the maintenance of this list, in this PR I propose to add a `CMakePresets.json`, that adds two [CMake presets](https://martin-fieber.de/blog/cmake-presets/) to the repo:
* `default` preset, that just enables the cartesian controller devices
* `robot` preset, that enables the devices required for robot control that compile fine on Linux, macOS and Windows (if you have a better suggestion for the name, that is great)

In this way, wherever we were hardcoding the long list of options, we can just change the list of options to use `cmake --preset robot` and everything works fine, without any duplication. As an example of this, I started using the `--preset robot` in the icub-main CI scripts.

The only two options that I did not included that are used on the robots are `ENABLE_icubmod_dragonfly2` and `ENABLE_icubmod_xsensmtx` as these options do not work on Windows and macOS, but I think this is already a net improvement over the current status quo of duplication of options.

Note that unfortunately we can't directly use in the superbuild the `--preset robot` until we keep supporting CMake 3.16 (that is the CMake default version used with apt dependencies on Ubuntu 20.04, see https://github.com/robotology/robotology-superbuild/issues/1439), anyhow I think we can start adding the `--preset robot` wherever we do not care about Ubuntu 20.04 compatibility.