### PR TITLE
Bug Fix: `FirmwareUpdater` update of CAN boards 

### DIFF
--- a/src/tools/FirmwareUpdater/firmwareupdatercore.h
+++ b/src/tools/FirmwareUpdater/firmwareupdatercore.h
@@ -36,7 +36,6 @@ public:
     boardInfo2_t getMoreDetails(int boardNum = EthMaintainer::ipv4OfAllSelected, QString *infoString = NULL, eOipv4addr_t *address = NULL);
     QList<sBoard> getCanBoardsFromEth(QString address, QString *retString, int canID = CanPacket::everyCANbus, bool force = false);
     QList<sBoard> getCanBoardsFromDriver(QString driver, int networkId, QString *retString, bool force = false);
-    QList<sBoard> discoverSingleCanBoardViaEth(QString address, int canID, int canAddress, QString *retString);
     void blinkEthBoards();
     QString getEthBoardInfo(int index);
     QString getEthBoardAddress(int index);

--- a/src/tools/FirmwareUpdater/main.cpp
+++ b/src/tools/FirmwareUpdater/main.cpp
@@ -1514,26 +1514,52 @@ int programCanDevice(FirmwareUpdaterCore *core,QString device,QString id,QString
                         }
                         if(selectedCount > 0){
                             core->setSelectedCanBoards(canBoards,board);
-                            // bool ret = core->uploadCanApplication(file, &retString, eraseEEprom, board);
-                            QList<sBoard> resultCanBoards; // Declare resultCanBoards
-                            bool ret = core->uploadCanApplication(file, &retString, eraseEEprom, board, canLine.toInt(), &resultCanBoards);
-                            if (verbosity >= 1) qDebug() << retString;
+                            bool ret = core->uploadCanApplication(file, &retString, eraseEEprom, board);
+                            if(verbosity >= 1) qDebug() << retString;
                             return ret ? 0 : -1;
-                        } else {
-                            if (verbosity >= 1) qDebug() << "No board selected";
+                        }else{
+                            if(verbosity >= 1) qDebug() << "No board selected";
                             return -1;
                         }
-                    } else {
-                        if (verbosity >= 1) qDebug() << retString;
+                    }else{
+                        if(verbosity >= 1) qDebug() << retString;
                         return -1;
                     }
 
                 }
             }
-        } 
+
+        }
+    }else{
+        QList <sBoard> canBoards = core->getCanBoardsFromDriver(device,id.toInt(),&retString,true);
+        if(canBoards.count() > 0){
+            int selectedCount = 0;
+            for(int j=0;j<canBoards.count();j++){
+                sBoard b = canBoards.at(j);
+                if(b.bus == canLine.toInt() && b.pid == canId.toInt()){
+                    b.selected = true;
+                    b.eeprom = eraseEEprom;
+                    canBoards.replace(j,b);
+                    selectedCount++;
+                }
+            }
+            if(selectedCount > 0){
+                core->setSelectedCanBoards(canBoards,device,id.toInt());
+                bool ret = core->uploadCanApplication(file, &retString, eraseEEprom, device, id.toInt());
+                if(verbosity >= 1) qDebug() << retString;
+                return ret ? 0 : -1;
+            }else{
+                if(verbosity >= 1) qDebug() << "No board selected";
+                return -1;
+            }
+        }else{
+            if(verbosity >= 1) qDebug() << retString;
+            return -1;
+        }
     }
     return -1;
 }
