### PR TITLE
Timeout parameters for PWM, current and torque setpoints added to protocol

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -64,7 +64,7 @@ checkandset_dependency(IPOPT)
 checkandset_dependency(OpenCV)
 checkandset_dependency(Qt5)
 
-set(MINIMUM_REQUIRED_icub_firmware_shared_VERSION 1.43.2)
+set(MINIMUM_REQUIRED_icub_firmware_shared_VERSION 1.43.3)
 
 if(icub_firmware_shared_FOUND AND ICUB_USE_icub_firmware_shared)
   if(icub_firmware_shared_VERSION VERSION_LESS ${MINIMUM_REQUIRED_icub_firmware_shared_VERSION})

--- a/src/libraries/icubmod/embObjLib/diagnosticInfoParsers.cpp
+++ b/src/libraries/icubmod/embObjLib/diagnosticInfoParsers.cpp
@@ -815,6 +815,31 @@ void MotionControlParser::parseInfo()
                                         );
             m_dnginfo.baseInfo.finalMessage.append(str);
         } break;
+        
+        case eoerror_value_MC_ref_setpoint_timeout:
+        {
+            uint16_t joint_num = m_dnginfo.param16;
+            int16_t timeout_type = m_dnginfo.param64 & 0xff;
+            
+            char* timeout_type_str = 0;
+            
+            switch(timeout_type)
+            {
+                case eoerror_value_MC_ref_timeout_torque:  timeout_type_str = "TORQUE";  break;
+                case eoerror_value_MC_ref_timeout_current: timeout_type_str = "CURRENT"; break;
+                case eoerror_value_MC_ref_timeout_pwm:     timeout_type_str = "PWM";     break;
+                default: timeout_type_str = "UNKNOWN"; break;
+            }
+
+            m_entityNameProvider.getAxisName(joint_num, m_dnginfo.baseInfo.axisName);
+            
+            snprintf(str, sizeof(str), " %s (Joint=%s (NIB=%d), %s setpoint timeout)",
+                     m_dnginfo.baseMessage.c_str(), m_dnginfo.baseInfo.axisName.c_str(), joint_num, timeout_type_str);
+            
+            snprintf(str, sizeof(str), " %s (Joint=%s (NIB=%d)). The board isn't receiving %s reference setpoint commands and has been faulted to prevent damage.",
+                     m_dnginfo.baseMessage.c_str(), m_dnginfo.baseInfo.axisName.c_str(), joint_num, timeout_type_str);
+            m_dnginfo.baseInfo.finalMessage.append(str);
+        } break;
 
         case eoerror_value_MC_motor_tdb_not_reading:
         {

--- a/src/libraries/icubmod/embObjLib/diagnosticInfoParsers.cpp
+++ b/src/libraries/icubmod/embObjLib/diagnosticInfoParsers.cpp
@@ -833,9 +833,6 @@ void MotionControlParser::parseInfo()
 
             m_entityNameProvider.getAxisName(joint_num, m_dnginfo.baseInfo.axisName);
             
-            snprintf(str, sizeof(str), " %s (Joint=%s (NIB=%d), %s setpoint timeout)",
-                     m_dnginfo.baseMessage.c_str(), m_dnginfo.baseInfo.axisName.c_str(), joint_num, timeout_type_str);
-            
             snprintf(str, sizeof(str), " %s (Joint=%s (NIB=%d)). The board isn't receiving %s reference setpoint commands and has been faulted to prevent damage.",
                      m_dnginfo.baseMessage.c_str(), m_dnginfo.baseInfo.axisName.c_str(), joint_num, timeout_type_str);
             m_dnginfo.baseInfo.finalMessage.append(str);

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -1043,11 +1043,17 @@ bool embObjMotionControl::fromConfig_Step2(yarp::os::Searchable &config)
             _temperatureSensorsVector.at(j) = std::make_unique<eomc::TemperatureSensorNONE>();
         }
     }
-    
 
+    int defaultTimeout = 100;
+
+    if (this->serviceConfig.ethservice.configuration.type == eomn_serv_MC_advfoc)
+    {
+        // in this case the default timeout is 100ms
+        defaultTimeout = 300;
+    }
 
     /////// [TIMEOUTS]
