### PR TITLE
POS service refactoring

### DIFF
--- a/src/libraries/icubmod/embObjLib/serviceParser.cpp
+++ b/src/libraries/icubmod/embObjLib/serviceParser.cpp
@@ -898,12 +898,7 @@ bool ServiceParser::check_analog(Searchable &config, eOmn_serv_type_t type)
                 }
 
                 b_PROPERTIES_SENSORS_pos_CALIBRATION = Bottle(b_PROPERTIES_SENSORS.findGroup("CALIBRATION"));
-                if(!b_PROPERTIES_SENSORS_pos_CALIBRATION.isNull())
-                {
-                    yError() << "ServiceParser::check_analog() found PROPERTIES.SENSORS.CALIBRATION group. This is not allowed. CALIBRATION must be removed";
-                    return false;
-                }
-                /*
+                if(b_PROPERTIES_SENSORS_pos_CALIBRATION.isNull())
                 {
                     yWarning() << "ServiceParser::check_analog() cannot find PROPERTIES.SENSORS.CALIBRATION. Using neutral values (ROT:zero, 0.0, false)";
                 }
@@ -931,7 +926,7 @@ bool ServiceParser::check_analog(Searchable &config, eOmn_serv_type_t type)
                         yWarning() << "ServiceParser::check_analog() cannot find PROPERTIES.SENSORS.CALIBRATION.invertDirection. Using value false";
                     }
                 }
-                */
+                
             }
             else
             {
@@ -1922,8 +1917,6 @@ bool ServiceParser::parseService(Searchable &config, servConfigPOS_t &posconfig)
     {
         yDebug() << "ServiceParser::parseService(POS) has received a valid SERVICE group for POS with size of enabled sensors equal to:" << as_service.settings.enabledsensors.size();
     }
-    
-
 
     if(as_service.settings.enabledsensors.size() > eOas_pos_sensorsinboard_maxnumber)
     {
@@ -4338,14 +4331,7 @@ bool ServiceParser::parseService(Searchable &config, servConfigMC_t &mcconfig)
 
                 pos->config.boardconfig[b].canloc.addr = mc_service.properties.poslocations[b].addr;
                 pos->config.boardconfig[b].canloc.port = mc_service.properties.poslocations[b].port;
-
-                // check if we have even 1 FAP board configured and send an error. Calibration group should not be present
-                // if(pos->config.boardconfig[b].sensors[0].type != nan)
-                // {
-                //     yError() << "ServiceParser::parseService() found PROPERTIES.SENSORS.CALIBRATION group in MC SERVICE. This is not allowed. CALIBRATION must be removed";
-                //     return false;
-                // }
-                /*
+                
                 for(size_t s=0; s<eOas_pos_sensorsinboard_maxnumber; s++)
                 {
                     pos->config.boardconfig[b].sensors[s].connector = s;
@@ -4356,7 +4342,6 @@ bool ServiceParser::parseService(Searchable &config, servConfigMC_t &mcconfig)
                     pos->config.boardconfig[b].sensors[s].rotation = eoas_pos_ROT_zero;
                     pos->config.boardconfig[b].sensors[s].offset = 0;
                 }
-                */
             }
 
 #if 0

--- a/src/libraries/icubmod/embObjLib/serviceParser.h
+++ b/src/libraries/icubmod/embObjLib/serviceParser.h
@@ -25,7 +25,7 @@ typedef struct
 {
     eOmn_serv_parameter_t   ethservice;
     int                     acquisitionrate;
-    std::string                  nameOfMais;
+    std::string             nameOfMais;
 } servConfigMais_t;
 
 
@@ -34,7 +34,7 @@ typedef struct
     eOmn_serv_parameter_t   ethservice;
     int                     acquisitionrate;
     bool                    useCalibration;
-    std::string                  nameOfStrain;
+    std::string             nameOfStrain;
     eObrd_cantype_t         boardType;
 } servConfigStrain_t;
 
@@ -81,6 +81,7 @@ typedef struct
     eOmn_serv_parameter_t     ethservice;
     int                       acquisitionrate;
     std::vector<std::string>  idList;
+    std::vector<std::string>  sensorName;
 } servConfigPOS_t;
 
 

--- a/src/libraries/icubmod/embObjMais/embObjMais.cpp
+++ b/src/libraries/icubmod/embObjMais/embObjMais.cpp
@@ -27,7 +27,6 @@
 // specific to this device driver.
 #include <embObjMais.h>
 #include <ethManager.h>
