### PR TITLE
[DRAFT] Ensure that EthSender and EthReceiver periodic threads used by embObj do not drift

### DIFF
--- a/src/libraries/icubmod/embObjLib/ethReceiver.cpp
+++ b/src/libraries/icubmod/embObjLib/ethReceiver.cpp
@@ -62,7 +62,7 @@ using namespace eth;
 
 
 
-EthReceiver::EthReceiver(int raterx): PeriodicThread((double)raterx/1000.0)
+EthReceiver::EthReceiver(int raterx): PeriodicThread((double)raterx/1000.0, yarp::os::ShouldUseSystemClock::Yes, yarp::os::PeriodicThreadClock::Absolute)
 {
     rateofthread = raterx;
     yDebug() << "EthReceiver is a PeriodicThread with rxrate =" << rateofthread << "ms";

--- a/src/libraries/icubmod/embObjLib/ethSender.cpp
+++ b/src/libraries/icubmod/embObjLib/ethSender.cpp
@@ -59,7 +59,7 @@ using yarp::os::Log;
 
 using namespace eth;
 
-EthSender::EthSender(int txrate) : PeriodicThread((double)txrate/1000.0)
+EthSender::EthSender(int txrate) : PeriodicThread((double)txrate/1000.0, yarp::os::ShouldUseSystemClock::Yes, yarp::os::PeriodicThreadClock::Absolute)
 {
     rateofthread = txrate;
     yDebug() << "EthSender is a PeriodicThread with txrate =" << rateofthread << "ms";


### PR DESCRIPTION
Attempted fix for https://github.com/robotology/icub-firmware/issues/577#issuecomment-2848086320, to be tested on the real robot.

In a nutshell, we explicitly pass to `yarp::os::PeriodicThread` constructors all the supported options, in particular:
* `yarp::os::ShouldUseSystemClock::Yes` : as the embObj-related communication is not connected in any way to YARP ports, we always want this thread to be scheduled accordingly to the system clock, even if `YARP_CLOCK` environment variable is set.
* `yarp::os::PeriodicThreadClock::Absolute` : this option is useful to avoid the drift of the scheduling period, as observed in https://github.com/robotology/icub-firmware/issues/577#issuecomment-2848086320