### PR TITLE
MVP1 and MVP2 for new calibrator

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -64,7 +64,7 @@ checkandset_dependency(IPOPT)
 checkandset_dependency(OpenCV)
 checkandset_dependency(Qt5)
 
-set(MINIMUM_REQUIRED_icub_firmware_shared_VERSION 1.42.0)
+set(MINIMUM_REQUIRED_icub_firmware_shared_VERSION 1.43.0)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
   if(icub_firmware_shared_VERSION VERSION_LESS ${MINIMUM_REQUIRED_icub_firmware_shared_VERSION})

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h
@@ -60,6 +60,7 @@ using namespace std;
 #include "measuresConverter.h"
 
 #include "mcEventDownsampler.h"
+#include "ethParser.h"
 
 
 #ifdef NETWORK_PERFORMANCE_BENCHMARK 
@@ -109,6 +110,10 @@ typedef struct
     bool pwmIsLimited;          /** set to true if pwm is limited */
 }behaviour_flags_t;
 
+typedef struct // this struct is used to store the configuration of flags and value for maintenance mode
+{
+    bool enableSkipRecalibration;   /** if true, the joint will not be recalibrated when the yri is restarted */
+} maintenanceModeCfg_t;
 
 class Watchdog
 {
@@ -285,6 +290,7 @@ private:
     double *                                _gearbox_E2J;   /** the gearbox ratio encoder to joint */
     double *                                _deadzone;
     std::vector<eomc::kalmanFilterParams_t> _kalman_params;  /** Kalman filter parameters */
+    eomc::maintenanceModeCfg_t              _maintenanceModeCfg; /** contains the configuration for maintenance mode */
 
     std::vector<std::unique_ptr<eomc::ITemperatureSensor>> _temperatureSensorsVector;  
     
@@ -319,6 +325,8 @@ private:
     
     // event downsampler
     mced::mcEventDownsampler* event_downsampler;
+
+    eth::parser::boardData bdata;
 
 #ifdef VERIFY_ROP_SETIMPEDANCE
     uint32_t *impedanceSignature;

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -2573,7 +2573,6 @@ bool Parser::parseMaintenanceModeGroup(yarp::os::Searchable &config, bool &skipR
     Bottle &maintenanceGroup=config.findGroup("MAINTENANCE");
     if (maintenanceGroup.isNull())
     {
-        yWarning() << "embObjMC BOARD " << _boardname << " detected that Group MAINTENANCE is not found in configuration file. Setting default values.";
         skipRecalibrationEnabled = false;
         return true;
     }
@@ -2588,6 +2587,7 @@ bool Parser::parseMaintenanceModeGroup(yarp::os::Searchable &config, bool &skipR
     {
         if (!skip_recalibration.isBool())
         {
+            yError() << "embObjMotionControl::open() detected that skipRecalibration bool param is different from accepted values (true / false). Assuming false";
             skipRecalibrationEnabled = false;
         }
         else

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -1994,7 +1994,7 @@ bool Parser::isVerboseEnabled(yarp::os::Searchable &config)
     return ret;
 }
 
-bool Parser::parseBehaviourFalgs(yarp::os::Searchable &config, bool &useRawEncoderData, bool  &pwmIsLimited )
+bool Parser::parseBehaviourFalgs(yarp::os::Searchable &config, bool &useRawEncoderData, bool  &pwmIsLimited)
 {
 
     // Check useRawEncoderData = do not use calibration data!
@@ -2564,6 +2564,43 @@ bool Parser::parseLugreGroup(yarp::os::Searchable &config,std::vector<lugreParam
     }
     return true;
 
+}
+
+
+bool Parser::parseMaintenanceModeGroup(yarp::os::Searchable &config, bool &skipRecalibrationEnabled)
+{
+    // Extract group MaintenanceModeGroup
+    Bottle &maintenanceGroup=config.findGroup("MAINTENANCE");
+    if (maintenanceGroup.isNull())
+    {
+        yWarning() << "embObjMC BOARD " << _boardname << " detected that Group MAINTENANCE is not found in configuration file. Setting default values.";
+        skipRecalibrationEnabled = false;
+        return true;
+    }
+    
+    // Check skipRecalibrationEnabled = do not recalibrate joint at yarprobointerface restart! Used by low level motion controller
+    Value skip_recalibration = maintenanceGroup.find("skipRecalibration");
+    if (skip_recalibration.isNull())
+    {
+        skipRecalibrationEnabled = false;
+    }
+    else
+    {
+        if (!skip_recalibration.isBool())
+        {
+            skipRecalibrationEnabled = false;
+        }
+        else
+        {
+            skipRecalibrationEnabled = skip_recalibration.asBool();
+            if(skipRecalibrationEnabled)
+            {
+                yWarning() << "embObjMotionControl::open() detected that skipRecalibration is requested! Be careful  See 'skipRecalibration' param in config file";
+                yWarning() << "THE ROBOT WILL SKIP THE RECALIBRATION IN THIS CONFIGURATION!";
+            }
+        }
+    }
+    return true;
 }
 
 bool Parser::convert(std::string const &fromstring, eOmc_jsetconstraint_t &jsetconstraint, bool& formaterror)

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.h
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.h
@@ -654,7 +654,7 @@ public:
     bool parseRotorsLimits(yarp::os::Searchable &config, std::vector<rotorLimits_t> &rotorsLimits);
     bool parseCouplingInfo(yarp::os::Searchable &config, couplingInfo_t &couplingInfo);
     bool parseMotioncontrolVersion(yarp::os::Searchable &config, int &version);
-    bool parseBehaviourFalgs(yarp::os::Searchable &config, bool &useRawEncoderData, bool  &pwmIsLimited );
+    bool parseBehaviourFalgs(yarp::os::Searchable &config, bool &useRawEncoderData, bool  &pwmIsLimited);
     bool isVerboseEnabled(yarp::os::Searchable &config);
     bool parseAxisInfo(yarp::os::Searchable &config, int axisMap[], std::vector<axisInfo_t> &axisInfo);
     bool parseEncoderFactor(yarp::os::Searchable &config, double encoderFactor[]);
@@ -666,6 +666,7 @@ public:
     bool parseLugreGroup(yarp::os::Searchable &config,std::vector<lugreParameters_t> &lugre);
     bool parseDeadzoneValue(yarp::os::Searchable &config, double deadzone[], bool *found);
     bool parseKalmanFilterParams(yarp::os::Searchable &config, std::vector<kalmanFilterParams_t> &kalmanFilterParams);
+    bool parseMaintenanceModeGroup(yarp::os::Searchable &config, bool &skipRecalibrationEnabled);
 };
 
 }}}; //close namespaces