-#include <yarp/os/LogStream.h>
 #include "EoAnalogSensors.h"
 #include "EOnv_hid.h"
 

--- a/src/libraries/icubmod/embObjPOS/embObjPOS.cpp
+++ b/src/libraries/icubmod/embObjPOS/embObjPOS.cpp
@@ -356,9 +356,7 @@ yarp::dev::MAS_status embObjPOS::getEncoderArrayStatus(size_t sens_index) const
 bool embObjPOS::getEncoderArrayName(size_t sens_index, std::string &name) const
 {
     //TODO: maybe we should add a mutex for each method which write data to be thread safe
-    if (sens_index >= serviceConfig.idList.size()) return false; //REV-VALE: same as line 269
-    // TODO: we can think to add a name specific for the encoder array, such as "left_arm_pos4", cosidering that now we have the name of the 2/4 actuators which is stored in idList
-    // and not a name for the encoder array itself, which might have dimension 2 or 4, depeding if the device is related to the open-close or abductions.
+    if (sens_index >= serviceConfig.idList.size()) return false; 
     name = serviceConfig.idList[sens_index];
     return true;
 }

--- a/src/libraries/icubmod/embObjPOS/embObjPOS.cpp
+++ b/src/libraries/icubmod/embObjPOS/embObjPOS.cpp
@@ -10,14 +10,17 @@
 #include <string>
 #include <iostream>
 #include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
 
 // Yarp Includes
 #include <yarp/os/Time.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
-#include <stdarg.h>
-#include <stdio.h>
 #include <yarp/dev/PolyDriver.h>
+#include <yarp/os/NetType.h>
+
+// external libraries includes
 #include <ace/config.h>
 #include <ace/Log_Msg.h>
 
@@ -25,21 +28,20 @@
 // specific to this device driver.
 #include <embObjPOS.h>
 #include <ethManager.h>
-#include <yarp/os/LogStream.h>
 #include "EoAnalogSensors.h"
 #include "EOnv_hid.h"
-
 #include "EoProtocol.h"
 #include "EoProtocolMN.h"
 #include "EoProtocolAS.h"
 
-#include <yarp/os/NetType.h>
 
 #ifdef WIN32
 #pragma warning(once:4355)
 #endif
 
-
+namespace {
+    YARP_LOG_COMPONENT(EMBOBJPOS, "yarp.dev.embObjPOS")
+}
 
 using namespace yarp;
 using namespace yarp::os;
@@ -81,28 +83,31 @@ bool embObjPOS::open(yarp::os::Searchable &config)
 {
     // 1) prepare eth service verifing if the eth manager is available and parsing info about the eth board.
 
-    yInfo() << "embObjPOS::open(): preparing ETH resource";
+    yCInfo(EMBOBJPOS) << "embObjPOS::open(): preparing ETH resource";
 
     if(! m_PDdevice.prerareEthService(config, this))
         return false;
 
-    yInfo() << "embObjPOS::open(): browsing xml files which describe the service";
+    yCInfo(EMBOBJPOS) << "embObjPOS::open(): browsing xml files which describe the service";
 
     // 2) read stuff from config file
-    servConfigPOS_t serviceConfig;
+    serviceConfig = {};
     if(!fromConfig(config, serviceConfig))
     {
-        yError() << "embObjPOS missing some configuration parameter. Check logs and your config file.";
+        yCError(EMBOBJPOS) << "embObjPOS missing some configuration parameter. Check logs and your config file.";
         return false;
     }
 
     // 3) prepare data vector
     {
-        m_data.resize(eOas_pos_data_maxnumber, 0.0);
+        // for now resize to max number of pos sensors 
+        //--> then we will resize to the number of enabled sensors 
+        //--> we can eventually use here reserve to max number and resize to enabled number
+        m_data.resize(eOas_pos_data_maxnumber, 0.0); 
     }
 
 
-    yInfo() << "embObjPOS::open(): verify the presence of the board and if its protocol version is correct";
+    yCInfo(EMBOBJPOS) << "embObjPOS::open(): verify the presence of the board and if its protocol version is correct";
 
     // 4) verify analog sensor protocol and then verify-Activate the POS service
     if(!m_PDdevice.res->verifyEPprotocol(eoprot_endpoint_analogsensors))
@@ -112,22 +117,19 @@ bool embObjPOS::open(yarp::os::Searchable &config)
     }
 
 