-    if(! _mcparser->parseTimeoutsGroup(config, _timeouts, 1000 /*defaultVelocityTimeout*/))
+    if(! _mcparser->parseTimeoutsGroup(config, _timeouts, defaultTimeout))
         return false;
 
 

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -1048,7 +1048,8 @@ bool embObjMotionControl::fromConfig_Step2(yarp::os::Searchable &config)
 
     if (this->serviceConfig.ethservice.configuration.type == eomn_serv_MC_advfoc)
     {
-        // in this case the default timeout is 100ms
+        // temporary workaround
+        // in this case the default timeout is 300 ms because there is some lag in AMC
         defaultTimeout = 300;
     }
 

--- a/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/embObjMotionControl.cpp
@@ -1406,7 +1406,11 @@ bool embObjMotionControl::init()
 
 
         jconfig.maxvelocityofjoint = S_32(_measureConverter->posA2E(_jointsLimits[logico].velMax, fisico)); //icubdeg/s
-        jconfig.velocitysetpointtimeout = (eOmeas_time_t) U_16(_timeouts[logico].velocity);
+        jconfig.velocitysetpointtimeout = (eOmeas_time_t) U_16(_timeouts[logico].velocity_ref);
+        jconfig.currentsetpointtimeout = (eOmeas_time_t) U_16(_timeouts[logico].current_ref);
+        jconfig.openloopsetpointtimeout = (eOmeas_time_t) U_16(_timeouts[logico].pwm_ref);
+        jconfig.torquesetpointtimeout = (eOmeas_time_t) U_16(_timeouts[logico].torque_ref);
+        jconfig.torquefeedbacktimeout = (eOmeas_time_t) U_16(_timeouts[logico].torque_fbk);
 
         jconfig.jntEncoderResolution = _jointEncs[logico].resolution;
         jconfig.jntEncoderType = _jointEncs[logico].type;

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -1671,7 +1671,7 @@ bool Parser::parseJointsetCfgGroup(yarp::os::Searchable &config, std::vector<Joi
     return true;
 }
 
