### PR TITLE
Fix for IBattery interface compatibility

### DIFF
--- a/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.cpp
@@ -222,51 +222,51 @@ void batteryReaderThread::run()
 #endif
 }
 
-bool BcbBattery::getBatteryVoltage(double &voltage)
+ReturnValue BcbBattery::getBatteryVoltage(double &voltage)
 {
-    if (!batteryReader) return false;
+    if (!batteryReader) return ReturnValue::return_code::return_value_error_generic;
     std::lock_guard<std::mutex> lg(batteryReader->datamut);
     voltage = batteryReader->battery_voltage;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool BcbBattery::getBatteryCurrent(double &current)
+ReturnValue BcbBattery::getBatteryCurrent(double &current)
 {
-    if (!batteryReader) return false;
+    if (!batteryReader) return ReturnValue::return_code::return_value_error_generic;
     std::lock_guard<std::mutex> lg(batteryReader->datamut);
     current = batteryReader->battery_current;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool BcbBattery::getBatteryCharge(double &charge)
+ReturnValue BcbBattery::getBatteryCharge(double &charge)
 {
-    if (!batteryReader) return false;
+    if (!batteryReader) return ReturnValue::return_code::return_value_error_generic;
     std::lock_guard<std::mutex> lg(batteryReader->datamut);
     charge = batteryReader->battery_charge;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool BcbBattery::getBatteryStatus(Battery_status &status)
+ReturnValue BcbBattery::getBatteryStatus(Battery_status &status)
 {
-    if (!batteryReader) return false;
+    if (!batteryReader) return ReturnValue::return_code::return_value_error_generic;
     std::lock_guard<std::mutex> lg(batteryReader->datamut);
     status= batteryReader->battery_status;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool BcbBattery::getBatteryTemperature(double &temperature)
+ReturnValue BcbBattery::getBatteryTemperature(double &temperature)
 {
     //yError("Not yet implemented");
     temperature = std::nan("");
-    return false;
+    return YARP_METHOD_NOT_YET_IMPLEMENTED();
 }
 
-bool BcbBattery::getBatteryInfo(string &info)
+ReturnValue BcbBattery::getBatteryInfo(string &info)
 {
-    if (!batteryReader) return false;
+    if (!batteryReader) return ReturnValue::return_code::return_value_error_generic;
     std::lock_guard<std::mutex> lg(batteryReader->datamut);
     info = batteryReader->battery_info;
-    return true;
+    return ReturnValue_ok;
 }
 
 void batteryReaderThread::threadRelease()

--- a/src/libraries/icubmod/bcbBattery/bcbBattery.h
+++ b/src/libraries/icubmod/bcbBattery/bcbBattery.h
@@ -46,7 +46,7 @@ class batteryReaderThread : public PeriodicThread
     double             battery_current = 0;
     std::string        battery_info = "icub battery system v1.0";
     int                backpack_status = 0;
-    IBattery::Battery_status     battery_status = IBattery::Battery_status::BATTERY_OK_STANDBY;    
+    IBattery::Battery_status     battery_status = IBattery::Battery_status::BATTERY_OK_STANDBY;
 
     batteryReaderThread (ISerialDevice *_iSerial, double period) :
     PeriodicThread((double)period),
@@ -84,12 +84,12 @@ public:
     virtual bool open(yarp::os::Searchable& config);
     virtual bool close();
 
-    virtual bool getBatteryVoltage     (double &voltage) override;
-    virtual bool getBatteryCurrent     (double &current) override;
-    virtual bool getBatteryCharge      (double &charge) override;
-    virtual bool getBatteryStatus      (Battery_status &status) override;
-    virtual bool getBatteryInfo        (std::string &info) override;
-    virtual bool getBatteryTemperature (double &temperature) override;
+    virtual ReturnValue getBatteryVoltage     (double &voltage) override;
+    virtual ReturnValue getBatteryCurrent     (double &current) override;
+    virtual ReturnValue getBatteryCharge      (double &charge) override;
+    virtual ReturnValue getBatteryStatus      (Battery_status &status) override;
+    virtual ReturnValue getBatteryInfo        (std::string &info) override;
+    virtual ReturnValue getBatteryTemperature (double &temperature) override;
 };
 
 

--- a/src/libraries/icubmod/bmsBattery/bmsBattery.cpp
+++ b/src/libraries/icubmod/bmsBattery/bmsBattery.cpp
@@ -52,7 +52,7 @@ bool BmsBattery::open(yarp::os::Searchable& config)
     if (!driver.isValid())
     {
         yError() << "Error opening PolyDriver check parameters";
-#ifndef DEBUG_TEST 
+#ifndef DEBUG_TEST
         return false;
 #endif
     }
@@ -62,7 +62,7 @@ bool BmsBattery::open(yarp::os::Searchable& config)
     if (!pSerial)
     {
         yError("Error opening serial driver. Device not available");
-#ifndef DEBUG_TEST 
+#ifndef DEBUG_TEST
         return false;
 #endif
     }
@@ -150,7 +150,7 @@ void BmsBattery::run()
                 timeinfo = localtime(&rawtime);
                 //battery_data.timestamp = asctime(timeinfo);
                 battery_voltage = double(battery_voltage) / 1024 * 66;
-                battery_current = (double(battery_current) - 512) / 128 * 20; //+- 60 is the maximum current that the sensor can read. 128+512 is the value of the AD 
+                battery_current = (double(battery_current) - 512) / 128 * 20; //+- 60 is the maximum current that the sensor can read. 128+512 is the value of the AD
                 //when the current is 20A.
                 battery_charge = double(battery_charge) / 100; // the value coming from the BCS board goes from 0 to 100%
                 reading_ok = true;
@@ -175,44 +175,44 @@ void BmsBattery::run()
     }
 }
 
-bool BmsBattery::getBatteryVoltage(double &voltage)
+ReturnValue BmsBattery::getBatteryVoltage(double &voltage)
 {
     lock_guard<mutex> lck(mtx);
     voltage = battery_voltage;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool BmsBattery::getBatteryCurrent(double &current)
+ReturnValue BmsBattery::getBatteryCurrent(double &current)
 {
     lock_guard<mutex> lck(mtx);
     current = battery_current;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool BmsBattery::getBatteryCharge(double &charge)
+ReturnValue BmsBattery::getBatteryCharge(double &charge)
 {
     lock_guard<mutex> lck(mtx);
     charge = battery_charge;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool BmsBattery::getBatteryStatus(Battery_status &status)
+ReturnValue BmsBattery::getBatteryStatus(Battery_status &status)
 {
     //yError("Not yet implemented");
-    return false;
+    return  YARP_METHOD_NOT_YET_IMPLEMENTED();
 }
 
-bool BmsBattery::getBatteryTemperature(double &temperature)
+ReturnValue BmsBattery::getBatteryTemperature(double &temperature)
 {
     //yError("Not yet implemented");
-    return false;
+    return  YARP_METHOD_NOT_YET_IMPLEMENTED();
 }
 
-bool BmsBattery::getBatteryInfo(string &info)
+ReturnValue BmsBattery::getBatteryInfo(string &info)
 {
     lock_guard<mutex> lck(mtx);
     info = battery_info;
-    return true;
+    return ReturnValue_ok;
 }
 
 void BmsBattery::threadRelease()

--- a/src/libraries/icubmod/bmsBattery/bmsBattery.h
+++ b/src/libraries/icubmod/bmsBattery/bmsBattery.h
@@ -57,12 +57,12 @@ public:
     virtual bool open(yarp::os::Searchable& config);
     virtual bool close();
 
-    virtual bool getBatteryVoltage     (double &voltage);
-    virtual bool getBatteryCurrent     (double &current);
-    virtual bool getBatteryCharge      (double &charge);
-    virtual bool getBatteryStatus      (Battery_status &status);
-    virtual bool getBatteryInfo        (std::string &info);
-    virtual bool getBatteryTemperature (double &temperature);
+    virtual ReturnValue getBatteryVoltage     (double &voltage);
+    virtual ReturnValue getBatteryCurrent     (double &current);
+    virtual ReturnValue getBatteryCharge      (double &charge);
+    virtual ReturnValue getBatteryStatus      (Battery_status &status);
+    virtual ReturnValue getBatteryInfo        (std::string &info);
+    virtual ReturnValue getBatteryTemperature (double &temperature);
 
     virtual bool threadInit();
     virtual void threadRelease();

--- a/src/libraries/icubmod/embObjBattery/embObjBattery.cpp
+++ b/src/libraries/icubmod/embObjBattery/embObjBattery.cpp
@@ -263,14 +263,14 @@ bool embObjBattery::update(eOprotID32_t id32, double timestamp, void *rxdata)
     else if (!isCanDataAvailable && (data->age != 0))
     {
         yDebug() << "First Status are:\n" << updateStatusStringStream(data->status, canBatteryData_.prevStatus_, true);
-        
+
         canBatteryData_.prevStatus_ = data->status;
         isCanDataAvailable = true;
     }
     else if (data->status != canBatteryData_.prevStatus_)
     {
         yDebug() << "Status changed to:\n" << updateStatusStringStream(data->status, canBatteryData_.prevStatus_, false);
-        
+
         canBatteryData_.prevStatus_ = data->status;
     }
 
@@ -372,14 +372,14 @@ std::string embObjBattery::updateStatusStringStream(const uint16_t &currStatus, 
                 if((embot::core::binary::bit::check(currStatus, bit_pos)))
                 {
                     statusstring.append(s_boards_map_of_battery_alarm_status.at(i).second);
-                } 
+                }
                 else
                 {
                     statusstring.append(s_boards_map_of_battery_alarm_status.at(i+1).second);
                 }
                 statusstring.append("\n");
             }
-            
+
             ++bit_pos;
         }
     }
@@ -389,7 +389,7 @@ std::string embObjBattery::updateStatusStringStream(const uint16_t &currStatus, 
         statusstring.append("\tNo Faults Detected. All Alarms Bit Down\n");
     }
 
-    
+
     return statusstring;
 }
 