-    yInfo() << "embObjPOS::open(): verify and activate the POS service";
+    yCInfo(EMBOBJPOS) << "embObjPOS::open(): verify and activate the POS service";
 
     const eOmn_serv_parameter_t* servparam = &serviceConfig.ethservice;
 
     if(!m_PDdevice.res->serviceVerifyActivate(eomn_serv_category_pos, servparam, 5.0))
     {
-        yError() << m_PDdevice.getBoardInfo() << "open() has an error in call of ethResources::serviceVerifyActivate() ";
+        yCError(EMBOBJPOS) << m_PDdevice.getBoardInfo() << "open() has an error in call of ethResources::serviceVerifyActivate()";
         cleanup();
         return false;
     }
 
 
-    //printServiceConfig();
-
-
-    yInfo() << "embObjPOS::open(): configure the POS service";
+    yCInfo(EMBOBJPOS) << "embObjPOS::open(): configure the POS service";
 
     if(false == sendConfig2boards(serviceConfig))
     {
@@ -135,7 +137,7 @@ bool embObjPOS::open(yarp::os::Searchable &config)
         return false;
     }
 
-    yInfo() << "embObjPOS::open(): impose the network variable which the ETH bord must stream up";
+    yCInfo(EMBOBJPOS) << "embObjPOS::open(): impose the network variable which the ETH bord must stream up";
 
     // Set variable to be signaled
     if(false == initRegulars())
@@ -145,11 +147,11 @@ bool embObjPOS::open(yarp::os::Searchable &config)
     }
 
 
-    yInfo() << "embObjPOS::open(): start the POS service";
+    yCInfo(EMBOBJPOS) << "embObjPOS::open(): start the POS service";
 
     if(!m_PDdevice.res->serviceStart(eomn_serv_category_pos))
     {
-        yError() << m_PDdevice.getBoardInfo() << "open() fails to start as service.... cannot continue";
+        yCError(EMBOBJPOS) << m_PDdevice.getBoardInfo() << "open() fails to start as service.... cannot continue";
         cleanup();
         return false;
     }
@@ -157,11 +159,11 @@ bool embObjPOS::open(yarp::os::Searchable &config)
     {
         if(m_PDdevice.isVerbose())
         {
-            yDebug() << m_PDdevice.getBoardInfo() << "open() correctly starts service";
+            yCDebug(EMBOBJPOS) << m_PDdevice.getBoardInfo() << "open() correctly starts service";
         }
     }
 
-    yInfo() << "embObjPOS::open(): start streaming of POS data";
+    yCInfo(EMBOBJPOS) << "embObjPOS::open(): start streaming of POS data";
 
     sendStart2boards();
 
@@ -181,13 +183,13 @@ bool embObjPOS::sendConfig2boards(servConfigPOS_t &serviceConfig)
 
     if(false == m_PDdevice.res->setcheckRemoteValue(id32, &cfg, 10, 0.010, 0.050))
     {
-        yError() << m_PDdevice.getBoardInfo() << "FATAL error in sendConfig2boards() while try to configure datarate=" << cfg.datarate;
+        yCError(EMBOBJPOS) << m_PDdevice.getBoardInfo() << "FATAL error in sendConfig2boards() while try to configure datarate=" << cfg.datarate;
         return false;
     }
 
     if(m_PDdevice.isVerbose())
     {
-        yDebug() << m_PDdevice.getBoardInfo() << ": sendConfig2boards() correctly configured boards with datarate=" << cfg.datarate;
+        yCDebug(EMBOBJPOS) << m_PDdevice.getBoardInfo() << ": sendConfig2boards() correctly configured boards with datarate=" << cfg.datarate;
     }
 
     return true;
@@ -204,13 +206,13 @@ bool embObjPOS::sendStart2boards(void)
 
     if(false == m_PDdevice.res->setcheckRemoteValue(id32, &enable, 10, 0.010, 0.050))
     {
-        yError() << m_PDdevice.getBoardInfo() << "FATAL error in sendStart2boards() while try to enable the boards transmission";
+        yCError(EMBOBJPOS) << m_PDdevice.getBoardInfo() << "FATAL error in sendStart2boards() while try to enable the boards transmission";
         return false;
     }
 
     if(m_PDdevice.isVerbose())
     {
-        yDebug() << m_PDdevice.getBoardInfo() << ": sendStart2boards() correctly enabled the boards transmission";
+        yCDebug(EMBOBJPOS) << m_PDdevice.getBoardInfo() << ": sendStart2boards() correctly enabled the boards transmission";
     }
 
     return true;
