### PR TITLE
Avoid using `typedef struct` in C++

### DIFF
--- a/src/libraries/icubmod/embObjIMU/eo_imu_privData.h
+++ b/src/libraries/icubmod/embObjIMU/eo_imu_privData.h
@@ -42,7 +42,7 @@ public:
 };
 
 
-typedef struct
+struct sensorInfo_t
 {
     std::string name;
     std::string framename;
@@ -50,7 +50,7 @@ typedef struct
     uint8_t state;
     double timestamp;
     double conversionFactor{1.0};  // raw to metric measure
-} sensorInfo_t;
+};
 
 class yarp::dev::SensorsData
 {


### PR DESCRIPTION
Fixes #1009.
Thanks @traversaro 