+
 
 int programEthDevice(FirmwareUpdaterCore *core,QString device,QString id,QString board,QString file)
 {

--- a/src/tools/canLoader/canLoaderLib/downloader.h
+++ b/src/tools/canLoader/canLoaderLib/downloader.h
@@ -175,8 +175,6 @@ void set_canbus_id      (int id);
 int strain_start_sampling    (int bus, int target_id, string *errorstring = NULL);
 int strain_stop_sampling     (int bus, int target_id, string *errorstring = NULL);
 
-int initSINGLEBOARD(int canbus, int canaddress);
-
 float strain_amplifier_discretegain2float(strain2_ampl_discretegain_t c);
 
 // the strain2 has multiple (up to 3) regulation sets. with these functions we can get / set the regulation set in use inside the strain2.


### PR DESCRIPTION
 This PR reverts the changes of the previous PR https://github.com/robotology/icub-main/pull/1020.

The fix is required because the above PR surely is more robust in discovering boards that don't behave well to broadcast messages (namely, the `mtb4` board before this [PR](https://github.com/robotology/icub-firmware-build/pull/211)) but has added code that prevents the FW update of any CAN board.

Now the update fails by showing the following message that is due to an initialization UDP message sent more than once to the `ETH` board.

![image](https://github.com/user-attachments/assets/cc205057-94e5-4d02-8145-b604181392cb)


As a quick and easy solution I prefer for now to revert back to a safe operation mode and later to design the best way to add the features of PR #1020 without side effect.



I have tested the changes on a dedicated setup, used the `FirmwareUpdater` GUI and successfully updated an `amcblc` and a `mtb4` board that cannot be updated w/ the current master release.

```
EthMaintainer::go2maintenance() succesfully sent in maintenance board 0.0.0.0 after 3 attempts
programming /home/acemor/rob/robotology-superbuild/src/icub-firmware-build/CAN/amcbldc/amcbldc.hex: 1% done
programming /home/acemor/rob/robotology-superbuild/src/icub-firmware-build/CAN/amcbldc/amcbldc.hex: 25% done
programming /home/acemor/rob/robotology-superbuild/src/icub-firmware-build/CAN/amcbldc/amcbldc.hex: 50% done
programming /home/acemor/rob/robotology-superbuild/src/icub-firmware-build/CAN/amcbldc/amcbldc.hex: 75% done
programming /home/acemor/rob/robotology-superbuild/src/icub-firmware-build/CAN/amcbldc/amcbldc.hex: finished!
EthMaintainer::command_restart(0.0.0.0): 1
ACE_INET_Addr::get_ip_address: address is a IPv6 address not IPv4
ACE_INET_Addr::get_ip_address: address is a IPv6 address not IPv4
ACE_INET_Addr::get_ip_address: address is a IPv6 address not IPv4
ACE_INET_Addr::get_ip_address: address is a IPv6 address not IPv4
FirmwareUpdaterCore::getCanBoardsFromEth(): No CAN boards found beneath  "10.0.1.5"  after a successful driver init.
EthMaintainer::command_restart(0.0.0.0): 1
EthMaintainer::processDiscoveryReplies2() has found a board @ 10.0.1.5: ems4 w/ eApplication v3.105 running protocol v2 w/ capabilities = 0x60030030. mainteinance = OFF
EthMaintainer::processDiscoveryReplies2() has found a board @ 10.0.1.5: ems4 w/ eApplication v3.105 running protocol v2 w/ capabilities = 0x60030030. mainteinance = OFF
[DEBUG] FirmwareUpdaterCore::connectTo() has found  1  ETH boards
EthMaintainer::processDiscoveryReplies2() has found a board @ 10.0.1.5: ems4 w/ eApplication v3.105 running protocol v2 w/ capabilities = 0x60030030. mainteinance = OFF
EthMaintainer::go2maintenance() resent command for the 1-th time to board 0.0.0.0 after 1.000000 secs
EthMaintainer::go2maintenance() resent command for the 2-th time to board 0.0.0.0 after 1.000000 secs
EthMaintainer::processDiscoveryReplies2() has found a board @ 10.0.1.5: ems4 w/ eUpdater v2.24 running protocol v2 w/ capabilities = 0x607ffbfa. mainteinance = ON
EthMaintainer::go2maintenance() succesfully sent in maintenance board 0.0.0.0 after 3 attempts
programming /home/acemor/rob/robotology-superbuild/src/icub-firmware-build/CAN/mtb4/mtb4.hex: 1% done
programming /home/acemor/rob/robotology-superbuild/src/icub-firmware-build/CAN/mtb4/mtb4.hex: 25% done
programming /home/acemor/rob/robotology-superbuild/src/icub-firmware-build/CAN/mtb4/mtb4.hex: 50% done
programming /home/acemor/rob/robotology-superbuild/src/icub-firmware-build/CAN/mtb4/mtb4.hex: 75% done
programming /home/acemor/rob/robotology-superbuild/src/icub-firmware-build/CAN/mtb4/mtb4.hex: finished!
```