@@ -237,85 +239,147 @@ bool embObjPOS::initRegulars(void)
 
     if(false == m_PDdevice.res->serviceSetRegulars(eomn_serv_category_pos, id32v))
     {
-        yError() << m_PDdevice.getBoardInfo() << "initRegulars() fails to add its variables to regulars: cannot proceed any further";
+        yCError(EMBOBJPOS) << m_PDdevice.getBoardInfo() << "initRegulars() fails to add its variables to regulars: cannot proceed any further";
         return false;
     }
 
     if(m_PDdevice.isVerbose())
     {
-        yDebug() << m_PDdevice.getBoardInfo() << "initRegulars() added" << id32v.size() << "regular rops ";
+        yCDebug(EMBOBJPOS) << m_PDdevice.getBoardInfo() << "initRegulars() added" << id32v.size() << "regular rops ";
         char nvinfo[128];
         for (size_t r = 0; r<id32v.size(); r++)
         {
             uint32_t item = id32v.at(r);
             eoprot_ID2information(item, nvinfo, sizeof(nvinfo));
-            yDebug() << "\t it added regular rop for" << nvinfo;
+            yCDebug(EMBOBJPOS) << "\t it added regular rop for" << nvinfo;
         }
     }
-
-
+    
     return true;
 }
 
-
-/*! Read a vector from the sensor.
- * @param out a vector containing the sensor's last readings.
- * @return AS_OK or return code. AS_TIMEOUT if the sensor timed-out.
- **/
-
-int embObjPOS::read(yarp::sig::Vector &out)
+void embObjPOS::helper_remapperFromSensorToDataIndex(const uint32_t sensorId, uint32_t &dataIndex) const
 {
-    // This method gives the data, received from embedded boards, to the analogServer
+    /**
+     * This is the typedef enum present in EoBoards.h 
+     * that defines the index in the data vector of each finger position read by the POS service.
+     * We can use this function to remap the sensorId (which is the idList[] element) to the corresponding index in m_data[] vector.
+     * therefore we can get from the m_data[] vector the position of the sensor corresponding to the desired finger.
+     * This remapping is needed bacause the sensorId is always in a sequence ranges from 0 to n-1, where n is the number of enabled sensors,
+     * which is 4 for open-close and 2 for abduction, while the index in m_data[] vector is not in a sequence from 0 to n-1,
+     * but it is defined by the eObrd_portpos_t enum, which has some values not in sequence, e.g. the abductions.
+     * We copy here the enum for clarity:
+     * typedef enum
+        {
+            eobrd_portpos_hand_thumb_oc         = 0,
+            eobrd_portpos_hand_index_oc         = 1,
+            eobrd_portpos_hand_middle_oc        = 2,
+            eobrd_portpos_hand_ring_pinky_oc    = 3,
+            eobrd_portpos_hand_thumb_add        = 4,
+            eobrd_portpos_hand_tbd              = 5,
+            eobrd_portpos_hand_index_add        = 6,    
+            
+            eobrd_portpos_none                  = 31,    // as ... eobrd_port_none
+            eobrd_portpos_unknown               = 30     // as ... eobrd_port_unknown
+        } eObrd_portpos_t;
+    */
+    
+    // First we need to understand if the sensorId is related to open-close or abduction.
+    // We can do this by checking the size of idList[] vector, which is 4 for open-close and 2 for abduction.
+    // We need to use a temporary variable to store the dataIndex, because it is passed by reference.
+    // and the enum has a different type than uint32_t.
 
-    if(!m_PDdevice.isOpen())
-        return AS_ERROR ;
+    eObrd_portpos_t portPosIndex = eobrd_portpos_unknown; // default value in case of error
+    if (serviceConfig.idList.size() == 4) // open-close
+    {
+        switch (sensorId)
+        {
+            case 0:
+                portPosIndex = eobrd_portpos_hand_thumb_oc;
+                break;
+            case 1:
+                portPosIndex = eobrd_portpos_hand_index_oc;
+                break;
+            case 2:
+                portPosIndex = eobrd_portpos_hand_middle_oc;
+                break;
+            case 3:
+                portPosIndex = eobrd_portpos_hand_ring_pinky_oc;
+                break;
+            default:
+                portPosIndex = eobrd_portpos_unknown; // error
+                break;
+        }
+    }
+    else if (serviceConfig.idList.size() == 2) // abduction
+    {
+       switch (sensorId)
+        {
+            case 0:
+                portPosIndex = eobrd_portpos_hand_thumb_add;
+                break;
+            case 1:
+                portPosIndex = eobrd_portpos_hand_index_add;
+                break;
+            default:
+                portPosIndex = eobrd_portpos_unknown; // error
+                break;
+        }
+    }
+    else
+    {
+        portPosIndex = eobrd_portpos_unknown; // error
+    }
 
-    std::lock_guard<std::mutex> lock(m_mutex);
-
-    // errors are not handled for now... it'll always be OK!!
-    out=m_data;
-
-    return AS_OK;
+    dataIndex = static_cast<uint32_t>(portPosIndex);
 }
 
