### PR TITLE
Remove find_package(iCubDev) from fineCalibrationChecker

### DIFF
--- a/src/tools/fineCalibrationChecker/CMakeLists.txt
+++ b/src/tools/fineCalibrationChecker/CMakeLists.txt
@@ -5,7 +5,7 @@
 project(fineCalibrationChecker)
 # find YARP
 find_package(YARP COMPONENTS os sig dev)
-find_package(iCubDev 2.7.0 QUIET)
+
 # set up our program
 add_executable(${PROJECT_NAME} 
     ./src/FineCalibrationCheckerModule.h 


### PR DESCRIPTION
Multiple-config CI builds of the robotology-superbuild started failing with error:

~~~
2025-06-30T12:46:04.2371322Z   -- Found YARP: C:/robotology/robotology/lib/cmake/YARP (found version "3.12.0+1-20250604.5+git285f6317e")
2025-06-30T12:46:04.2757524Z   CMake Error at C:/robotology-superbuild/build/src/ICUB/iCubDev/iCubDevConfig.cmake:21 (include):
2025-06-30T12:46:04.2758248Z     include could not find requested file:
2025-06-30T12:46:04.2758639Z   
2025-06-30T12:46:04.2758905Z       C:/robotology-superbuild/build/src/ICUB/iCubDev/iCubDevTargets.cmake
2025-06-30T12:46:04.2759257Z   Call Stack (most recent call first):
2025-06-30T12:46:04.2759602Z     C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake:824 (_find_package)
2025-06-30T12:46:04.2760039Z     src/tools/fineCalibrationChecker/CMakeLists.txt:8 (find_package)
~~~

I tried to understand the reason behind that, but then I gave up, as I do not see the point of having `find_package(iCubDev 2.7.0 QUIET)`. In this context,  `ICUB::iCubDev` is already defined by the ICUB build system, and as this CMakeLists.txt does not contain any `cmake_minimum_required` call, so I think we can just remove `find_package(iCubDev 2.7.0 QUIET)` and call it a day.