### PR TITLE
Add further check for eomn_serv_MC_mc4plusmais device

### DIFF
--- a/src/libraries/icubmod/embObjLib/serviceParser.cpp
+++ b/src/libraries/icubmod/embObjLib/serviceParser.cpp
@@ -3211,7 +3211,7 @@ bool ServiceParser::check_motion(Searchable &config)
     } // has_PROPERTIES_CANBOARDS
 
 
-    if(true == has_PROPERTIES_MAIS)
+    if(true == has_PROPERTIES_MAIS && mc_service.type == eomn_serv_MC_mc4plusmais)
     {
         // i get .location and nothing else
 


### PR DESCRIPTION
As per title, this further check will allow the group [`MAIS`](https://github.com/robotology/robots-configuration/blob/1d292659dc4777b5d5c20d2a702fe8968ea9f8ef/iCubGenova11/hardware/motorControl/right_arm-eb28-j8_11-mc_service.xml#L29-L31) within the motorControl service XML file to be parsed only when the device is of type `eomn_serv_MC_mc4plusmais`, otherwise will be ignored by the parser.