-
-
-int embObjPOS::getState(int ch)
+size_t embObjPOS::getNrOfEncoderArrays() const
 {
-    printf("getstate\n");
-    return AS_OK;
+    // this should return the number of sensors we wanna have per control boards
+    // e.g. currently POS service can manage up to 4 position sensors (2 for open/close and 2 for abduction)
+    // so we are returning the number of enabled sensors, i.e. 2 or 4, depending on the device
+    // differently, we can choose another approach, i.e. return 1, as the encoder array is a single entity, 
+    // which is actually the control board associated with the opened serivice
+    // and then getEncoderArraySize() should return 2 or 4, i.es the number of enabled sensors
+    yCDebug(EMBOBJPOS) << m_PDdevice.getBoardInfo() << "embObjPOS::getNrOfEncoderArrays called at timestamp=" << yarp::os::Time::now() << "returning" << serviceConfig.idList.size();
+    return serviceConfig.idList.size();
 }
 
-
-int embObjPOS::getChannels()
+yarp::dev::MAS_status embObjPOS::getEncoderArrayStatus(size_t sens_index) const
 {
-    return static_cast<int>(eOas_pos_data_maxnumber);
+    //TODO: maybe we should add a mutex for each method which write data to be thread safe
+    if (sens_index >= serviceConfig.idList.size()) return yarp::dev::MAS_UNKNOWN; //REV-VALE:this is wrong. I guess it is a copy-paste error. It should be 4 or the max size of sensor we can manage. Maybe in fw-shared there is already a constant for this. defined.
+    return yarp::dev::MAS_OK;
 }
 
-
-int embObjPOS::calibrateSensor()
+bool embObjPOS::getEncoderArrayName(size_t sens_index, std::string &name) const
 {
-    return AS_OK;
+    //TODO: maybe we should add a mutex for each method which write data to be thread safe
+    if (sens_index >= serviceConfig.idList.size()) return false; //REV-VALE: same as line 269
+    // TODO: we can think to add a name specific for the encoder array, such as "left_arm_pos4", cosidering that now we have the name of the 2/4 actuators which is stored in idList
+    // and not a name for the encoder array itself, which might have dimension 2 or 4, depeding if the device is related to the open-close or abductions.
+    name = serviceConfig.idList[sens_index];
+    return true;
 }
 
-
-int embObjPOS::calibrateSensor(const yarp::sig::Vector& value)
+bool embObjPOS::getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
-    return AS_OK;
+    // we cannot receice an index higher that the number of enabled sensors
+    if (sens_index >= serviceConfig.idList.size()) return false; 
+    timestamp = yarp::os::Time::now();
+    // we need to remap the sens_index, which is the index in idList[], to the corresponding index in m_data[] vector
+    uint32_t dataIndex = 0;
+    helper_remapperFromSensorToDataIndex(static_cast<uint32_t>(sens_index), dataIndex);
+    out = m_data[dataIndex]; //TODO: this should be a vector of 2 or 4 elements, depending on the device, if related to abduction or open-close. Each number is the position of the actuator.
+    return true;
 }
 
-
-int embObjPOS::calibrateChannel(int ch)
+size_t embObjPOS::getEncoderArraySize(size_t sens_index) const
 {
-    return AS_OK;
+    if (sens_index >= serviceConfig.idList.size()) return 0;
+    return 1; //TODO: this should return the size of data at index sens_index, which should actually be 1.
 }
