### PR TITLE
embObjMotionControl: switch to log error once to avoid flooding terminal for non-implemented and deprecated functions

### DIFF
--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -54,13 +54,13 @@ using namespace yarp::dev::eomc;
 
 static inline bool NOT_YET_IMPLEMENTED(const char *txt)
 {
-    yError() << txt << " is not yet implemented for embObjMotionControl";
+    yErrorOnce() << txt << " is not yet implemented for embObjMotionControl";
     return true;
 }
 
 static inline bool DEPRECATED(const char *txt)
 {
-    yError() << txt << " has been deprecated for embObjMotionControl";
+    yErrorOnce() << txt << " has been deprecated for embObjMotionControl";
     return true;
 }
 


### PR DESCRIPTION
As per title, this PR aims for a tiny QoL improvement to avoid flooding the yarprobotinterface terminal when using clients (e.g. `robometry`) that periodically call interfaces with methods deprecated or not implemented. 