### PR TITLE
`FU` recognise `amcfoc` applications name

### DIFF
--- a/src/tools/FirmwareUpdater/firmwareupdatercore.cpp
+++ b/src/tools/FirmwareUpdater/firmwareupdatercore.cpp
@@ -330,14 +330,14 @@ QString FirmwareUpdaterCore::getProcessFromUint(uint8_t id, bool isMultiCore, eO
     case uprot_proc_Application00:
         if ((boardtype == eobrd_ethtype_amc) && isMultiCore)
             return "eApplication_core_0";
-        else if ((boardtype == eobrd_amcfoc) && isMultiCore)
+        else if ((boardtype == eobrd_ethtype_amcfoc) && isMultiCore)
             return "app.yri" ;
         else
             return "eApplication";
     case uprot_proc_Application01:
-        if ((boardtype == eobrd_amc) && isMultiCore)
+        if ((boardtype == eobrd_ethtype_amc) && isMultiCore)
             return "eApplication_core_1";
-        else if ((boardtype == eobrd_amcfoc) && isMultiCore)
+        else if ((boardtype == eobrd_ethtype_amcfoc) && isMultiCore)
             return "app.mot" ;
         else
             return "eApplication_core_1";

--- a/src/tools/FirmwareUpdater/firmwareupdatercore.cpp
+++ b/src/tools/FirmwareUpdater/firmwareupdatercore.cpp
@@ -320,7 +320,7 @@ boardInfo2_t FirmwareUpdaterCore::getMoreDetails(int boardNum,QString *infoStrin
 
 }
 
-QString FirmwareUpdaterCore::getProcessFromUint(uint8_t id, bool isMultiCore)
+QString FirmwareUpdaterCore::getProcessFromUint(uint8_t id, bool isMultiCore, eObrd_ethtype_t boardtype)
 {
     switch (id) {
     case uprot_proc_Loader:
@@ -328,9 +328,19 @@ QString FirmwareUpdaterCore::getProcessFromUint(uint8_t id, bool isMultiCore)
     case uprot_proc_Updater:
         return "eUpdater";
     case uprot_proc_Application00:
-        return isMultiCore ? "eApplication_core_0" : "eApplication";
+        if ((boardtype == eobrd_ethtype_amc) && isMultiCore)
+            return "eApplication_core_0";
+        else if ((boardtype == eobrd_amcfoc) && isMultiCore)
+            return "app.yri" ;
+        else
+            return "eApplication";
     case uprot_proc_Application01:
-        return "eApplication_core_1";
+        if ((boardtype == eobrd_amc) && isMultiCore)
+            return "eApplication_core_1";
+        else if ((boardtype == eobrd_amcfoc) && isMultiCore)
+            return "app.mot" ;
+        else
+            return "eApplication_core_1";
     case uprot_proc_ApplPROGupdater:
         return "eApplPROGupdater";
     default:

--- a/src/tools/FirmwareUpdater/firmwareupdatercore.h
+++ b/src/tools/FirmwareUpdater/firmwareupdatercore.h
@@ -56,7 +56,7 @@ public:
     bool goToMaintenance();
     bool eraseEthEprom();
     void eraseCanEprom();
-     QString getProcessFromUint(uint8_t id, bool isMultiCore = false, eObrd_ethtype_t boardtype = eobrd_ethtype_unknown);
+    QString getProcessFromUint(uint8_t id, bool isMultiCore = false, eObrd_ethtype_t boardtype = eobrd_ethtype_unknown);
 
     cDownloader *getDownloader();
 

--- a/src/tools/FirmwareUpdater/firmwareupdatercore.h
+++ b/src/tools/FirmwareUpdater/firmwareupdatercore.h
@@ -56,7 +56,7 @@ public:
     bool goToMaintenance();
     bool eraseEthEprom();
     void eraseCanEprom();
-    QString getProcessFromUint(uint8_t id, bool isMultiCore = false);
+     QString getProcessFromUint(uint8_t id, bool isMultiCore = false, eObrd_ethtype_t boardtype = eobrd_ethtype_unknown);
 
     cDownloader *getDownloader();
 

--- a/src/tools/FirmwareUpdater/mainwindow.cpp
+++ b/src/tools/FirmwareUpdater/mainwindow.cpp
@@ -1097,14 +1097,14 @@ void MainWindow::onAppendInfo(boardInfo2_t info,eOipv4addr_t address)
 
     /*******************************************************************************/
     bool isMulticore = (eoboards_type2numberofcores(eoboards_ethtype2type(info.boardtype))) > 1 ? true : false;
-    QTreeWidgetItem *startUpNode = new QTreeWidgetItem(bootStrapNode, QStringList() << "Startup" << core->getProcessFromUint(info.processes.startup, isMulticore));
+    QTreeWidgetItem *startUpNode = new QTreeWidgetItem(bootStrapNode, QStringList() << "Startup" << core->getProcessFromUint(info.processes.startup, isMulticore, info.boardtype));
     bootStrapNode->addChild(startUpNode);
     bootStrapNode->setExpanded(true);
 
-    QTreeWidgetItem *defaultNode = new QTreeWidgetItem(bootStrapNode, QStringList() << "Default" << core->getProcessFromUint(info.processes.def2run, isMulticore));
+    QTreeWidgetItem *defaultNode = new QTreeWidgetItem(bootStrapNode, QStringList() << "Default" << core->getProcessFromUint(info.processes.def2run, isMulticore, info.boardtype));
     bootStrapNode->addChild(defaultNode);
 
-    QTreeWidgetItem *runningNode = new QTreeWidgetItem(bootStrapNode, QStringList() << "Running" << core->getProcessFromUint(info.processes.runningnow, isMulticore));
+    QTreeWidgetItem *runningNode = new QTreeWidgetItem(bootStrapNode, QStringList() << "Running" << core->getProcessFromUint(info.processes.runningnow, isMulticore, info.boardtype));
     bootStrapNode->addChild(runningNode);
 
     /*******************************************************************************/
@@ -1125,7 +1125,7 @@ void MainWindow::onAppendInfo(boardInfo2_t info,eOipv4addr_t address)
         propertiesNode->addChild(processNode);
         processNode->setExpanded(true);
 
-        QTreeWidgetItem *processType = new QTreeWidgetItem(processNode, QStringList() << "Type" << core->getProcessFromUint(pinfo.type, isMulticore));
+        QTreeWidgetItem *processType = new QTreeWidgetItem(processNode, QStringList() << "Type" << core->getProcessFromUint(pinfo.type, isMulticore, info.boardtype));
         processNode->addChild(processType);
 
         QTreeWidgetItem *processVersion = new QTreeWidgetItem(processNode, QStringList() << "Version" << QString("%1.%2").arg(pinfo.version.major).arg(pinfo.version.minor));


### PR DESCRIPTION
The `FirmwareUpdater` now recognise the `amcfoc` application names correctly.