### PR TITLE
Fu enhancement unicast

### DIFF
--- a/src/tools/FirmwareUpdater/firmwareupdatercore.cpp
+++ b/src/tools/FirmwareUpdater/firmwareupdatercore.cpp
@@ -263,10 +263,10 @@ void FirmwareUpdaterCore::setSelectedCanBoards(QList <sBoard> selectedBoards,QSt
     this->canBoards = selectedBoards;
 
 
-    qDebug() << "setSelectedCanBoards called with:";
-    qDebug() << "  address:" << address;
-    qDebug() << "  deviceId:" << deviceId;
-    qDebug() << "  canBoards count:" << canBoards.count();
+    // qDebug() << "setSelectedCanBoards called with:";
+    // qDebug() << "  address:" << address;
+    // qDebug() << "  deviceId:" << deviceId;
+    // qDebug() << "  canBoards count:" << canBoards.count();
 
     foreach (sBoard b, selectedBoards) {
         qDebug() << "Selecting CAN board with Bus: " << selectedBoards[0].bus
@@ -499,10 +499,10 @@ QList<sBoard > FirmwareUpdaterCore::getCanBoardsFromEth(QString address, QString
     unsigned int remoteAddr;
     unsigned int localAddr;
 
-    qDebug() << "getCanBoardsFromEth called with:";
-    qDebug() << "  address:" << address;
-    qDebug() << "  canID:" << canID;
-    qDebug() << "  force:" << force;
+    // qDebug() << "getCanBoardsFromEth called with:";
+    // qDebug() << "  address:" << address;
+    // qDebug() << "  canID:" << canID;
+    // qDebug() << "  force:" << force;
 
 
 
@@ -554,17 +554,17 @@ QList<sBoard > FirmwareUpdaterCore::getCanBoardsFromEth(QString address, QString
         return canBoards;
     }
 
-    for (int i = 0; i < downloader.board_list_size; i++) {
-        qDebug() << "Discovered Board: Bus " << downloader.board_list[i].bus
-                 << " ID: " << downloader.board_list[i].pid
-                 << " Status: " << downloader.board_list[i].status;
-    }
+    // for (int i = 0; i < downloader.board_list_size; i++) {
+    //     qDebug() << "Discovered Board: Bus " << downloader.board_list[i].bus
+    //              << " ID: " << downloader.board_list[i].pid
+    //              << " Status: " << downloader.board_list[i].status;
+    // }
 
     for(int i=0; i<downloader.board_list_size;i++){
         canBoards.append(downloader.board_list[i]);
     }
     currentAddress = address;
-    qDebug() << "getCanBoardsFromEth returning" << canBoards.count() << "boards.";
+    // qDebug() << "getCanBoardsFromEth returning" << canBoards.count() << "boards.";
 
     //downloader.stopdriver();
     mutex.unlock();
@@ -1088,14 +1088,14 @@ bool FirmwareUpdaterCore::uploadCanApplication(QString filename, QString *result
 
 //    }
     // Debug inputs
-    qDebug() << "uploadCanApplication called with:";
-    qDebug() << "  filename:" << filename;
-    qDebug() << "  address:" << address;
-    qDebug() << "  deviceId:" << deviceId;
-    qDebug() << "  resultCanBoards is null:" << (resultCanBoards == nullptr);
-    if (resultCanBoards != nullptr) {
-        qDebug() << "  resultCanBoards size:" << resultCanBoards->size();
-    }
+    // qDebug() << "uploadCanApplication called with:";
+    // qDebug() << "  filename:" << filename;
+    // qDebug() << "  address:" << address;
+    // qDebug() << "  deviceId:" << deviceId;
+    // qDebug() << "  resultCanBoards is null:" << (resultCanBoards == nullptr);
+    // if (resultCanBoards != nullptr) {
+    //     qDebug() << "  resultCanBoards size:" << resultCanBoards->size();
+    // }
 
 
 
@@ -1119,14 +1119,14 @@ bool FirmwareUpdaterCore::uploadCanApplication(QString filename, QString *result
 
 
 
-    QString res;
-    QList<sBoard> boards;
+    // QString res;
+    // QList<sBoard> boards;
 
-    if(!address.isEmpty() && deviceId == -1){
-        getCanBoardsFromEth(address,&res);
-    }else{
-        getCanBoardsFromDriver("SOCKETCAN",deviceId,&res);
-    }
+    // if(!address.isEmpty() && deviceId == -1){
+    //     getCanBoardsFromEth(address,&res);
+    // }else{
+    //     getCanBoardsFromDriver("SOCKETCAN",deviceId,&res);
+    // }
 
 
     if (resultCanBoards->size() == 1)

--- a/src/tools/FirmwareUpdater/firmwareupdatercore.cpp
+++ b/src/tools/FirmwareUpdater/firmwareupdatercore.cpp
@@ -259,18 +259,9 @@ void FirmwareUpdaterCore::setSelectedCanBoards(QList <sBoard> selectedBoards,QSt
         getCanBoardsFromDriver(address,deviceId,&res);
     }
 
-
     this->canBoards = selectedBoards;
 
-
-    // qDebug() << "setSelectedCanBoards called with:";
-    // qDebug() << "  address:" << address;
-    // qDebug() << "  deviceId:" << deviceId;
-    // qDebug() << "  canBoards count:" << canBoards.count();
-
     foreach (sBoard b, selectedBoards) {
-        qDebug() << "Selecting CAN board with Bus: " << selectedBoards[0].bus
-                 << " ID: " << selectedBoards[0].pid;
         for(int i=0;i<downloader.board_list_size;i++){
             if(downloader.board_list[i].bus == b.bus &&
                     downloader.board_list[i].pid == b.pid){
@@ -362,8 +353,6 @@ QList<sBoard> FirmwareUpdaterCore::getCanBoardsFromDriver(QString driver, int ne
 {
     mutex.lock();
 
-
-
     if(force){
         downloader.stopdriver();
     }else{
@@ -379,51 +368,24 @@ QList<sBoard> FirmwareUpdaterCore::getCanBoardsFromDriver(QString driver, int ne
     canBoards.clear();
     yarp::os::Property params;
     QString networkType;
-    // if(driver.contains("CFW2",Qt::CaseInsensitive)){
-    //     networkType="cfw2can";
-    // } else if(driver.contains("ECAN",Qt::CaseInsensitive)){
-    //     networkType = "ecan";
-    // } else if(driver.contains("PCAN",Qt::CaseInsensitive)){
-    //     networkType = "pcan";
-    // } else if(driver.contains("SOCKET",Qt::CaseInsensitive)){
-    //     networkType="socketcan";
-    // }
-    if (driver.contains("CFW2", Qt::CaseInsensitive)) {
-        networkType = "cfw2can";
-    } else if (driver.contains("ECAN", Qt::CaseInsensitive)) {
+    if(driver.contains("CFW2",Qt::CaseInsensitive)){
+        networkType="cfw2can";
+    } else if(driver.contains("ECAN",Qt::CaseInsensitive)){
         networkType = "ecan";
-    } else if (driver.contains("PCAN", Qt::CaseInsensitive)) {
+    } else if(driver.contains("PCAN",Qt::CaseInsensitive)){
         networkType = "pcan";
-    } else if (driver.contains("SOCKET", Qt::CaseInsensitive)) {
-        networkType = "socketcan";
-    } else {
-        qDebug() << "Error: Unknown driver type:" << driver;
-        *retString = "Unknown driver type: " + driver;
-        mutex.unlock();
-        return canBoards; // Return an empty list
+    } else if(driver.contains("SOCKET",Qt::CaseInsensitive)){
+        networkType="socketcan";
     }
-
-
     params.put("device", networkType.toLatin1().data());
-    params.put("canDeviceNum", 0);
+    params.put("canDeviceNum", networkId);
     params.put("canTxQueue", 64);
     params.put("canRxQueue", 64);
     params.put("canTxTimeout", 2000);
     params.put("canRxTimeout", 2000);
 
-    qDebug() << "Initializing driver with parameters:";
-    qDebug() << "  device:" << QString::fromStdString(params.find("device").asString());
-    qDebug() << "  canDeviceNum:" << params.find("canDeviceNum").asInt32();
-    qDebug() << "  canTxQueue:" << params.find("canTxQueue").asInt32();
-    qDebug() << "  canRxQueue:" << params.find("canRxQueue").asInt32();
-    qDebug() << "  canTxTimeout:" << params.find("canTxTimeout").asInt32();
-    qDebug() << "  canRxTimeout:" << params.find("canRxTimeout").asInt32();
-
-
     //try to connect to the driver
     int ret = downloader.initdriver(params, (verbosity>1) ? true : false);
-
-
 
     if (0 != ret){
         if(-2 == ret){
@@ -440,8 +402,6 @@ QList<sBoard> FirmwareUpdaterCore::getCanBoardsFromDriver(QString driver, int ne
     }
 
 
-
-
     ret = downloader.initschede();
 
     if (ret == -1)
@@ -453,13 +413,6 @@ QList<sBoard> FirmwareUpdaterCore::getCanBoardsFromDriver(QString driver, int ne
         //not_connected_status();
         mutex.unlock();
         return canBoards;
-    }
-
-
-    for (int i = 0; i < downloader.board_list_size; i++) {
-        qDebug() << "Discovered Board: Bus " << downloader.board_list[i].bus
-                 << " ID: " << downloader.board_list[i].pid
-                 << " Status: " << downloader.board_list[i].status;
     }
 
     for(int i=0; i<downloader.board_list_size;i++){
@@ -477,8 +430,6 @@ QList<sBoard> FirmwareUpdaterCore::getCanBoardsFromDriver(QString driver, int ne
 
 QList<sBoard > FirmwareUpdaterCore::getCanBoardsFromEth(QString address, QString *retString, int canID, bool force)
 {
- 
-
     mutex.lock();
 
     if(force){
@@ -498,11 +449,6 @@ QList<sBoard > FirmwareUpdaterCore::getCanBoardsFromEth(QString address, QString
     canBoards.clear();
     unsigned int remoteAddr;
     unsigned int localAddr;
-
-    // qDebug() << "getCanBoardsFromEth called with:";
-    // qDebug() << "  address:" << address;
-    // qDebug() << "  canID:" << canID;
-    // qDebug() << "  force:" << force;
 
 
 
@@ -554,21 +500,13 @@ QList<sBoard > FirmwareUpdaterCore::getCanBoardsFromEth(QString address, QString
         return canBoards;
     }
 
-    // for (int i = 0; i < downloader.board_list_size; i++) {
-    //     qDebug() << "Discovered Board: Bus " << downloader.board_list[i].bus
-    //              << " ID: " << downloader.board_list[i].pid
-    //              << " Status: " << downloader.board_list[i].status;
-    // }
-
     for(int i=0; i<downloader.board_list_size;i++){
         canBoards.append(downloader.board_list[i]);
     }
     currentAddress = address;
-    // qDebug() << "getCanBoardsFromEth returning" << canBoards.count() << "boards.";
 
     //downloader.stopdriver();
     mutex.unlock();
-
     return canBoards;
 
 }
@@ -1075,7 +1013,6 @@ bool FirmwareUpdaterCore::uploadCanApplication(QString filename,QString *resultS
 
 #else
 bool FirmwareUpdaterCore::uploadCanApplication(QString filename, QString *resultString, bool ee, QString address, int deviceId, QList<sBoard> *resultCanBoards)
-
 // bool FirmwareUpdaterCore::uploadCanApplication(QString filename,QString *resultString, bool ee, QString address,int deviceId,QList <sBoard> *resultCanBoards)
 {
 //    if(!address.isEmpty()){
@@ -1087,48 +1024,8 @@ bool FirmwareUpdaterCore::uploadCanApplication(QString filename, QString *result
 //        }
 
 //    }
-    // Debug inputs
-    // qDebug() << "uploadCanApplication called with:";
-    // qDebug() << "  filename:" << filename;
-    // qDebug() << "  address:" << address;
-    // qDebug() << "  deviceId:" << deviceId;
-    // qDebug() << "  resultCanBoards is null:" << (resultCanBoards == nullptr);
-    // if (resultCanBoards != nullptr) {
-    //     qDebug() << "  resultCanBoards size:" << resultCanBoards->size();
-    // }
-
-
-
-
-    if (filename.isEmpty() || resultCanBoards == nullptr) {
-        *resultString = "Invalid input: filename or resultCanBoards is null/empty.";
-        qDebug() << "Error: Invalid input. filename or resultCanBoards is null/empty.";
-
-        return false;
-    }
-
-    // Add debug statements here to inspect the board list
-    for (int i = 0; i < downloader.board_list_size; i++) {
-        qDebug() << "Board " << i
-                 << " Bus: " << downloader.board_list[i].bus
-                 << " ID: " << downloader.board_list[i].pid
-                 << " Selected: " << downloader.board_list[i].selected
-                 << " Status: " << downloader.board_list[i].status;
-    }
-
-
-
-
     // QString res;
     // QList<sBoard> boards;
-
-    // if(!address.isEmpty() && deviceId == -1){
-    //     getCanBoardsFromEth(address,&res);
-    // }else{
-    //     getCanBoardsFromDriver("SOCKETCAN",deviceId,&res);
-    // }
-
-
     if (resultCanBoards->size() == 1)
     {
         int canID = resultCanBoards->at(0).bus;

--- a/src/tools/FirmwareUpdater/firmwareupdatercore.h
+++ b/src/tools/FirmwareUpdater/firmwareupdatercore.h
@@ -36,6 +36,7 @@ public:
     boardInfo2_t getMoreDetails(int boardNum = EthMaintainer::ipv4OfAllSelected, QString *infoString = NULL, eOipv4addr_t *address = NULL);
     QList<sBoard> getCanBoardsFromEth(QString address, QString *retString, int canID = CanPacket::everyCANbus, bool force = false);
     QList<sBoard> getCanBoardsFromDriver(QString driver, int networkId, QString *retString, bool force = false);
+    QList<sBoard> getCanBoardsFromEthSINGLEONE(QString address, int canID, int canAddress, QString *retString);
     void blinkEthBoards();
     QString getEthBoardInfo(int index);
     QString getEthBoardAddress(int index);

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -1485,80 +1485,152 @@ int setBoardToMaintenance(FirmwareUpdaterCore *core,QString device,QString id,QS
     return 0;
 }
 
-
-int programCanDevice(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canId,QString file,bool eraseEEprom)
+int programCanDevice(FirmwareUpdaterCore *core, QString device, QString id, QString board, QString canLine, QString canId, QString file, bool eraseEEprom)
 {
     QString retString;
-    if(device.contains("ETH")){
-        int boards = core->connectTo(device,id);
-        if(boards > 0){
+
+    // Log the input parameters
+    qDebug() << "programCanDevice called with:";
+    qDebug() << "  device:" << device;
+    qDebug() << "  id:" << id;
+    qDebug() << "  board:" << board;
+    qDebug() << "  canLine:" << canLine;
+    qDebug() << "  canId:" << canId;
+    qDebug() << "  file:" << file;
+    qDebug() << "  eraseEEprom:" << eraseEEprom;
+
+    if (device.contains("ETH")) {
+        int boards = core->connectTo(device, id);
+        if (boards > 0) {
             char board_ipaddr[16];
-            for(int i=0;i<core->getEthBoardList().size();i++){
+            for (int i = 0; i < core->getEthBoardList().size(); i++) {
                 EthBoard ethBoard = core->getEthBoardList()[i];
                 snprintf(board_ipaddr, sizeof(board_ipaddr), "%s", ethBoard.getIPV4string().c_str());
 
-                if(board.contains(board_ipaddr)){
-                    core->setSelectedEthBoard(i,true);
-                    QList <sBoard> canBoards = core->getCanBoardsFromEth(board,&retString,canLine.toInt(),true);
-                    if(canBoards.count() > 0){
+                if (board.contains(board_ipaddr)) {
+                    core->setSelectedEthBoard(i, true);
+
+                    // Log the retrieved CAN boards
+                    QList<sBoard> canBoards = core->getCanBoardsFromEth(board, &retString, canLine.toInt(), true);
+                    qDebug() << "Retrieved CAN boards count:" << canBoards.count();
+
+                    if (canBoards.count() > 0) {
                         int selectedCount = 0;
-                        for(int j=0;j<canBoards.count();j++){
+                        for (int j = 0; j < canBoards.count(); j++) {
                             sBoard b = canBoards.at(j);
-                            if(b.bus == canLine.toInt() && b.pid == canId.toInt()){
+                            if (b.bus == canLine.toInt() && b.pid == canId.toInt()) {
                                 b.selected = true;
                                 b.eeprom = eraseEEprom;
-                                canBoards.replace(j,b);
+                                canBoards.replace(j, b);
                                 selectedCount++;
                             }
-
                         }
-                        if(selectedCount > 0){
-                            core->setSelectedCanBoards(canBoards,board);
-                            bool ret = core->uploadCanApplication(file, &retString, eraseEEprom, board);
-                            if(verbosity >= 1) qDebug() << retString;
+
+                        // Log the number of selected boards
+                        qDebug() << "Selected CAN boards count:" << selectedCount;
+
+                        if (selectedCount > 0) {
+                            core->setSelectedCanBoards(canBoards, board);
+
+                            // Log before calling uploadCanApplication
+                            qDebug() << "Calling uploadCanApplication with file:" << file;
+                            // bool ret = core->uploadCanApplication(file, &retString, eraseEEprom, board);
+                            QList<sBoard> resultCanBoards; // Declare resultCanBoards
+                            bool ret = core->uploadCanApplication(file, &retString, eraseEEprom, board, canLine.toInt(), &resultCanBoards);
+                            if (verbosity >= 1) qDebug() << retString;
                             return ret ? 0 : -1;
-                        }else{
-                            if(verbosity >= 1) qDebug() << "No board selected";
+                        } else {
+                            if (verbosity >= 1) qDebug() << "No board selected";
                             return -1;
                         }
-                    }else{
-                        if(verbosity >= 1) qDebug() << retString;
+                    } else {
+                        if (verbosity >= 1) qDebug() << retString;
                         return -1;
                     }
-
                 }
             }
-
-        }
-    }else{
-        QList <sBoard> canBoards = core->getCanBoardsFromDriver(device,id.toInt(),&retString,true);
-        if(canBoards.count() > 0){
-            int selectedCount = 0;
-            for(int j=0;j<canBoards.count();j++){
-                sBoard b = canBoards.at(j);
-                if(b.bus == canLine.toInt() && b.pid == canId.toInt()){
-                    b.selected = true;
-                    b.eeprom = eraseEEprom;
-                    canBoards.replace(j,b);
-                    selectedCount++;
-                }
-            }
-            if(selectedCount > 0){
-                core->setSelectedCanBoards(canBoards,device,id.toInt());
-                bool ret = core->uploadCanApplication(file, &retString, eraseEEprom, device, id.toInt());
-                if(verbosity >= 1) qDebug() << retString;
-                return ret ? 0 : -1;
-            }else{
-                if(verbosity >= 1) qDebug() << "No board selected";
-                return -1;
-            }
-        }else{
-            if(verbosity >= 1) qDebug() << retString;
-            return -1;
         }
     }
     return -1;
 }
+
+
+
+
+
+// int programCanDevice(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canId,QString file,bool eraseEEprom)
+// {
+//     QString retString;
+//     if(device.contains("ETH")){
+//         int boards = core->connectTo(device,id);
+//         if(boards > 0){
+//             char board_ipaddr[16];
+//             for(int i=0;i<core->getEthBoardList().size();i++){
+//                 EthBoard ethBoard = core->getEthBoardList()[i];
+//                 snprintf(board_ipaddr, sizeof(board_ipaddr), "%s", ethBoard.getIPV4string().c_str());
+
+//                 if(board.contains(board_ipaddr)){
+//                     core->setSelectedEthBoard(i,true);
+//                     QList <sBoard> canBoards = core->getCanBoardsFromEth(board,&retString,canLine.toInt(),true);
+//                     if(canBoards.count() > 0){
+//                         int selectedCount = 0;
+//                         for(int j=0;j<canBoards.count();j++){
+//                             sBoard b = canBoards.at(j);
+//                             if(b.bus == canLine.toInt() && b.pid == canId.toInt()){
+//                                 b.selected = true;
+//                                 b.eeprom = eraseEEprom;
+//                                 canBoards.replace(j,b);
+//                                 selectedCount++;
+//                             }
+
+//                         }
+//                         if(selectedCount > 0){
+//                             core->setSelectedCanBoards(canBoards,board);
+//                             bool ret = core->uploadCanApplication(file, &retString, eraseEEprom, board);
+//                             if(verbosity >= 1) qDebug() << retString;
+//                             return ret ? 0 : -1;
+//                         }else{
+//                             if(verbosity >= 1) qDebug() << "No board selected";
+//                             return -1;
+//                         }
+//                     }else{
+//                         if(verbosity >= 1) qDebug() << retString;
+//                         return -1;
+//                     }
+
+//                 }
+//             }
+
+//         }
+//     }else{
+//         QList <sBoard> canBoards = core->getCanBoardsFromDriver(device,id.toInt(),&retString,true);
+//         if(canBoards.count() > 0){
+//             int selectedCount = 0;
+//             for(int j=0;j<canBoards.count();j++){
+//                 sBoard b = canBoards.at(j);
+//                 if(b.bus == canLine.toInt() && b.pid == canId.toInt()){
+//                     b.selected = true;
+//                     b.eeprom = eraseEEprom;
+//                     canBoards.replace(j,b);
+//                     selectedCount++;
+//                 }
+//             }
+//             if(selectedCount > 0){
+//                 core->setSelectedCanBoards(canBoards,device,id.toInt());
+//                 bool ret = core->uploadCanApplication(file, &retString, eraseEEprom, device, id.toInt());
+//                 if(verbosity >= 1) qDebug() << retString;
+//                 return ret ? 0 : -1;
+//             }else{
+//                 if(verbosity >= 1) qDebug() << "No board selected";
+//                 return -1;
+//             }
+//         }else{
+//             if(verbosity >= 1) qDebug() << retString;
+//             return -1;
+//         }
+//     }
+//     return -1;
+// }
 
 
 int programEthDevice(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString file)

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -1490,14 +1490,14 @@ int programCanDevice(FirmwareUpdaterCore *core, QString device, QString id, QStr
     QString retString;
 
     // Log the input parameters
-    qDebug() << "programCanDevice called with:";
-    qDebug() << "  device:" << device;
-    qDebug() << "  id:" << id;
-    qDebug() << "  board:" << board;
-    qDebug() << "  canLine:" << canLine;
-    qDebug() << "  canId:" << canId;
-    qDebug() << "  file:" << file;
-    qDebug() << "  eraseEEprom:" << eraseEEprom;
+    // qDebug() << "programCanDevice called with:";
+    // qDebug() << "  device:" << device;
+    // qDebug() << "  id:" << id;
+    // qDebug() << "  board:" << board;
+    // qDebug() << "  canLine:" << canLine;
+    // qDebug() << "  canId:" << canId;
+    // qDebug() << "  file:" << file;
+    // qDebug() << "  eraseEEprom:" << eraseEEprom;
 
     if (device.contains("ETH")) {
         int boards = core->connectTo(device, id);
@@ -1512,7 +1512,7 @@ int programCanDevice(FirmwareUpdaterCore *core, QString device, QString id, QStr
 
                     // Log the retrieved CAN boards
                     QList<sBoard> canBoards = core->getCanBoardsFromEth(board, &retString, canLine.toInt(), true);
-                    qDebug() << "Retrieved CAN boards count:" << canBoards.count();
+                    // qDebug() << "Retrieved CAN boards count:" << canBoards.count();
 
                     if (canBoards.count() > 0) {
                         int selectedCount = 0;
@@ -1527,7 +1527,7 @@ int programCanDevice(FirmwareUpdaterCore *core, QString device, QString id, QStr
                         }
 
                         // Log the number of selected boards
-                        qDebug() << "Selected CAN boards count:" << selectedCount;
+                        // qDebug() << "Selected CAN boards count:" << selectedCount;
 
                         if (selectedCount > 0) {
                             core->setSelectedCanBoards(canBoards, board);

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -1485,55 +1485,35 @@ int setBoardToMaintenance(FirmwareUpdaterCore *core,QString device,QString id,QS
     return 0;
 }
 
-int programCanDevice(FirmwareUpdaterCore *core, QString device, QString id, QString board, QString canLine, QString canId, QString file, bool eraseEEprom)
+
+int programCanDevice(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString canLine,QString canId,QString file,bool eraseEEprom)
 {
     QString retString;
-
-    // Log the input parameters
-    // qDebug() << "programCanDevice called with:";
-    // qDebug() << "  device:" << device;
-    // qDebug() << "  id:" << id;
-    // qDebug() << "  board:" << board;
-    // qDebug() << "  canLine:" << canLine;
-    // qDebug() << "  canId:" << canId;
-    // qDebug() << "  file:" << file;
-    // qDebug() << "  eraseEEprom:" << eraseEEprom;
-
-    if (device.contains("ETH")) {
-        int boards = core->connectTo(device, id);
-        if (boards > 0) {
+    if(device.contains("ETH")){
+        int boards = core->connectTo(device,id);
+        if(boards > 0){
             char board_ipaddr[16];
-            for (int i = 0; i < core->getEthBoardList().size(); i++) {
+            for(int i=0;i<core->getEthBoardList().size();i++){
                 EthBoard ethBoard = core->getEthBoardList()[i];
                 snprintf(board_ipaddr, sizeof(board_ipaddr), "%s", ethBoard.getIPV4string().c_str());
 
-                if (board.contains(board_ipaddr)) {
-                    core->setSelectedEthBoard(i, true);
-
-                    // Log the retrieved CAN boards
-                    QList<sBoard> canBoards = core->getCanBoardsFromEth(board, &retString, canLine.toInt(), true);
-                    // qDebug() << "Retrieved CAN boards count:" << canBoards.count();
-
-                    if (canBoards.count() > 0) {
+                if(board.contains(board_ipaddr)){
+                    core->setSelectedEthBoard(i,true);
+                    QList <sBoard> canBoards = core->getCanBoardsFromEth(board,&retString,canLine.toInt(),true);
+                    if(canBoards.count() > 0){
                         int selectedCount = 0;
-                        for (int j = 0; j < canBoards.count(); j++) {
+                        for(int j=0;j<canBoards.count();j++){
                             sBoard b = canBoards.at(j);
-                            if (b.bus == canLine.toInt() && b.pid == canId.toInt()) {
+                            if(b.bus == canLine.toInt() && b.pid == canId.toInt()){
                                 b.selected = true;
                                 b.eeprom = eraseEEprom;
-                                canBoards.replace(j, b);
+                                canBoards.replace(j,b);
                                 selectedCount++;
                             }
+
                         }
-
-                        // Log the number of selected boards
-                        // qDebug() << "Selected CAN boards count:" << selectedCount;
-
-                        if (selectedCount > 0) {
-                            core->setSelectedCanBoards(canBoards, board);
-
-                            // Log before calling uploadCanApplication
-                            qDebug() << "Calling uploadCanApplication with file:" << file;
+                        if(selectedCount > 0){
+                            core->setSelectedCanBoards(canBoards,board);
                             // bool ret = core->uploadCanApplication(file, &retString, eraseEEprom, board);
                             QList<sBoard> resultCanBoards; // Declare resultCanBoards
                             bool ret = core->uploadCanApplication(file, &retString, eraseEEprom, board, canLine.toInt(), &resultCanBoards);
@@ -1547,9 +1527,10 @@ int programCanDevice(FirmwareUpdaterCore *core, QString device, QString id, QStr
                         if (verbosity >= 1) qDebug() << retString;
                         return -1;
                     }
+
                 }
             }
-        }
+        } 
     }
     return -1;
 }

--- a/src/tools/canLoader/canLoaderLib/downloader.h
+++ b/src/tools/canLoader/canLoaderLib/downloader.h
@@ -175,6 +175,8 @@ void set_canbus_id      (int id);
 int strain_start_sampling    (int bus, int target_id, string *errorstring = NULL);
 int strain_stop_sampling     (int bus, int target_id, string *errorstring = NULL);
 
+int initSINGLEBOARD(int canbus, int canaddress, icubCanProto_boardType_t boardtype);
+
 float strain_amplifier_discretegain2float(strain2_ampl_discretegain_t c);
 
 // the strain2 has multiple (up to 3) regulation sets. with these functions we can get / set the regulation set in use inside the strain2.


### PR DESCRIPTION
This update introduces a more robust and targeted approach for CAN board discovery during firmware updates in the FirmwareUpdater, specifically within the function FirmwareUpdaterCore::uploadCanApplication. 

When updating a single CAN board, the system now uses a new unicast discovery method with multiple retries, implemented in cDownloader::initSINGLEBOARD and accessed via FirmwareUpdaterCore::getCanBoardsFromEthSINGLEONE, rather than relying solely on broadcast discovery (cDownloader::initschede and FirmwareUpdaterCore::getCanBoardsFromEth). 

This change improves reliability in scenarios where broadcast messages may not reach all boards, addressing cases where a board fails to respond and the update does not proceed. The implementation includes these new functions for single-board discovery and integrates them into the firmware update workflow, while maintaining backward compatibility for multi-board updates. 