### PR TITLE
diagnosticInfoParsers: Remove intermediate upcast to int in uint8_t to uint8_t assignment

### DIFF
--- a/src/libraries/icubmod/embObjLib/diagnosticInfoParsers.cpp
+++ b/src/libraries/icubmod/embObjLib/diagnosticInfoParsers.cpp
@@ -556,7 +556,7 @@ void ConfigParser::parseInfo()
             uint8_t bus          = (m_dnginfo.param64 & MASK_BUS)          >> SHIFT_BUS;
 
             uint16_t invalidmask = m_dnginfo.param16;
-            eOlocation_t location = { static_cast<eObus_t>(bus), 0, address};
+            eOlocation_t location = { bus, 0, address};
             char location_str[64];
             ServiceParser parser;
             parser.convert(location, &location_str[0], sizeof(location_str));


### PR DESCRIPTION
Down in robotology-superbuild CI, I saw this evening errors like:

~~~
2025-07-08T18:34:50.8721830Z /Users/runner/work/robotology-superbuild/robotology-superbuild/src/ICUB/src/libraries/icubmod/embObjLib/diagnosticInfoParsers.cpp:559:39: error: non-constant-expression cannot be narrowed from type 'eObus_t' to 'uint8_t' (aka 'unsigned char') in initializer list [-Wc++11-narrowing]
2025-07-08T18:34:50.9726850Z   559 |             eOlocation_t location = { static_cast<eObus_t>(bus), 0, address};
2025-07-08T18:34:51.0729820Z       |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~
2025-07-08T18:34:51.1734290Z /Users/runner/work/robotology-superbuild/robotology-superbuild/src/ICUB/src/libraries/icubmod/embObjLib/diagnosticInfoParsers.cpp:559:39: note: insert an explicit cast to silence this issue
2025-07-08T18:34:51.2473210Z   559 |             eOlocation_t location = { static_cast<eObus_t>(bus), 0, address};
2025-07-08T18:34:51.3374950Z       |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~
2025-07-08T18:34:51.3915830Z       |                                       static_cast<uint8_t>(    )
~~~

see https://github.com/robotology/robotology-superbuild/actions/runs/16150522106/job/45580392587 .

Indeed, looking at the code it seems that we are upcasting a `uint8_t` to `int` that is then converted back to `uint8_t`, so I think we can directly assign the `uint8_t` to `uint8_t` to keep things simple.