--- a/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.cpp
+++ b/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.cpp
@@ -711,8 +711,7 @@ bool parametricCalibratorEth::calibrate()
                 
                 if (it != failedJoints.end()) 
                 {
-                    yDebug() << deviceName << ": joint # " << *lit << " failed the calibration. Idling it and setting safe PWM limits";
-                    iAmp->setPWMLimit((*it), limited_max_pwm[(*it)]);
+                    yError() << deviceName << ": joint # " << *lit << " failed the calibration. Idling it and keeping safe PWM limits";
                     // stop calibration for expired timeout
                     iControlMode->setControlMode((*it),VOCAB_CM_IDLE); // eventually think to set FORCE_IDLE or NOT_CONFIGURED
                 }
@@ -777,8 +776,7 @@ bool parametricCalibratorEth::calibrate()
                 
                 if (it != failedJoints.end()) 
                 {
-                    yDebug() << deviceName << ": joint # " << *lit << " failed reaching zero position. Idling it and setting safe PWM limits";
-                    iAmp->setPWMLimit((*it), limited_max_pwm[(*it)]);
+                    yError() << deviceName << ": joint # " << *lit << " failed reaching zero position. Idling it and keeping safe PWM limits";
                     iControlMode->setControlMode((*it),VOCAB_CM_IDLE); // eventually think to set FORCE_IDLE
                 }
                 else

--- a/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.cpp
+++ b/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.cpp
@@ -715,7 +715,8 @@ bool parametricCalibratorEth::calibrate()
                 {
                     yDebug() << deviceName << ": joint # " << *fji << " failed the calibration. Idling it and setting safe PWM limits";
                     iAmp->setPWMLimit((*it), limited_max_pwm[(*it)]);
-                    iControlMode->setControlMode((*it),VOCAB_CM_IDLE); // eventually think to set FORCE_IDLE
+                    // stop calibration for expired timeout
+                    iControlMode->setControlMode((*it),VOCAB_CM_IDLE); // eventually think to set FORCE_IDLE or NOT_CONFIGURED
                 }
             }
             Bit++;