-
-
-int embObjPOS::calibrateChannel(int ch, double v)
-{
-    return AS_OK;
-}
-
 
 eth::iethresType_t embObjPOS::type()
 {
@@ -327,6 +391,8 @@ bool embObjPOS::update(eOprotID32_t id32, double timestamp, void* rxdata)
 {
     // called by feat_manage_analogsensors_data() which is called by:
     // eoprot_fun_UPDT_as_pos_status
+    char nvinfo[128] = {};
+    eoprot_ID2information(id32, nvinfo, sizeof(nvinfo));
     if(!m_PDdevice.isOpen())
         return false;
 
@@ -334,7 +400,7 @@ bool embObjPOS::update(eOprotID32_t id32, double timestamp, void* rxdata)
     uint32_t sizeOfData = pos_st_ptr->arrayofdata.head.size;
 
     if(sizeOfData>m_data.size())
-        yWarning() << m_PDdevice.getBoardInfo() << "In update function I received more data than I had been configured to store.My size is " << m_data.size() << "while I received " << sizeOfData << "values!";
+        yCWarning(EMBOBJPOS) << m_PDdevice.getBoardInfo() << "In update function I received more data than I had been configured to store.My size is " << m_data.size() << "while I received " << sizeOfData << "values!";
 
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -348,38 +414,15 @@ bool embObjPOS::update(eOprotID32_t id32, double timestamp, void* rxdata)
     return true;
 }
 
-
-
-
 bool embObjPOS::close()
 {
     cleanup();
     return true;
 }
 
-
-// void embObjPOS::printServiceConfig(void)
-// {
-//     char loc[20] = {0};
-//     char fir[20] = {0};
-//     char pro[20] = {0};
-//
-//     const char * boardname = (NULL != res) ? (res->getProperties().boardnameString.c_str()) : ("NOT-ASSIGNED-YET");
-//     const char * ipv4 = (NULL != res) ? (res->getProperties().ipv4addrString.c_str()) : ("NOT-ASSIGNED-YET");
-//
-//     parser->convert(serviceConfig.ethservice.configuration.data.as.mais.canloc, loc, sizeof(loc));
-//     parser->convert(serviceConfig.ethservice.configuration.data.as.mais.version.firmware, fir, sizeof(fir));
-//     parser->convert(serviceConfig.ethservice.configuration.data.as.mais.version.protocol, pro, sizeof(pro));
-//
-//     yInfo() << "The embObjPOS device using BOARD" << boardname << "w/ IP" << ipv4 << "has the following service config:";
-//     yInfo() << "- acquisitionrate =" << serviceConfig.acquisitionrate;
-//     yInfo() << "- MAIS named" << serviceConfig.nameOfMais << "@" << loc << "with required protocol version =" << pro << "and required firmware version =" << fir;
-// }
-
-
 void embObjPOS::cleanup(void)
 {
-    m_PDdevice.cleanup(static_cast <eth::IethResource*> (this));
+    m_PDdevice.cleanup(static_cast<eth::IethResource*> (this));
 }
 
 // eof

--- a/src/libraries/icubmod/embObjPOS/embObjPOS.cpp
+++ b/src/libraries/icubmod/embObjPOS/embObjPOS.cpp
@@ -47,7 +47,8 @@ using namespace yarp;
 using namespace yarp::os;
 using namespace yarp::dev;
 
-
+constexpr int POS_OPEN_CLOSE_SENSORS_COUNT = 4;
+constexpr int POS_ABDUCTION_SENSORS_COUNT = 2;
 
 bool embObjPOS::fromConfig(yarp::os::Searchable &config, servConfigPOS_t &serviceConfig)
 {
@@ -246,7 +247,7 @@ bool embObjPOS::initRegulars(void)
     if(m_PDdevice.isVerbose())
     {
         yCDebug(EMBOBJPOS) << m_PDdevice.getBoardInfo() << "initRegulars() added" << id32v.size() << "regular rops ";
-        char nvinfo[128];
+        char nvinfo[128] = {};
         for (size_t r = 0; r<id32v.size(); r++)
         {
             uint32_t item = id32v.at(r);
@@ -302,7 +303,7 @@ void embObjPOS::helper_remapperFromSensorToDataIndex(const uint32_t sensorId, ui
     // and the enum has a different type than uint32_t.
 
     eObrd_portpos_t portPosIndex = eobrd_portpos_unknown; // default value in case of error
-    if (serviceConfig.idList.size() == 4) // open-close
+    if (serviceConfig.idList.size() == POS_OPEN_CLOSE_SENSORS_COUNT) // open-close
     {
         switch (sensorId)
         {
@@ -323,7 +324,7 @@ void embObjPOS::helper_remapperFromSensorToDataIndex(const uint32_t sensorId, ui
                 break;
         }
     }
-    else if (serviceConfig.idList.size() == 2) // abduction
+    else if (serviceConfig.idList.size() == POS_ABDUCTION_SENSORS_COUNT) // abduction
     {
        switch (sensorId)
         {
@@ -360,7 +361,7 @@ size_t embObjPOS::getNrOfEncoderArrays() const
 
 yarp::dev::MAS_status embObjPOS::getEncoderArrayStatus(size_t sens_index) const
 {
-    if (sens_index >= serviceConfig.idList.size()) return yarp::dev::MAS_UNKNOWN; //REV-VALE:this is wrong. I guess it is a copy-paste error. It should be 4 or the max size of sensor we can manage. Maybe in fw-shared there is already a constant for this. defined.
+    if (sens_index >= serviceConfig.idList.size()) return yarp::dev::MAS_UNKNOWN;
     return yarp::dev::MAS_OK;
 }
 
@@ -400,9 +401,7 @@ eth::iethresType_t embObjPOS::type()
 bool embObjPOS::update(eOprotID32_t id32, double timestamp, void* rxdata)
 {
     // called by feat_manage_analogsensors_data() which is called by:
-    // eoprot_fun_UPDT_as_pos_status
-    char nvinfo[128] = {};
-    eoprot_ID2information(id32, nvinfo, sizeof(nvinfo));
+    // eoprot_fun_UPDT_as_pos_status()
     if(!m_PDdevice.isOpen())
         return false;
 

--- a/src/libraries/icubmod/embObjPOS/embObjPOS.cpp
+++ b/src/libraries/icubmod/embObjPOS/embObjPOS.cpp
@@ -360,14 +360,12 @@ size_t embObjPOS::getNrOfEncoderArrays() const
 
 yarp::dev::MAS_status embObjPOS::getEncoderArrayStatus(size_t sens_index) const
 {
-    //TODO: maybe we should add a mutex for each method which write data to be thread safe
     if (sens_index >= serviceConfig.idList.size()) return yarp::dev::MAS_UNKNOWN; //REV-VALE:this is wrong. I guess it is a copy-paste error. It should be 4 or the max size of sensor we can manage. Maybe in fw-shared there is already a constant for this. defined.
     return yarp::dev::MAS_OK;
 }
 
 bool embObjPOS::getEncoderArrayName(size_t sens_index, std::string &name) const
 {
-    //TODO: maybe we should add a mutex for each method which write data to be thread safe
     if (sens_index >= serviceConfig.idList.size()) return false; 
     name = serviceConfig.idList[sens_index];
     return true;
@@ -390,7 +388,7 @@ bool embObjPOS::getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out
 size_t embObjPOS::getEncoderArraySize(size_t sens_index) const
 {
     if (sens_index >= serviceConfig.idList.size()) return 0;
-    return 1; //TODO: this should return the size of data at index sens_index, which should actually be 1.
+    return 1; //this should return the size of data at index sens_index, which should actually be 1.
 }
 
 eth::iethresType_t embObjPOS::type()

--- a/src/libraries/icubmod/embObjPOS/embObjPOS.h
+++ b/src/libraries/icubmod/embObjPOS/embObjPOS.h
@@ -12,9 +12,8 @@
 #include <string>
 #include <mutex>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/IAnalogSensor.h>
 #include <yarp/sig/Vector.h>
-
+#include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 
 
 #include "embObjGeneralDevPrivData.h"
@@ -31,7 +30,7 @@ namespace yarp {
 
 
 class yarp::dev::embObjPOS: public yarp::dev::DeviceDriver,
-                            public yarp::dev::IAnalogSensor,
+                            public yarp::dev::IEncoderArrays,
                             public eth::IethResource
 {
 
@@ -43,14 +42,25 @@ public:
     bool open(yarp::os::Searchable &config);
     bool close();
 
-    // IAnalogSensor interface
-    virtual int read(yarp::sig::Vector &out);
-    virtual int getState(int ch);
-    virtual int getChannels();
-    virtual int calibrateChannel(int ch, double v);
-    virtual int calibrateSensor();
-    virtual int calibrateSensor(const yarp::sig::Vector& value);
-    virtual int calibrateChannel(int ch);
+    // IEncoderArrays interface
+    virtual size_t getNrOfEncoderArrays() const override; // this should return the number of enabledSensor, i.e. 2 or 4, depending on the device
+
+    // This should be the status of the actuator at index sens_index.
+    virtual yarp::dev::MAS_status getEncoderArrayStatus(size_t sens_index) const override;
+
+    // This should be the name of the actuator at index sens_index, i.e. serviceConfig.idList[sens_index].
+    virtual bool getEncoderArrayName(size_t sens_index, std::string &name) const override;
+
+    // TODO: In this case, if we keep the analysis done around this service, out element should contain the position of the actuator at sens_index, i.e. m_data[sens_index]. 
+    // Thus, it is actually a single value, not a vector of 2 or 4 elements.
+    virtual bool getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+
+    // I think this cannot return 2 or 4, i.e. the number of enabled-sensors, which is the size of m_data, but it should return 1, as the encoder array is a single entity. 
+    // Otherwise, it won't make sense to have the API getNrOfEncoderArrays(), which return the number of enabled sensors. 
+    // So, I think that in this case we have a number of encoder arrays equal to the number of enabled sensors, and each one of these arrays has a size equal to 1.
+    virtual size_t getEncoderArraySize(size_t sens_index) const override; // this should return the size of data at index sens_index, which should actually be 1. 
+
+
 
     // IethResource interface
     virtual bool initialised();
@@ -59,9 +69,10 @@ public:
 
 private:
 
+    servConfigPOS_t serviceConfig;
     yarp::dev::embObjDevPrivData m_PDdevice;
     std::mutex m_mutex;
-    yarp::sig::Vector m_data;
+    yarp::sig::Vector m_data; //TODO: this should be a vector of 2 or 4 elements, depending on the device, if related to abduction or open-close. Each number is the position of the actuator.
 
 
 private:
@@ -71,7 +82,8 @@ private:
     bool sendStart2boards(void);
     bool initRegulars(void);
     void cleanup(void);
-//     void printServiceConfig(void);
+
+    void helper_remapperFromSensorToDataIndex(const uint32_t sensorId, uint32_t &dataIndex) const;
 
 
 };

--- a/src/libraries/icubmod/embObjPOS/embObjPOS.h
+++ b/src/libraries/icubmod/embObjPOS/embObjPOS.h
@@ -51,7 +51,7 @@ public:
     // This should be the name of the actuator at index sens_index, i.e. serviceConfig.idList[sens_index].
     virtual bool getEncoderArrayName(size_t sens_index, std::string &name) const override;
 
-    // TODO: In this case, if we keep the analysis done around this service, out element should contain the position of the actuator at sens_index, i.e. m_data[sens_index]. 
+    // In this case, if we keep the analysis done around this service, out element should contain the position of the actuator at sens_index, i.e. m_data[sens_index]. 
     // Thus, it is actually a single value, not a vector of 2 or 4 elements.
     virtual bool getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
@@ -72,7 +72,7 @@ private:
     servConfigPOS_t serviceConfig;
     yarp::dev::embObjDevPrivData m_PDdevice;
     mutable std::mutex m_mutex;
-    yarp::sig::Vector m_data; //TODO: this should be a vector of 2 or 4 elements, depending on the device, if related to abduction or open-close. Each number is the position of the actuator.
+    yarp::sig::Vector m_data; //this should be a vector of 2 or 4 elements, depending on the device, if related to abduction or open-close. Each number is the position of the actuator.
 
 
 private:

--- a/src/libraries/icubmod/embObjPOS/embObjPOS.h
+++ b/src/libraries/icubmod/embObjPOS/embObjPOS.h
@@ -71,7 +71,7 @@ private:
 
     servConfigPOS_t serviceConfig;
     yarp::dev::embObjDevPrivData m_PDdevice;
-    std::mutex m_mutex;
+    mutable std::mutex m_mutex;
     yarp::sig::Vector m_data; //TODO: this should be a vector of 2 or 4 elements, depending on the device, if related to abduction or open-close. Each number is the position of the actuator.
 
 


### PR DESCRIPTION
This PR brings the following changes:

- POS switch parent class from IAnalogSensor to IEncoderArrays with redefinition of derived classes to match with
multipleanalogsensorsremapper and multipleanalogsensorsserver 
- we add private function for remapping wrapped sensors index with index from boards data
- we add `sensorName` to `servConfigPOS_t` that might be useful if we wanna change the POS remapper strategy passing from one remmaper per service open to one remapper per all joints that mounts a FAP encoder

It has been tested on ergoCub001