@@ -410,44 +410,44 @@ double embObjBattery::calculateBoardTime(eOabstime_t current)
     return realtime;
 }
 
-bool embObjBattery::getBatteryVoltage(double &voltage)
+ReturnValue embObjBattery::getBatteryVoltage(double &voltage)
 {
     voltage = canBatteryData_.voltage_;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool embObjBattery::getBatteryCurrent(double &current)
+ReturnValue embObjBattery::getBatteryCurrent(double &current)
 {
     current = canBatteryData_.current_;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool embObjBattery::getBatteryCharge(double &charge)
+ReturnValue embObjBattery::getBatteryCharge(double &charge)
 {
     charge = (canBatteryData_.charge_ != 0.0) ? canBatteryData_.charge_ : NAN;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool embObjBattery::getBatteryStatus(Battery_status &status)
+ReturnValue embObjBattery::getBatteryStatus(Battery_status &status)
 {
     status = static_cast<Battery_status>(canBatteryData_.status_);
-    return true;
+    return ReturnValue_ok;
 }
 
-bool embObjBattery::getBatteryTemperature(double &temperature)
+ReturnValue embObjBattery::getBatteryTemperature(double &temperature)
 {
     temperature = (canBatteryData_.temperature_ != 0) ? canBatteryData_.temperature_ : NAN;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool embObjBattery::getBatteryInfo(std::string &battery_info)
+ReturnValue embObjBattery::getBatteryInfo(std::string &battery_info)
 {
     std::stringstream ss;
     ss << "{\"temperature\":" << canBatteryData_.temperature_ << ",\"voltage\":" << canBatteryData_.voltage_ << ",\"current\":" << canBatteryData_.current_ << ",\"charge\":" << canBatteryData_.charge_ << ",\"status\":" << canBatteryData_.status_
        << ",\"ts\":" << canBatteryData_.timeStamp_ << "}" << std::endl;
 
     battery_info = ss.str();
-    return true;
+    return ReturnValue_ok;
 }
 
 bool CanBatteryData::operator==(const CanBatteryData &other) const
@@ -468,7 +468,7 @@ bool CanBatteryData::operator==(const CanBatteryData &other) const
         return false;
     if (sensorType_ != other.sensorType_)
         return false;
-    
+
     return true;
 }
 

--- a/src/libraries/icubmod/embObjBattery/embObjBattery.h
+++ b/src/libraries/icubmod/embObjBattery/embObjBattery.h
@@ -40,7 +40,7 @@ class CanBatteryData
     double timeStamp_{0};
     std::string sensorName_{};
     eObrd_type_t sensorType_{eobrd_unknown};
-    
+
 
     void decode(eOas_battery_timedvalue_t *data, double timestamp);
     bool operator==(const CanBatteryData &other) const;
@@ -63,12 +63,12 @@ class yarp::dev::embObjBattery : public yarp::dev::DeviceDriver, public eth::Iet
     bool update(eOprotID32_t id32, double timestamp, void *rxdata) override;
 
     // IBattery
-    bool getBatteryVoltage(double &voltage) override;
-    bool getBatteryCurrent(double &current) override;
-    bool getBatteryCharge(double &charge) override;
-    bool getBatteryStatus(Battery_status &status) override;
-    bool getBatteryTemperature(double &temperature) override;
-    bool getBatteryInfo(std::string &battery_info) override;
+    ReturnValue getBatteryVoltage(double &voltage) override;
+    ReturnValue getBatteryCurrent(double &current) override;
+    ReturnValue getBatteryCharge(double &charge) override;
+    ReturnValue getBatteryStatus(Battery_status &status) override;
+    ReturnValue getBatteryTemperature(double &temperature) override;
+    ReturnValue getBatteryInfo(std::string &battery_info) override;
 
     virtual double calculateBoardTime(eOabstime_t current);
 


### PR DESCRIPTION
This PR updates `bcbBattery`, `bmsBattery` and `embObjBattery` in order to make them compatible with the new `yarp::dev::IBattery` that now uses the `yarp::dev::ReturnValue`