-bool Parser::parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeouts_t> &timeouts, int defaultVelocityTimeout)
+bool Parser::parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeouts_t> &timeouts, int defaultTimeout)
 {
     if(!checkAndSetVectorSize(timeouts, _njoints, "parseTimeoutsGroup"))
         return false;
@@ -1691,7 +1691,7 @@ bool Parser::parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeou
     {
         yWarning() << "embObjMC BOARD " << _boardname << " no velocity parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
         for(i=0; i<_njoints; i++)
-            timeouts[i].velocity_ref = 100;
+            timeouts[i].velocity_ref = defaultTimeout;
     }
     else
     {
@@ -1704,7 +1704,7 @@ bool Parser::parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeou
     {
         yWarning() << "embObjMC BOARD " << _boardname << " no current parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
         for(i=0; i<_njoints; i++)
-            timeouts[i].current_ref = 100;        
+            timeouts[i].current_ref = defaultTimeout;        
     }
     else
     {
@@ -1717,7 +1717,7 @@ bool Parser::parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeou
     {
         yWarning() << "embObjMC BOARD " << _boardname << " no pwm parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
         for(i=0; i<_njoints; i++)
-            timeouts[i].pwm_ref = 100;
+            timeouts[i].pwm_ref = defaultTimeout;
     }
     else
     {
@@ -1730,7 +1730,7 @@ bool Parser::parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeou
     {
         yWarning() << "embObjMC BOARD " << _boardname << " no torque parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
         for(i=0; i<_njoints; i++)
-            timeouts[i].torque_ref = 100;
+            timeouts[i].torque_ref = defaultTimeout;
     }
     else
     {
@@ -1743,7 +1743,7 @@ bool Parser::parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeou
     {
         yWarning() << "embObjMC BOARD " << _boardname << " no torque_measure parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
         for(i=0; i<_njoints; i++)
-            timeouts[i].torque_fbk = 100;
+            timeouts[i].torque_fbk = defaultTimeout;
     }
     else
     {

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -1687,17 +1687,69 @@ bool Parser::parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeou
 
     Bottle xtmp;
     xtmp.clear();
-    if (!extractGroup(timeoutsGroup, xtmp, "velocity", "a list of timeout to be used in the vmo control", _njoints))
+    if (!extractGroup(timeoutsGroup, xtmp, "velocity", "a list of timeout to be used in the vmo control", _njoints, false))
     {
-        yError() << "embObjMC BOARD " << _boardname << " no velocity parameter found in TIMEOUTS group in motion control config file.";
-        return false;
+        yWarning() << "embObjMC BOARD " << _boardname << " no velocity parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
+        for(i=0; i<_njoints; i++)
+            timeouts[i].velocity_ref = 100;
     }
     else
     {
         for(i=1; i<xtmp.size(); i++)
-            timeouts[i-1].velocity = xtmp.get(i).asInt32();
+            timeouts[i-1].velocity_ref = xtmp.get(i).asInt32();
+    }
+    
+    xtmp.clear();
+    if (!extractGroup(timeoutsGroup, xtmp, "current", "a list of timeout to be used in the vmo control", _njoints, false))
+    {
+        yWarning() << "embObjMC BOARD " << _boardname << " no current parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
+        for(i=0; i<_njoints; i++)
+            timeouts[i].current_ref = 100;        
+    }
+    else
+    {
+        for(i=1; i<xtmp.size(); i++)
+            timeouts[i-1].current_ref = xtmp.get(i).asInt32();
     }
 
+    xtmp.clear();
+    if (!extractGroup(timeoutsGroup, xtmp, "pwm", "a list of timeout to be used in the vmo control", _njoints, false))
+    {
+        yWarning() << "embObjMC BOARD " << _boardname << " no pwm parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
+        for(i=0; i<_njoints; i++)
+            timeouts[i].pwm_ref = 100;
+    }
+    else
+    {
+        for(i=1; i<xtmp.size(); i++)
+            timeouts[i-1].pwm_ref = xtmp.get(i).asInt32();
+    }
+
+    xtmp.clear();
+    if (!extractGroup(timeoutsGroup, xtmp, "torque", "a list of timeout to be used in the vmo control", _njoints, false))
+    {
+        yWarning() << "embObjMC BOARD " << _boardname << " no torque parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
+        for(i=0; i<_njoints; i++)
+            timeouts[i].torque_ref = 100;
+    }
+    else
+    {
+        for(i=1; i<xtmp.size(); i++)
+            timeouts[i-1].torque_ref = xtmp.get(i).asInt32();
+    }
+
+    xtmp.clear();
+    if (!extractGroup(timeoutsGroup, xtmp, "torque_measure", "a list of timeout to be used in the vmo control", _njoints, false))
+    {
+        yWarning() << "embObjMC BOARD " << _boardname << " no torque_measure parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
+        for(i=0; i<_njoints; i++)
+            timeouts[i].torque_fbk = 100;
+    }
+    else
+    {
+        for(i=1; i<xtmp.size(); i++)
+            timeouts[i-1].torque_fbk = xtmp.get(i).asInt32();
+    }
 
     return true;
 

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.cpp
@@ -1689,7 +1689,7 @@ bool Parser::parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeou
     xtmp.clear();
     if (!extractGroup(timeoutsGroup, xtmp, "velocity", "a list of timeout to be used in the vmo control", _njoints, false))
     {
-        yWarning() << "embObjMC BOARD " << _boardname << " no velocity parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
+        yWarning() << "embObjMC BOARD " << _boardname << " no velocity parameter found in TIMEOUTS group in motion control config file, using default = " << defaultTimeout << " ms.";
         for(i=0; i<_njoints; i++)
             timeouts[i].velocity_ref = defaultTimeout;
     }
@@ -1702,7 +1702,7 @@ bool Parser::parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeou
     xtmp.clear();
     if (!extractGroup(timeoutsGroup, xtmp, "current", "a list of timeout to be used in the vmo control", _njoints, false))
     {
-        yWarning() << "embObjMC BOARD " << _boardname << " no current parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
+        yWarning() << "embObjMC BOARD " << _boardname << " no current parameter found in TIMEOUTS group in motion control config file, using default = " << defaultTimeout << " ms.";
         for(i=0; i<_njoints; i++)
             timeouts[i].current_ref = defaultTimeout;        
     }
@@ -1715,7 +1715,7 @@ bool Parser::parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeou
     xtmp.clear();
     if (!extractGroup(timeoutsGroup, xtmp, "pwm", "a list of timeout to be used in the vmo control", _njoints, false))
     {
-        yWarning() << "embObjMC BOARD " << _boardname << " no pwm parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
+        yWarning() << "embObjMC BOARD " << _boardname << " no pwm parameter found in TIMEOUTS group in motion control config file, using default = " << defaultTimeout << " ms.";
         for(i=0; i<_njoints; i++)
             timeouts[i].pwm_ref = defaultTimeout;
     }
@@ -1728,7 +1728,7 @@ bool Parser::parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeou
     xtmp.clear();
     if (!extractGroup(timeoutsGroup, xtmp, "torque", "a list of timeout to be used in the vmo control", _njoints, false))
     {
-        yWarning() << "embObjMC BOARD " << _boardname << " no torque parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
+        yWarning() << "embObjMC BOARD " << _boardname << " no torque parameter found in TIMEOUTS group in motion control config file, using default = " << defaultTimeout << " ms.";
         for(i=0; i<_njoints; i++)
             timeouts[i].torque_ref = defaultTimeout;
     }
@@ -1741,7 +1741,7 @@ bool Parser::parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeou
     xtmp.clear();
     if (!extractGroup(timeoutsGroup, xtmp, "torque_measure", "a list of timeout to be used in the vmo control", _njoints, false))
     {
-        yWarning() << "embObjMC BOARD " << _boardname << " no torque_measure parameter found in TIMEOUTS group in motion control config file, using default = 100 ms.";
+        yWarning() << "embObjMC BOARD " << _boardname << " no torque_measure parameter found in TIMEOUTS group in motion control config file, using default = " << defaultTimeout << " ms.";
         for(i=0; i<_njoints; i++)
             timeouts[i].torque_fbk = defaultTimeout;
     }

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.h
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.h
@@ -651,7 +651,7 @@ public:
     bool parseFocGroup(yarp::os::Searchable &config, focBasedSpecificInfo_t *foc_based_info, std::string groupName, std::vector<std::unique_ptr<eomc::ITemperatureSensor>>& temperatureSensorsVector);
     //bool parseCurrentPid(yarp::os::Searchable &config, PidInfo *cpids);//deprecated
     bool parseJointsetCfgGroup(yarp::os::Searchable &config, std::vector<JointsSet> &jsets, std::vector<int> &jointtoset);
-    bool parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeouts_t> &timeouts, int defaultVelocityTimeout);
+    bool parseTimeoutsGroup(yarp::os::Searchable &config, std::vector<timeouts_t> &timeouts, int defaultTimeout);
     bool parseCurrentLimits(yarp::os::Searchable &config, std::vector<motorCurrentLimits_t> &currLimits);
     bool parseTemperatureLimits(yarp::os::Searchable &config, std::vector<temperatureLimits_t> &temperatureLimits);
     bool parseJointsLimits(yarp::os::Searchable &config, std::vector<jointLimits_t> &jointsLimits);

--- a/src/libraries/icubmod/embObjMotionControl/eomcParser.h
+++ b/src/libraries/icubmod/embObjMotionControl/eomcParser.h
@@ -449,7 +449,11 @@ public:
 
 typedef struct
 {
-    int velocity;
+    int velocity_ref;
+    int current_ref;
+    int pwm_ref;
+    int torque_ref;
+    int torque_fbk;
 } timeouts_t;
 
 typedef struct


### PR DESCRIPTION
I've added configurable timeouts for PWM, current and torque setpoints, and timeout for torque feedback.
The timeout for torque measure was already implemented, but it wasn't  configurable.
Only the velocity timeout is mandatory in configurable files because (same as before), and the other parameters are optional with default value = 100 ms to maintain compatibility. A value of 0 disables the watchdog.
In order to use the yarpmotorgui in PWM, current and torque modes these values must be set to 0 in the configuration files. 