--- a/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.cpp
+++ b/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.cpp
@@ -267,14 +267,13 @@ bool parametricCalibratorEth::open(yarp::os::Searchable& config)
     Value checkSkipReCalib = config.findGroup("MAINTENANCE").find("skipRecalibration");
     if(checkSkipReCalib.isNull())
     {
-        yWarning() << deviceName << ": skipRecalibration bool param not found. Assuming false";
         skipReCalibration = false;
     }
     else
     {
         if(!checkSkipReCalib.isBool())
         {
-            yWarning() << deviceName << ": skipRecalibration bool param is different from accepted values (true / false). Assuming false";
+            yError() << deviceName << ": skipRecalibration bool param is different from accepted values (true / false). Assuming false";
             skipReCalibration = false;
         }
         else
@@ -712,7 +711,7 @@ bool parametricCalibratorEth::calibrate()
                 
                 if (it != failedJoints.end()) 
                 {
-                    yDebug() << deviceName << ": joint # " << *fji << " failed the calibration. Idling it and setting safe PWM limits";
+                    yDebug() << deviceName << ": joint # " << *lit << " failed the calibration. Idling it and setting safe PWM limits";
                     iAmp->setPWMLimit((*it), limited_max_pwm[(*it)]);
                     // stop calibration for expired timeout
                     iControlMode->setControlMode((*it),VOCAB_CM_IDLE); // eventually think to set FORCE_IDLE or NOT_CONFIGURED
@@ -778,13 +777,13 @@ bool parametricCalibratorEth::calibrate()
                 
                 if (it != failedJoints.end()) 
                 {
-                    yDebug() << deviceName << ": joint # " << *fji << " failed reaching zero position. Idling it and setting safe PWM limits";
+                    yDebug() << deviceName << ": joint # " << *lit << " failed reaching zero position. Idling it and setting safe PWM limits";
                     iAmp->setPWMLimit((*it), limited_max_pwm[(*it)]);
                     iControlMode->setControlMode((*it),VOCAB_CM_IDLE); // eventually think to set FORCE_IDLE
                 }
                 else
                 {
-                    yDebug() << deviceName << ": joint # " << *fji << " reached zero position. Setting original max PWM limits";
+                    yDebug() << deviceName << ": joint # " << *lit << " reached zero position. Setting original max PWM limits";
                     iAmp->setPWMLimit((*it),original_max_pwm[(*it)]);
                 }
             }

--- a/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.h
+++ b/src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.h
@@ -109,8 +109,8 @@ private:
     bool calibrate();
     bool calibrateJoint(int j);
     bool goToStartupPosition(int j);
-    bool checkCalibrateJointEnded(std::list<int> set);
-    bool checkGoneToZeroThreshold(int j);
+    bool checkCalibrateJointEnded(std::list<int> set, std::list<int> &failedJoints);
+    bool checkGoneToZeroThreshold(int j, std::list<int> &failedJoints);
     bool checkHwFault(); 
 
 
@@ -144,6 +144,7 @@ private:
     int    *disableHomeAndPark;
     int    *disableStartupPosCheck;
     bool    clearHwFault;
+    bool    skipReCalibration;
 
     int    *timeout_goToZero;
     int    *timeout_calibration;


### PR DESCRIPTION
 ## Summary of Changes
This pull request introduces the first MVP for a new calibrator. The key changes include setting safe PWM limits only to joints that fail calibration, defining a new MAINTENANCE mode to enalble `skipRecalibration` feature and other minor changes.
Moreover, we create a new struct in the firmware for this maintenance mode in order to collect in a single group current and upcoming flags and data related to this mode. Then we fix the code  preventing errors when joints go to zero position during calibration with `skipRecalibration` enabled.
Another small change that we have added is modifying the control mode requests in `embObjMotionControl::calibrationDoneRaw()` from remote to local RAM call
Finally we have aligned dependencies to `icub_firmware_shared` protocol v1.43.0. 
The main goal of this PR is to improve the calibration process and provide more control over PWM limits settings and recalibration behavior.
 
 ### Highlights
 * **PID Control**: Safe PWM limits are now set only for joints that fail calibration, allowing other joints of the robot subpart to move with full-scale PWM limits (regarding naming used, you can often read PID limits used instead of PWM limits. To clarify this we can say that from a fw point of view what is limited as a consequence of a failed calibration is the full scale of the PWM so that the joint won't work at its full power even if the user requires it from the GUI or other application). This points solves this issue: https://github.com/robotology/icub-main/issues/990
 * **Maintenance Mode**: Introduces a new MAINTENANCE group in `general.xml` with a `skipRecalibration` flag to control recalibration behavior. You can check how to setup the configuration files for enabling this feature in the body of this PR:  https://github.com/robotology/icub-firmware-build/pull/205. Enabling this feature allows the user to start the robot skipping the calibration phase of the joint from the second run of the `yarprobotinterface`. Specifically, a joint will skip the calibration if it calibrated correctly in the first run and if the boards are not switched off. When using this modality pay attention to the behaviour of the robot since the joints already calibrated are restarted in IDLE. This point solves this issue: https://github.com/icub-tech-iit/tickets/issues/3763
 * **Firmware Changes**: A new struct is created in the firmware to support the maintenance mode configuration.
 * **Calibration Process**: Prevents errors when joints need to reach zero position during calibration when `skipRecalibration` is enabled or not. We had issues when IDLE control mode was requested due to a failing in the calibration process during either the hard-stop calibration or while joint was going to the startup zero position, that made embedded controller failing to set IDLE control mode. Now this is solved.
 * **Dependency Alignment**: Aligns dependencies to `icub_firmware_shared` protocol v1.43.0.
 
 ### Changelog
 Click here to see the changelog
 * **conf/iCubFindDependencies.cmake**
   
   * Updated the minimum required version of `icub_firmware_shared` to 1.43.0 (line 67).
 * **src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp**
   
   * Added initialization for `_maintenanceModeCfg.enableSkipRecalibration` to `false` in the constructor (line 271).
   * Added a check to read board configuration data from the XML file using `eth::parser::read` (lines 368-372).
   * Added parsing for the MAINTENANCE group to enable/disable skip recalibration (lines 1283-1286).
   * Implemented sending the controller configuration, including `enableSkipRecalibration`, to the firmware (lines 1519-1537).
   * Modified `calibrationDoneRaw` to return true if `skipRecalibration` is enabled and the control mode is idle (lines 2477-2492).
   * Changed request of control modes in `embObjMotionControl::calibrationDoneRaw()` from remote to local RAM call (lines 2478-2483).
 * **src/libraries/icubmod/embObjMotionControl/embObjMotionControl.h**
   
   * Added include for `ethParser.h` (line 63).
   * Added `maintenanceModeCfg_t` struct definition to store maintenance mode configuration (lines 113-116).
   * Added `_maintenanceModeCfg` member to the `embObjMotionControl` class (line 293).
   * Added `bdata` member of type `eth::parser::boardData` to the `embObjMotionControl` class (line 329).
 * **src/libraries/icubmod/eomcParser.cpp**
   
   * Added `parseMaintenanceModeGroup` function to parse the MAINTENANCE group from the configuration file (lines 2570-2604).
 * **src/libraries/icubmod/eomcParser.h**
   
   * Added declaration for `parseMaintenanceModeGroup` function (line 669).
 * **src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.cpp**
   
   * Added `skipReCalibration` member variable and initialized it to `false` (line 143).
   * Added logic to read the `skipRecalibration` flag from the MAINTENANCE group in the configuration file (lines 267-289).
   * Modified the `calibrate` function to set safe PID limits only for joints that failed calibration (lines 697-731).
   * Modified the `calibrate` function to check if joints are in position, and if not, set safe PID limits (lines 756-803).
   * Modified `checkCalibrateJointEnded` to populate a list of failed joints (lines 833-866).
   * Modified `goToStartupPosition` to skip homing if `skipReCalibration` is enabled and the joint is in IDLE mode (lines 935-940).
   * Modified `checkGoneToZeroThreshold` to return completed if `skipReCalibration` is enabled and the joint is in IDLE mode (lines 982-986).
 * **src/libraries/icubmod/parametricCalibratorEth/parametricCalibratorEth.h**
   
   * Added `skipReCalibration` member variable (line 147).
   * Modified `checkCalibrateJointEnded` and `checkGoneToZeroThreshold` to take a list of failed joints as input (lines 112-113).


More infos about the feature are available is here: https://github.com/robotology/icub-firmware-build/pull/205