### PR TITLE
Fixes/yarp4 get axes

### DIFF
--- a/src/libraries/actionPrimitives/include/iCub/action/actionPrimitives.h
+++ b/src/libraries/actionPrimitives/include/iCub/action/actionPrimitives.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2010 RobotCub Consortium, European Commission FP6 Project IST-004370
  * Author: Ugo Pattacini
  * email:  ugo.pattacini@iit.it
@@ -18,63 +18,63 @@
 
 /**
  * \defgroup ActionPrimitives actionPrimitives
- *  
- * @ingroup icub_libraries 
- *  
- * Abstract layers for dealing with primitive actions (reach, 
- * grasp and more). 
  *
- * \author Ugo Pattacini 
- *  
+ * @ingroup icub_libraries
+ *
+ * Abstract layers for dealing with primitive actions (reach,
+ * grasp and more).
+ *
+ * \author Ugo Pattacini
+ *
  * Copyright (C) 2010 RobotCub Consortium
  *
- * CopyPolicy: Released under the terms of the GNU GPL v2.0. 
+ * CopyPolicy: Released under the terms of the GNU GPL v2.0.
  *
  * \section intro_sec Description
  *
- * The library relies on the Yarp Cartesian Interface and 
- * provides the user a collection of action primitives in task 
+ * The library relies on the Yarp Cartesian Interface and
+ * provides the user a collection of action primitives in task
  * space and joint space along with an easy way to combine them
- * together forming higher level actions (e.g. grasp(), tap(), 
- * �) in order to eventually execute more sophisticated tasks 
- * without reference to the motion control details. 
- *  
- * \image html actionPrimitives.jpg 
- *  
- * Central to the library's implementation is the concept of 
+ * together forming higher level actions (e.g. grasp(), tap(),
+ * �) in order to eventually execute more sophisticated tasks
+ * without reference to the motion control details.
+ *
+ * \image html actionPrimitives.jpg
+ *
+ * Central to the library's implementation is the concept of
  * @b action. An action is a "request" for an execution of three
- * different tasks according to its internal selector: 
- *  
- * -# It can ask to steer the arm to a specified pose, hence 
+ * different tasks according to its internal selector:
+ *
+ * -# It can ask to steer the arm to a specified pose, hence
  * performing a motion in the operational space.
- * -# It can command the execution of some predefined 
- * fingers sequences in the joint space identified by a tag. 
- * -# It can ask the system to wait for a specified time 
+ * -# It can command the execution of some predefined
+ * fingers sequences in the joint space identified by a tag.
+ * -# It can ask the system to wait for a specified time
  * interval.
- *  
- * Besides, there exists the possibility of generating one 
- * action for the execution of a task of type 1 simultaneously 
- * to a task of type 2. 
- *  
- * Moreover, whenever an action is produced from within the code 
- * the corresponding request item is pushed at the bottom of 
- * <b>actions queue</b>. Therefore, user can identify suitable 
- * fingers movements in the joint space, associate proper 
- * grasping 3d points together with hand posture and finally 
- * execute the grasping task as a harmonious combination of a 
- * reaching movement and fingers actuations, complying with the 
- * time requirements of the synchronized sequence. 
- *  
+ *
+ * Besides, there exists the possibility of generating one
+ * action for the execution of a task of type 1 simultaneously
+ * to a task of type 2.
+ *
+ * Moreover, whenever an action is produced from within the code
+ * the corresponding request item is pushed at the bottom of
+ * <b>actions queue</b>. Therefore, user can identify suitable
+ * fingers movements in the joint space, associate proper
+ * grasping 3d points together with hand posture and finally
+ * execute the grasping task as a harmonious combination of a
+ * reaching movement and fingers actuations, complying with the
+ * time requirements of the synchronized sequence.
+ *
  * It is also given the option to execute a callback whenever an
- * action is accomplished. 
- * 
+ * action is accomplished.
+ *
  * To detect contacts among fingers and objects the \ref
  * PerceptiveModels library is employed.
- * 
+ *
  * @note To streamline the code, the <b>context switching of
  *       the Cartesian Interface</b> is delegated to the module
  *       linking against ActionPrimitives.
- */ 
+ */
 
 #ifndef __AFFACTIONPRIMITIVES_H__
 #define __AFFACTIONPRIMITIVES_H__
@@ -105,20 +105,20 @@ namespace action
 /**
 * \ingroup ActionPrimitives
 *
-* Class for defining routines to be called when action is 
-* completed. 
+* Class for defining routines to be called when action is
+* completed.
 */
 class ActionPrimitivesCallback
 {
 public:
     /**
-    * Default Constructor. 
+    * Default Constructor.
     */
     ActionPrimitivesCallback() { }
 
     /**
     * Defines the callback body to be called at the action end.
-    */ 
+    */
     virtual void exec() = 0;
 };
 
@@ -126,56 +126,56 @@ public:
 /**
 * \ingroup ActionPrimitives
 *
-* Struct for defining way points used for movements in the 
-* operational space. 
+* Struct for defining way points used for movements in the
+* operational space.
 */
 struct ActionPrimitivesWayPoint
 {
     /**
-     * The 3x1 Vector specifyng the position of the waypoint [m]. 
+     * The 3x1 Vector specifyng the position of the waypoint [m].
      */
     yarp::sig::Vector x;
 
     /**
-     * The 4x1 Vector specifying the orientation of the waypoint in 
-     * axis-angle representation. 
+     * The 4x1 Vector specifying the orientation of the waypoint in
+     * axis-angle representation.
      */
     yarp::sig::Vector o;
 
     /**
-     * If this flag is set to true then orientation will be taken 
+     * If this flag is set to true then orientation will be taken
      * into account.
      */
     bool oEnabled;
 
     /**
-     * The time duration [s] to achieve the waypoint. Non-positive 
-     * values indicate that a duration equal to default one will be 
-     * employed. \n 
+     * The time duration [s] to achieve the waypoint. Non-positive
+     * values indicate that a duration equal to default one will be
+     * employed. \n
      */
     double duration;
 
     /**
-     * The arm execution time [s] accounting for the controller's 
-     * responsivity. Non-positive values indicate that the default 
+     * The arm execution time [s] accounting for the controller's
+     * responsivity. Non-positive values indicate that the default
      * time will be employed.
      */
     double trajTime;
 
     /**
-     * The time granularity [s] used by the trajectory generator 
-     * [s]. 
+     * The time granularity [s] used by the trajectory generator
+     * [s].
      */
     double granularity;
 
     /**
-     * Action callback that is executed when the waypoint is 
-     * reached. 
+     * Action callback that is executed when the waypoint is
+     * reached.
      */
     ActionPrimitivesCallback *callback;
 
     /**
-    * Default Constructor. 
+    * Default Constructor.
     */
     ActionPrimitivesWayPoint();
 };
@@ -184,11 +184,11 @@ struct ActionPrimitivesWayPoint
 /**
 * \ingroup ActionPrimitives
 *
-* The base class defining actions. 
-*  
+* The base class defining actions.
+*
 * It allows executing arm (in task-space, e.g. reach()) and hand
-* (in joint-space) primitive actions and to combine them in the 
-* actions queue. 
+* (in joint-space) primitive actions and to combine them in the
+* actions queue.
 */
 class ActionPrimitives : protected yarp::os::PeriodicThread
 {
@@ -205,7 +205,7 @@ protected:
     yarp::dev::ICartesianControl *cartCtrl;
 
     perception::Model            *graspModel;
-                                 
+
     yarp::os::PeriodicThread     *armWaver;
     std::mutex                    mtx;
     std::mutex                    mtx_motionStartEvent;
@@ -223,7 +223,7 @@ protected:
 
     bool configured;
     bool closed;
-    bool checkEnabled;    
+    bool checkEnabled;
     bool tracking_mode;
     bool torsoActive;
     bool reachTmoEnabled;
@@ -238,11 +238,11 @@ protected:
     double latchTimerReachLog;
 
     int jHandMin;
-    int jHandMax;
+    size_t jHandMax;
 
     yarp::sig::Vector enableTorsoSw;
     yarp::sig::Vector disableTorsoSw;
-                      
+
     yarp::sig::Vector curHandFinalPoss;
     yarp::sig::Vector curHandTols;
     yarp::sig::Vector curGraspDetectionThres;
@@ -296,7 +296,7 @@ protected:
         void clear();
     } actionsQueue;
     std::map<std::string,std::deque<HandWayPoint> > handSeqMap;
-    
+
     virtual void printMessage(const int logtype, const char *format, ...) const;
 
     virtual bool handleTorsoDOF(yarp::os::Property &opt, const std::string &key);
@@ -326,21 +326,21 @@ protected:
 
 public:
     /**
-    * Default Constructor. 
+    * Default Constructor.
     */
     ActionPrimitives();
 
     /**
-    * Constructor. 
+    * Constructor.
     * @param opt the Property used to configure the object after its
     *            creation.
     */
     ActionPrimitives(yarp::os::Property &opt);
 
     /**
-    * Destructor. 
-    *  
-    * @note it calls the close() method. 
+    * Destructor.
+    *
+    * @note it calls the close() method.
     */
     virtual ~ActionPrimitives();
 
@@ -349,85 +349,85 @@ public:
     * @param opt the Property used to configure the object after its
     *            creation.
     * @return true/false on success/fail.
-    *  
-    * @note To be called after object creation. 
-    *  
-    * @note Available options are: 
-    *  
-    * @b local <string>: specify a stem name used to open local 
-    *    ports and to highlight messages printed on the screen. 
-    *  
-    * @b robot <string>: the robot name to connect to (e.g. icub). 
-    *  
-    * @b part <string>:  the arm to be controlled (e.g. left_arm). 
-    *  
-    * @b thread_period <int>: the thread period [ms] which selects 
+    *
+    * @note To be called after object creation.
+    *
+    * @note Available options are:
+    *
+    * @b local <string>: specify a stem name used to open local
+    *    ports and to highlight messages printed on the screen.
+    *
+    * @b robot <string>: the robot name to connect to (e.g. icub).
+    *
+    * @b part <string>:  the arm to be controlled (e.g. left_arm).
+    *
+    * @b thread_period <int>: the thread period [ms] which selects
     *    the time granularity as well.
-    *  
+    *
     * @b default_exec_time <double>: the arm movement execution time
     *    [s].
-    *  
-    * @b reach_tol <double>: the reaching tolerance [m]. 
-    *  
-    * @b tracking_mode <string>: enable/disable the tracking mode; 
+    *
+    * @b reach_tol <double>: the reaching tolerance [m].
+    *
+    * @b tracking_mode <string>: enable/disable the tracking mode;
     *    possible values: "on"/"off".
-    * @note In tracking mode the cartesian position is mantained on 
+    * @note In tracking mode the cartesian position is mantained on
     *       the reached target.
-    *  
-    * @b verbosity <string>: enable/disable the verbose mode; 
+    *
+    * @b verbosity <string>: enable/disable the verbose mode;
     *    possible values: "on"/"off".
     *
     * @b torso_pitch <string>: if "on" it enables the control of the
     *    pitch of the torso.
-    *  
-    * @b torso_pitch_min <double>: set the pitch minimum value 
+    *
+    * @b torso_pitch_min <double>: set the pitch minimum value
     *    [deg].
-    *  
-    * @b torso_pitch_max <double>: set the pitch maximum value 
+    *
+    * @b torso_pitch_max <double>: set the pitch maximum value
     *    [deg].
-    *  
-    * @b torso_roll <string>: if "on" it enables the control of the 
+    *
+    * @b torso_roll <string>: if "on" it enables the control of the
     *    roll of the torso.
-    *  
-    * @b torso_roll_min <double>: set the roll minimum value [deg]. 
-    *  
+    *
+    * @b torso_roll_min <double>: set the roll minimum value [deg].
+    *
     * @b torso_roll_max <double>: set the roll maximum value [deg].
-    *  
-    * @b torso_yaw <string>: if "on" it enables the control of the 
+    *
+    * @b torso_yaw <string>: if "on" it enables the control of the
     *    yaw of the torso.
-    *  
-    * @b torso_yaw_min <double>: set the yaw minimum value [deg]. 
-    *  
-    * @b torso_yaw_max <double>: set the yaw maximum value [deg]. 
-    *  
-    * @b grasp_model_type <string>: establish the type of the model 
+    *
+    * @b torso_yaw_min <double>: set the yaw minimum value [deg].
+    *
+    * @b torso_yaw_max <double>: set the yaw maximum value [deg].
+    *
+    * @b grasp_model_type <string>: establish the type of the model
     *    used to detect external contacts while moving fingers. It
     *    refers to the types implemented within the \ref
     *    PerceptiveModels library, such as the "springy" or
     *    "tactile".
-    * @note the special tag "none" is used to skip this part. 
-    *  
-    * @b grasp_model_file <string>: complete path to the file 
+    * @note the special tag "none" is used to skip this part.
+    *
+    * @b grasp_model_file <string>: complete path to the file
     *    containing the options to initialize the grasp model.
-    *  
-    * @b hand_sequences_file <string>: complete path to the file 
+    *
+    * @b hand_sequences_file <string>: complete path to the file
     *    containing the hand motions sequences.<br />Here is the
     *    format of motion sequences:
-    *  
+    *
     *  @code
     *  [GENERAL]
     *  numSequences ***
-    *  
+    *
     *  [SEQ_0]
     *  key ***
     *  numWayPoints ***
     *  wp_0  (poss (10 ...)) (vels (20 ...)) (tols (30 ...)) (thres
     *  (1 2 3 4 5)) (tmo 10.0)
     *  wp_1  *** ...
-    *  
+    *
     *  [SEQ_1]
     *  ...
-    *  
+    *
     *  // the "poss", "vels" and "tols" keys specify 9 joints
     *  // positions, velocities and tolerances whereas the "thres"
     *  // key specifies 5 fingers thresholds used for contact detection
@@ -435,15 +435,15 @@ public:
     *  // The "tmo" key specifies the timeout beyond which the motion
     *  // is considered to be finished.
     *  @endcode
-    *  
-    * @note A port called <i> /<local>/<part>/detectGrasp:i </i> is 
+    *
+    * @note A port called <i> /<local>/<part>/detectGrasp:i </i> is
     *       open to acquire data provided by graspDetector module.
     */
     virtual bool open(yarp::os::Property &opt);
 
     /**
-    * Check if the object is initialized correctly. 
-    * @return true/fail on success/fail. 
+    * Check if the object is initialized correctly.
+    * @return true/fail on success/fail.
     */
     virtual bool isValid() const;
 
@@ -453,78 +453,78 @@ public:
     virtual void close();
 
     /**
-    * Insert a combination of arm and hand primitive actions in the 
-    * actions queue. 
-    * @param x the 3-d target position [m]. 
-    * @param o the 4-d hand orientation used while reaching (given 
+    * Insert a combination of arm and hand primitive actions in the
+    * actions queue.
+    * @param x the 3-d target position [m].
+    * @param o the 4-d hand orientation used while reaching (given
     *          in axis-angle representation: ax ay az angle in rad).
-    * @param handSeqKey the hand sequence key. 
-    * @param execTime the arm action execution time [s] (to be 
+    * @param handSeqKey the hand sequence key.
+    * @param execTime the arm action execution time [s] (to be
     *          specified iff different from default value).
-    * @param clb action callback that is executed when the action 
+    * @param clb action callback that is executed when the action
     *            ends; none by default.
-    * @return true/false on success/fail. 
-    *  
-    * @note Some examples: 
-    *  
-    * the call @b pushAction(x,o,"close_hand") pushes the combined 
-    * action of reachPose(x,o) and hand "close_hand" sequence into 
-    * the queue; the action will be executed as soon as all the 
-    * previous items in the queue will have been served. 
+    * @return true/false on success/fail.
+    *
+    * @note Some examples:
+    *
+    * the call @b pushAction(x,o,"close_hand") pushes the combined
+    * action of reachPose(x,o) and hand "close_hand" sequence into
+    * the queue; the action will be executed as soon as all the
+    * previous items in the queue will have been served.
     */
-    virtual bool pushAction(const yarp::sig::Vector &x, const yarp::sig::Vector &o, 
+    virtual bool pushAction(const yarp::sig::Vector &x, const yarp::sig::Vector &o,
                             const std::string &handSeqKey,
                             const double execTime=ACTIONPRIM_DISABLE_EXECTIME,
                             ActionPrimitivesCallback *clb=NULL);
 
     /**
-    * Insert a combination of arm and hand primitive actions in the 
-    * actions queue. 
-    * @param x the 3-d target position [m]. 
-    * @param handSeqKey the hand sequence key. 
-    * @param execTime the arm action execution time [s] (to be 
+    * Insert a combination of arm and hand primitive actions in the
+    * actions queue.
+    * @param x the 3-d target position [m].
+    * @param handSeqKey the hand sequence key.
+    * @param execTime the arm action execution time [s] (to be
     *          specified iff different from default value).
-    * @param clb action callback that is executed when the action 
+    * @param clb action callback that is executed when the action
     *            ends; none by default.
-    * @return true/false on success/fail. 
-    *  
-    * @note Some examples: 
-    *  
-    * the call @b pushAction(x,"close_hand") pushes the combined 
+    * @return true/false on success/fail.
+    *
+    * @note Some examples:
+    *
+    * the call @b pushAction(x,"close_hand") pushes the combined
     * action of reachPosition(x) and hand "close_hand" sequence into
-    * the queue; the action will be executed as soon as all the 
-    * previous items in the queue will have been served. 
+    * the queue; the action will be executed as soon as all the
+    * previous items in the queue will have been served.
     */
-    virtual bool pushAction(const yarp::sig::Vector &x, 
+    virtual bool pushAction(const yarp::sig::Vector &x,
                             const std::string &handSeqKey,
                             const double execTime=ACTIONPRIM_DISABLE_EXECTIME,
                             ActionPrimitivesCallback *clb=NULL);
 
     /**
-    * Insert the arm-primitive action reach for target in the 
-    * actions queue. 
-    * @param x the 3-d target position [m]. 
-    * @param o the 4-d hand orientation used while reaching (given 
+    * Insert the arm-primitive action reach for target in the
+    * actions queue.
+    * @param x the 3-d target position [m].
+    * @param o the 4-d hand orientation used while reaching (given
     *          in axis-angle representation: ax ay az angle in rad).
-    * @param execTime the arm action execution time [s] (to be 
+    * @param execTime the arm action execution time [s] (to be
     *          specified iff different from default value).
-    * @param clb action callback that is executed when the action 
+    * @param clb action callback that is executed when the action
     *            ends; none by default.
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool pushAction(const yarp::sig::Vector &x, const yarp::sig::Vector &o,
                             const double execTime=ACTIONPRIM_DISABLE_EXECTIME,
                             ActionPrimitivesCallback *clb=NULL);
 
     /**
-    * Insert the arm-primitive action reach for target in the 
-    * actions queue. 
-    * @param x the 3-d target position [m]. 
-    * @param execTime the arm action execution time [s] (to be 
+    * Insert the arm-primitive action reach for target in the
+    * actions queue.
+    * @param x the 3-d target position [m].
+    * @param execTime the arm action execution time [s] (to be
     *          specified iff different from default value).
-    * @param clb action callback that is executed when the action 
+    * @param clb action callback that is executed when the action
     *            ends; none by default.
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool pushAction(const yarp::sig::Vector &x,
                             const double execTime=ACTIONPRIM_DISABLE_EXECTIME,
@@ -532,87 +532,87 @@ public:
 
     /**
     * Insert a hand-primitive action in the actions queue.
-    * @param handSeqKey the hand sequence key. 
-    * @param clb action callback that is executed when the action 
-    *            ends; none by default. 
-    * @return true/false on success/fail. 
+    * @param handSeqKey the hand sequence key.
+    * @param clb action callback that is executed when the action
+    *            ends; none by default.
+    * @return true/false on success/fail.
     */
     virtual bool pushAction(const std::string &handSeqKey,
                             ActionPrimitivesCallback *clb=NULL);
 
     /**
-    * Insert in the actions queue a trajectory in the operational 
-    * space parametrized in terms of waypoints. 
-    * @param wayPoints the list of waypoints that will be used to 
+    * Insert in the actions queue a trajectory in the operational
+    * space parametrized in terms of waypoints.
+    * @param wayPoints the list of waypoints that will be used to
     *                  generate the trajectory.
     * @note The first waypoint will act as the end-point of the path
     *       whose starting point is the current position of robot
     *       end-effector.
-    * @param clb action callback that is executed when the action 
-    *            ends; none by default. 
-    * @return true/false on success/fail. 
+    * @param clb action callback that is executed when the action
+    *            ends; none by default.
+    * @return true/false on success/fail.
     */
     virtual bool pushAction(const std::deque<ActionPrimitivesWayPoint> &wayPoints,
                             ActionPrimitivesCallback *clb=NULL);
 
     /**
-    * Insert in the actions queue a combination of hand and arm 
-    * trajectory in the operational space parametrized in terms of 
-    * waypoints. 
-    * @param wayPoints the list of waypoints that will be used to 
+    * Insert in the actions queue a combination of hand and arm
+    * trajectory in the operational space parametrized in terms of
+    * waypoints.
+    * @param wayPoints the list of waypoints that will be used to
     *                  generate the trajectory.
     * @note The first waypoint will act as the end-point of the path
     *       whose starting point is the current position of robot
-    *       end-effector. 
-    * @param handSeqKey the hand sequence key.  
-    * @param clb action callback that is executed when the action 
-    *            ends; none by default. 
-    * @return true/false on success/fail. 
+    *       end-effector.
+    * @param handSeqKey the hand sequence key.
+    * @param clb action callback that is executed when the action
+    *            ends; none by default.
+    * @return true/false on success/fail.
     */
     virtual bool pushAction(const std::deque<ActionPrimitivesWayPoint> &wayPoints,
                             const std::string &handSeqKey, ActionPrimitivesCallback *clb=NULL);
 
     /**
     * Insert a wait state in the actions queue.
-    * @param tmo is the wait timeout [s]. 
+    * @param tmo is the wait timeout [s].
     * @param clb callback that is executed when the timeout expires;
     *            none by default.
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool pushWaitState(const double tmo, ActionPrimitivesCallback *clb=NULL);
 
     /**
-    * Immediately update the current reaching target (without 
-    * affecting the actions queue) or initiate a new reach (if the 
+    * Immediately update the current reaching target (without
+    * affecting the actions queue) or initiate a new reach (if the
     * actions queue is empty).
-    * @param x the 3-d target position [m]. 
-    * @param o the 4-d hand orientation used while reaching (given 
+    * @param x the 3-d target position [m].
+    * @param o the 4-d hand orientation used while reaching (given
     *          in axis-angle representation: ax ay az angle in rad).
-    * @param execTime the arm action execution time [s] (to be 
+    * @param execTime the arm action execution time [s] (to be
     *          specified iff different from default value).
-    * @return true/false on success/fail. 
-    *  
-    * @note The intended use is for tracking moving targets. 
+    * @return true/false on success/fail.
+    *
+    * @note The intended use is for tracking moving targets.
     */
     virtual bool reachPose(const yarp::sig::Vector &x, const yarp::sig::Vector &o,
                            const double execTime=ACTIONPRIM_DISABLE_EXECTIME);
 
     /**
-    * Immediately update the current reaching target (without 
-    * affecting the actions queue) or initiate a new reach (if the 
+    * Immediately update the current reaching target (without
+    * affecting the actions queue) or initiate a new reach (if the
     * actions queue is empty).
-    * @param x the 3-d target position [m]. 
-    * @param execTime the arm action execution time [s] (to be 
+    * @param x the 3-d target position [m].
+    * @param execTime the arm action execution time [s] (to be
     *          specified iff different from default value).
-    * @return true/false on success/fail. 
-    *  
-    * @note The intended use is for tracking moving targets. 
+    * @return true/false on success/fail.
+    *
+    * @note The intended use is for tracking moving targets.
     */
     virtual bool reachPosition(const yarp::sig::Vector &x,
                                const double execTime=ACTIONPRIM_DISABLE_EXECTIME);
 
     /**
-    * Empty the actions queue. 
+    * Empty the actions queue.
     * @return true/false on success/fail.
     */
     virtual bool clearActionsQueue();
@@ -636,20 +636,20 @@ public:
     virtual bool getActionsLockStatus() const;
 
     /**
-    * Define an hand WayPoint (WP) to be added at the bottom of the 
-    * hand motion sequence pointed by the key. 
+    * Define an hand WayPoint (WP) to be added at the bottom of the
+    * hand motion sequence pointed by the key.
     * @param handSeqKey the hand sequence key.
-    * @param poss the 9 fingers joints WP positions to be attained 
+    * @param poss the 9 fingers joints WP positions to be attained
     *             [deg].
-    * @param vels the 9 fingers joints velocities [deg/s]. 
-    * @param tols the 9 fingers joints tolerances [deg] used to 
+    * @param vels the 9 fingers joints velocities [deg/s].
+    * @param tols the 9 fingers joints tolerances [deg] used to
     *             detect end motion condition (motion is considered
     *             finished if |des(i)-fb(i)|<tols(i)).
-    * @param thres the 5 fingers thresholds used for grasp 
+    * @param thres the 5 fingers thresholds used for grasp
     *              detection.
-    * @param tmo the wayPoint timeout. 
-    * @return true/false on success/fail. 
-    *  
+    * @param tmo the wayPoint timeout.
+    * @return true/false on success/fail.
+    *
     * @note this method creates a new empty wayPoint referred by the
     *       passed key if the key does not point to any valid
     *       sequence; hence the set (poss,vels,thres,tmo) will be
@@ -661,10 +661,10 @@ public:
 
     /**
     * Define an hand motion sequence from a configuration bottle.
-    * @param handSeqKey the hand sequence key. 
-    * @param sequence the configuration bottle. 
+    * @param handSeqKey the hand sequence key.
+    * @param sequence the configuration bottle.
     * @see open
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool addHandSequence(const std::string &handSeqKey,
                                  const yarp::os::Bottle &sequence);
@@ -672,14 +672,14 @@ public:
     /**
     * Check whether a sequence key is defined.
     * @param handSeqKey the hand sequence key.
-    * @return true iff valid key. 
+    * @return true iff valid key.
     */
     virtual bool isValidHandSeq(const std::string &handSeqKey);
 
     /**
     * Remove an already existing hand motion sequence.
     * @param handSeqKey the hand sequence key.
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool removeHandSeq(const std::string &handSeqKey);
 
@@ -690,26 +690,26 @@ public:
     std::deque<std::string> getHandSeqList();
 
     /**
-    * Return a hand sequence. 
-    * @param handSeqKey the hand sequence key. 
+    * Return a hand sequence.
+    * @param handSeqKey the hand sequence key.
     * @param sequence the bottle containing the sequence
     * @return true iff valid key.
     */
     virtual bool getHandSequence(const std::string &handSeqKey, yarp::os::Bottle &sequence);
 
     /**
-    * Query if fingers are moving. 
+    * Query if fingers are moving.
     * @param f the result of the check.
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool areFingersMoving(bool &f);
 
     /**
-    * Query if fingers are in position (cumulative response). 
-    * @param f the result of the check. 
-    * @return true/false on success/fail. 
-    *  
-    * @note Fingers are intended to be in position if they have 
+    * Query if fingers are in position (cumulative response).
+    * @param f the result of the check.
+    * @return true/false on success/fail.
+    *
+    * @note Fingers are intended to be in position if they have
     *       attained the desired position or while moving they
     *       follow the desired trajectory. Any possible contact
     *       among fingers or with objects causes the method to
@@ -718,11 +718,11 @@ public:
     virtual bool areFingersInPosition(bool &f);
 
     /**
-    * Query if fingers are in position (finger-wise response). 
-    * @param f a list containing the result of the single checks. 
-    * @return true/false on success/fail. 
-    *  
-    * @note Fingers are intended to be in position if they have 
+    * Query if fingers are in position (finger-wise response).
+    * @param f a list containing the result of the single checks.
+    * @return true/false on success/fail.
+    *
+    * @note Fingers are intended to be in position if they have
     *       attained the desired position or while moving they
     *       follow the desired trajectory. Any possible contact
     *       among fingers or with objects causes the method to
@@ -733,9 +733,9 @@ public:
     /**
     * Return the model used internally to detect external contacts.
     * @param model the perceptive model.
-    * @return true/false on success/fail. 
-    *  
-    * @note Useful to access the model methods as defined in \ref 
+    * @return true/false on success/fail.
+    *
+    * @note Useful to access the model methods as defined in \ref
     *       PerceptiveModels library, such as the calibration
     *       procedures.
     */
@@ -755,12 +755,12 @@ public:
 
     /**
     * Return the control status of torso joints.
-    * @param torso the vector containing the control status of torso 
+    * @param torso the vector containing the control status of torso
     *              joints.
     * @see getDOF
-    * @return true/false on success/fail. 
-    *  
-    * @note Unlike the arm, the torso is a part that can be shared, 
+    * @return true/false on success/fail.
+    *
+    * @note Unlike the arm, the torso is a part that can be shared,
     *       therefore the enabling/disabling of its joints must be
     *       properly notified.
     */
@@ -771,9 +771,9 @@ public:
     * @param torso the vector containing the control status of torso
     *              joints.
     * @see setDOF
-    * @return true/false on success/fail. 
-    *  
-    * @note Unlike the arm, the torso is a part that can be shared, 
+    * @return true/false on success/fail.
+    *
+    * @note Unlike the arm, the torso is a part that can be shared,
     *       therefore the enabling/disabling of its joints must be
     *       properly notified.
     */
@@ -781,9 +781,9 @@ public:
 
     /**
     * Get the current arm pose.
-    * @param x a 3-d vector which is filled with the actual 
+    * @param x a 3-d vector which is filled with the actual
     *         position x,y,z (meters).
-    * @param od a 4-d vector which is filled with the actual 
+    * @param od a 4-d vector which is filled with the actual
     *           orientation using axis-angle representation xa, ya,
     *           za, theta (meters and radians).
     * @return true/false on success/failure.
@@ -792,30 +792,30 @@ public:
 
     /**
     * Stop any ongoing arm/hand movements.
-    * @return true/false on success/fail. 
-    *  
-    * @note it empty out the actions queue. 
+    * @return true/false on success/fail.
+    *
+    * @note it empty out the actions queue.
     */
     virtual bool stopControl();
 
     /**
     * Set the default arm movement execution time.
-    * @param execTime execution time given in seconds. 
+    * @param execTime execution time given in seconds.
     * @return true/false on success/failure.
     */
     virtual bool setDefaultExecTime(const double execTime);
 
     /**
     * Get the current default arm movement execution time.
-    * @return current execution time given in seconds. 
+    * @return current execution time given in seconds.
     */
     virtual double getDefaultExecTime() const;
 
     /**
-    * Set the task space controller in tracking or non-tracking 
-    * mode. 
-    * @param f true for tracking mode, false otherwise. 
-    * @note In tracking mode the cartesian position is mantained on 
+    * Set the task space controller in tracking or non-tracking
+    * mode.
+    * @param f true for tracking mode, false otherwise.
+    * @note In tracking mode the cartesian position is mantained on
     *       the reached target.
     * @return true/false on success/failure.
     */
@@ -823,15 +823,15 @@ public:
 
     /**
     * Get the current controller mode.
-    * @return true/false on tracking/non-tracking mode. 
+    * @return true/false on tracking/non-tracking mode.
     */
     virtual bool getTrackingMode() const;
 
     /**
-    * Enable the waving mode that keeps on moving the arm around a 
-    * predefined position. 
-    * @param restPos: the 3-d position around which to wave. 
-    * @note useful to give a kind of more human perception when the 
+    * Enable the waving mode that keeps on moving the arm around a
+    * predefined position.
+    * @param restPos: the 3-d position around which to wave.
+    * @note useful to give a kind of more human perception when the
     *       arm is homed. This mode is automatically disabled each
     *       time a new action is commanded.
     * @return true/false on success/failure.
@@ -847,7 +847,7 @@ public:
     /**
     * Enable timeout while reaching.
     * @param tmo the timeout given in seconds.
-    * @note if a reaching task is not accomplished within the 
+    * @note if a reaching task is not accomplished within the
     *       timeout, then the action is considered done.
     * @return true/false on success/failure.
     */
@@ -861,12 +861,12 @@ public:
 
     /**
     * Check whether all the actions in queue are accomplished.
-    * @param f the result of the check. 
-    * @param sync if true wait until all actions are accomplished 
+    * @param f the result of the check.
+    * @param sync if true wait until all actions are accomplished
     *             (blocking call).
-    * @return true/false on success/fail. 
-    *  
-    * @note As specified the check is performed on the content of 
+    * @return true/false on success/fail.
+    *
+    * @note As specified the check is performed on the content of
     *       the actions queue so that the blocking call returns as
     *       soon as the queue is empty.
     */
@@ -874,56 +874,56 @@ public:
 
     /**
     * Check whether an action is still ongoing.
-    * @param f the result of the check. 
-    * @param sync if true wait that at least one action has just 
+    * @param f the result of the check.
+    * @param sync if true wait that at least one action has just
     *             started (blocking call).
-    * @return true/false on success/fail. 
-    *  
-    * @note Sometimes it might be helpful to wait in the calling 
+    * @return true/false on success/fail.
+    *
+    * @note Sometimes it might be helpful to wait in the calling
     *       module until the beginning of the action inserted in the
     *       queue. For example:
-    * @code 
-    * pushAction(A); 
-    * checkActionOnGoing(f,true); 
-    * // perform some computations that require the motion has been 
-    * // started off 
-    * checkActionsDone(f,true); 
-    * @endcode 
+    * @code
+    * pushAction(A);
+    * checkActionOnGoing(f,true);
+    * // perform some computations that require the motion has been
+    * // started off
+    * checkActionsDone(f,true);
+    * @endcode
     */
     virtual bool checkActionOnGoing(bool &f, const bool sync=false);
 
     /**
-    * Suddenly interrupt any blocking call that is pending on 
-    * querying the action status. 
-    * @param disable disable the blocking feature for future 
-    * calls with sync switch on; useful to allow a graceful stop of 
-    * the application. 
+    * Suddenly interrupt any blocking call that is pending on
+    * querying the action status.
+    * @param disable disable the blocking feature for future
+    * calls with sync switch on; useful to allow a graceful stop of
+    * the application.
     * @see syncCheckReinstate
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool syncCheckInterrupt(const bool disable=false);
 
     /**
-    * Reinstate the blocking feature for future calls with sync 
-    * switch on. 
-    * @return true/false on success/fail. 
+    * Reinstate the blocking feature for future calls with sync
+    * switch on.
+    * @return true/false on success/fail.
     */
-    virtual bool syncCheckReinstate();    
+    virtual bool syncCheckReinstate();
 };
 
 
 /**
 * \ingroup ActionPrimitives
 *
-* A derived class defining a first abstraction layer on top of 
-* @ref ActionPrimitives father class. 
-*  
+* A derived class defining a first abstraction layer on top of
+* @ref ActionPrimitives father class.
+*
 * It internally predeclares (without actually defining) a set of
-* hand sequence motions key ("open_hand", "close_hand" and 
-* "karate_hand" :) that are used for grasp(), touch() and tap() 
-* actions. 
-*  
-* @note Given as an example of how primitive actions can be 
+* hand sequence motions key ("open_hand", "close_hand" and
+* "karate_hand" :) that are used for grasp(), touch() and tap()
+* actions.
+*
+* @note Given as an example of how primitive actions can be
 *       combined in higher level actions, thus how further
 *       layers can be inherited from the base class.
 */
@@ -931,12 +931,12 @@ class ActionPrimitivesLayer1 : public ActionPrimitives
 {
 public:
     /**
-    * Default Constructor. 
+    * Default Constructor.
     */
     ActionPrimitivesLayer1() : ActionPrimitives() { }
 
     /**
-    * Constructor. 
+    * Constructor.
     * @param opt the Property used to configure the object after its
     *            creation.
     */
@@ -944,77 +944,77 @@ public:
 
     /**
     * Grasp the given target (combined action).
-    * @param x the 3-d target position [m]. 
+    * @param x the 3-d target position [m].
     * @param o the 4-d hand orientation used while reaching/grasping
     *          (given in axis-angle representation: ax ay az angle
     *          in rad).
-    * @param d the displacement [m] wrt the target position that 
+    * @param d the displacement [m] wrt the target position that
     *          identifies a location to be reached prior to
     *          grasping.
-    * @return true/false on success/fail. 
-    *  
-    * @note internal implementation (pseudo-code): 
-    * @code 
-    * ... 
-    * pushAction(x+d,o,"open_hand"); 
-    * pushAction(x,o); 
-    * pushAction("close_hand"); 
-    * ... 
-    * @endcode 
-    *  
+    * @return true/false on success/fail.
+    *
+    * @note internal implementation (pseudo-code):
+    * @code
+    * ...
+    * pushAction(x+d,o,"open_hand");
+    * pushAction(x,o);
+    * pushAction("close_hand");
+    * ...
+    * @endcode
+    *
     * It reachs for (x+d,o) opening the hand, then reachs for (x,o)
-    * and finally closes the hand. 
+    * and finally closes the hand.
     */
     virtual bool grasp(const yarp::sig::Vector &x, const yarp::sig::Vector &o,
                        const yarp::sig::Vector &d);
 
     /**
     * Touch the given target (combined action).
-    * @param x the 3-d target position [m]. 
+    * @param x the 3-d target position [m].
     * @param o the 4-d hand orientation used while reaching/touching
     *          (given in axis-angle representation: ax ay az angle
     *          in rad).
-    * @param d the displacement [m] wrt the target position that 
+    * @param d the displacement [m] wrt the target position that
     *          identifies a location to be reached prior to
     *          touching.
-    * @return true/false on success/fail. 
-    *  
-    * @note internal implementation (pseudo-code): 
-    * @code 
-    * ... 
-    * pushAction(x+d,o,"karate_hand"); 
-    * pushAction(x,o); 
-    * ... 
-    * @endcode 
-    *  
-    * It reachs for (x+d,o), then reachs for (x,o). 
-    * Similar to grasp but without final hand action. 
+    * @return true/false on success/fail.
+    *
+    * @note internal implementation (pseudo-code):
+    * @code
+    * ...
+    * pushAction(x+d,o,"karate_hand");
+    * pushAction(x,o);
+    * ...
+    * @endcode
+    *
+    * It reachs for (x+d,o), then reachs for (x,o).
+    * Similar to grasp but without final hand action.
     */
     virtual bool touch(const yarp::sig::Vector &x, const yarp::sig::Vector &o,
                        const yarp::sig::Vector &d);
 
     /**
     * Tap the given target (combined action).
-    * @param x1 the fisrt 3-d target position [m]. 
-    * @param o1 the first 4-d hand orientation (given in axis-angle 
+    * @param x1 the fisrt 3-d target position [m].
+    * @param o1 the first 4-d hand orientation (given in axis-angle
     *           representation: ax ay az angle in rad).
-    * @param x2 the second 3-d target position [m]. 
+    * @param x2 the second 3-d target position [m].
     * @param o2 the second 4-d hand orientation (given in axis-angle
     *           representation: ax ay az angle in rad).
-    * @param execTime the arm action execution time only while 
+    * @param execTime the arm action execution time only while
     *          tapping [s] (to be specified iff different from
     *          default value).
-    * @return true/false on success/fail. 
-    *  
-    * @note internal implementation (pseudo-code): 
-    * @code 
+    * @return true/false on success/fail.
+    *
+    * @note internal implementation (pseudo-code):
+    * @code
     * ...
     * pushAction(x1,o1,"karate_hand");
     * pushAction(x2,o2,execTime);
-    * pushAction(x1,o1); 
-    * ... 
-    * @endcode 
-    *  
+    * pushAction(x1,o1);
+    * ...
+    * @endcode
+    *
     * It reachs for (x1,o1), then reachs for (x2,o2) and then again
     * for (x1,o1).
     */
@@ -1059,12 +1059,12 @@ public:
 /**
 * \ingroup ActionPrimitives
 *
-* A class that inherits from @ref ActionPrimitivesLayer1 and 
-* integrates the force-torque sensing in order to stop the limb 
-* while reaching as soon as a contact with external objects is 
-* detected. 
+* A class that inherits from @ref ActionPrimitivesLayer1 and
+* integrates the force-torque sensing in order to stop the limb
+* while reaching as soon as a contact with external objects is
+* detected.
 * The module \ref wholeBodyDynamics - in charge of computing the
-* robot dynamics - must be running. 
+* robot dynamics - must be running.
 */
 class ActionPrimitivesLayer2 : public ActionPrimitivesLayer1
 {
@@ -1098,21 +1098,21 @@ protected:
 
 public:
     /**
-    * Default Constructor. 
+    * Default Constructor.
     */
     ActionPrimitivesLayer2();
 
     /**
-    * Constructor. 
+    * Constructor.
     * @param opt the Property used to configure the object after its
     *            creation.
     */
     ActionPrimitivesLayer2(yarp::os::Property &opt);
 
     /**
-    * Destructor. 
-    *  
-    * @note it calls the close() method. 
+    * Destructor.
+    *
+    * @note it calls the close() method.
     */
     virtual ~ActionPrimitivesLayer2();
 
@@ -1120,24 +1120,24 @@ public:
     * Configure the object.
     * @param opt the Property used to configure the object after its
     *            creation.
-    *  
-    * @note To be called after object creation. 
-    *  
-    * Further available options are: 
-    *  
-    * @b ext_force_thres <double>: specify the maximum external 
+    *
+    * @note To be called after object creation.
+    *
+    * Further available options are:
+    *
+    * @b ext_force_thres <double>: specify the maximum external
     *    force magnitude applied to the end-effector in order to
     *    detect contact between end-effector and objects while
     *    reaching.
-    *  
-    * @b wbdyn_stem_name <string>: specify the stem-name of the 
+    *
+    * @b wbdyn_stem_name <string>: specify the stem-name of the
     *    \ref wholeBodyDynamics module.
-    *  
-    * @b wbdyn_port_name <string>: specify the tag-name of the port 
+    *
+    * @b wbdyn_port_name <string>: specify the tag-name of the port
     *    used by \ref wholeBodyDynamics to stream out the wrench at
     *    the end-effector.
-    *  
-    * @note A port called <i> /<local>/<part>/wbdyn:i </i> is open 
+    *
+    * @note A port called <i> /<local>/<part>/wbdyn:i </i> is open
     *       to acquire data provided by \ref wholeBodyDynamics. The
     *       port is automatically connected to
     *       /<wbdyn_stem_name>/<part>/<wbdyn_port_name>.
@@ -1145,8 +1145,8 @@ public:
     virtual bool open(yarp::os::Property &opt);
 
     /**
-    * Check if the object is initialized correctly. 
-    * @return true/fail on success/fail. 
+    * Check if the object is initialized correctly.
+    * @return true/fail on success/fail.
     */
     virtual bool isValid() const;
 
@@ -1156,99 +1156,99 @@ public:
     virtual void close();
 
     /**
-    * More evolute version of grasp. It exploits the contact 
-    * detection in order to lift up a bit the hand prior to 
+    * More evolute version of grasp. It exploits the contact
+    * detection in order to lift up a bit the hand prior to
     * grasping (this happens only after contact).
-    * @param x the 3-d target position [m]. 
+    * @param x the 3-d target position [m].
     * @param o the 4-d hand orientation used while reaching/grasping
     *          (given in axis-angle representation: ax ay az angle
     *          in rad).
-    * @param d1 the displacement [m] wrt the target position that 
+    * @param d1 the displacement [m] wrt the target position that
     *          identifies a location to be reached prior to
     *          grasping.
-    * @param d2 the displacement [m] that identifies the amount of 
+    * @param d2 the displacement [m] that identifies the amount of
     *           the lift after the contact.
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool grasp(const yarp::sig::Vector &x, const yarp::sig::Vector &o,
                        const yarp::sig::Vector &d1, const yarp::sig::Vector &d2);
 
     /**
     * The usual grasp is still available.
-    * @param x the 3-d target position [m]. 
+    * @param x the 3-d target position [m].
     * @param o the 4-d hand orientation used while reaching/grasping
     *          (given in axis-angle representation: ax ay az angle
     *          in rad).
-    * @param d the displacement [m] wrt the target position that 
+    * @param d the displacement [m] wrt the target position that
     *          identifies a location to be reached prior to
     *          grasping.
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool grasp(const yarp::sig::Vector &x, const yarp::sig::Vector &o,
                        const yarp::sig::Vector &d);
 
     /**
     * More evolute version of touch, exploiting contact detection.
-    * @param x the 3-d target position [m]. 
+    * @param x the 3-d target position [m].
     * @param o the 4-d hand orientation used while reaching/touching
     *          (given in axis-angle representation: ax ay az angle
     *          in rad).
-    * @param d the displacement [m] wrt the target position that 
+    * @param d the displacement [m] wrt the target position that
     *          identifies a location to be reached prior to
     *          touching.
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool touch(const yarp::sig::Vector &x, const yarp::sig::Vector &o,
                        const yarp::sig::Vector &d);
 
     /**
     * Retrieve the current wrench on the end-effector.
-    * @param wrench a vector containing the external forces/moments 
+    * @param wrench a vector containing the external forces/moments
     *               acting on the end-effector.
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool getExtWrench(yarp::sig::Vector &wrench) const;
 
     /**
-    * Retrieve the current threshold on the external force used to 
-    * stop the limb while reaching. 
+    * Retrieve the current threshold on the external force used to
+    * stop the limb while reaching.
     * @param thres where to return the threshold.
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool getExtForceThres(double &thres) const;
 
     /**
     * Set the threshold on the external force used to stop the limb
-    * while reaching. 
+    * while reaching.
     * @param thres the new threshold.
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool setExtForceThres(const double thres);
 
     /**
     * Self-explaining :)
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool enableContactDetection();
 
     /**
     * Self-explaining :)
-    * @return true/false on success/fail. 
+    * @return true/false on success/fail.
     */
     virtual bool disableContactDetection();
 
     /**
-    * Self-explaining :) 
-    * @param f the result of the check.  
-    * @return true/false on success/fail. 
+    * Self-explaining :)
+    * @param f the result of the check.
+    * @return true/false on success/fail.
     */
     virtual bool isContactDetectionEnabled(bool &f) const;
 
     /**
-    * Check whether the reaching has been stopped due to a contact 
-    * with external objects. 
-    * @param f the result of the check. 
-    * @return true/false on success/fail. 
+    * Check whether the reaching has been stopped due to a contact
+    * with external objects.
+    * @param f the result of the check.
+    * @return true/false on success/fail.
     */
     virtual bool checkContact(bool &f) const;
 };

--- a/src/libraries/actionPrimitives/src/actionPrimitives.cpp
+++ b/src/libraries/actionPrimitives/src/actionPrimitives.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2010 RobotCub Consortium, European Commission FP6 Project IST-004370
  * Author: Ugo Pattacini
  * email:  ugo.pattacini@iit.it
@@ -33,7 +33,7 @@
 #include <iCub/action/actionPrimitives.h>
 
 #define RES_WAVER(x)                                (dynamic_cast<ArmWavingMonitor*>(x))
-                                                    
+
 #define ACTIONPRIM_DEFAULT_PER                      50      // [ms]
 #define ACTIONPRIM_DEFAULT_EXECTIME                 2.0     // [s]
 #define ACTIONPRIM_DEFAULT_REACHTOL                 0.005   // [m]
@@ -353,7 +353,7 @@ void ActionPrimitives::init()
     fingersInPosition=true;
     fingerInPosition.insert(fingerInPosition.begin(),5,true);
     reachTmoEnabled=false;
-    locked=false;    
+    locked=false;
 
     latchTimerWait=waitTmo=0.0;
     latchTimerReach=reachTmo=0.0;
@@ -376,10 +376,10 @@ void ActionPrimitives::printMessage(const int logtype, const char *format, ...) 
     {
         string str;
         str="*** "+local+"/"+part+": ";
-    
+
         va_list arg;
         char buf[512];
-        va_start(arg,format);        
+        va_start(arg,format);
         vsnprintf(buf,sizeof(buf),format,arg);
         va_end(arg);
 
@@ -468,22 +468,22 @@ bool ActionPrimitives::configHandSeq(Property &opt)
 {
     if (opt.check("hand_sequences_file"))
     {
-        string handSeqFile=opt.find("hand_sequences_file").asString();        
+        string handSeqFile=opt.find("hand_sequences_file").asString();
 
         printMessage(log::info,"Processing %s file",handSeqFile.c_str());
         Property handSeqProp; handSeqProp.fromConfigFile(handSeqFile);
-    
+
         // GENERAL group
         Bottle &bGeneral=handSeqProp.findGroup("GENERAL");
         if (bGeneral.isNull())
         {
-            printMessage(log::warning,"\"GENERAL\" group is missing");    
+            printMessage(log::warning,"\"GENERAL\" group is missing");
             return false;
         }
 
         if (!bGeneral.check("numSequences"))
         {
-            printMessage(log::warning,"\"numSequences\" option is missing");    
+            printMessage(log::warning,"\"numSequences\" option is missing");
             return false;
         }
 
@@ -519,7 +519,7 @@ bool ActionPrimitives::configHandSeq(Property &opt)
 
             addHandSequence(key,bSeq);
         }
-    
+
         return true;
     }
     else
@@ -548,7 +548,7 @@ bool ActionPrimitives::configGraspModel(Property &opt)
                     return false;
                 }
 
-                string modelFile=opt.find("grasp_model_file").asString();                
+                string modelFile=opt.find("grasp_model_file").asString();
                 printMessage(log::info,"Retrieving grasp model data from %s file",modelFile.c_str());
                 Property modelProp; modelProp.fromConfigFile(modelFile);
 
@@ -600,9 +600,9 @@ bool ActionPrimitives::open(Property &opt)
     part=opt.check("part",Value(ACTIONPRIM_DEFAULT_PART)).asString();
     default_exec_time=opt.check("default_exec_time",Value(ACTIONPRIM_DEFAULT_EXECTIME)).asFloat64();
     tracking_mode=opt.check("tracking_mode",Value(ACTIONPRIM_DEFAULT_TRACKINGMODE)).asString()=="on"?true:false;
-    verbose=opt.check("verbosity",Value(ACTIONPRIM_DEFAULT_VERBOSITY)).asString()=="on"?true:false;    
+    verbose=opt.check("verbosity",Value(ACTIONPRIM_DEFAULT_VERBOSITY)).asString()=="on"?true:false;
 
-    int period=opt.check("thread_period",Value(ACTIONPRIM_DEFAULT_PER)).asInt32();    
+    int period=opt.check("thread_period",Value(ACTIONPRIM_DEFAULT_PER)).asInt32();
     double reach_tol=opt.check("reach_tol",Value(ACTIONPRIM_DEFAULT_REACHTOL)).asFloat64();
 
     // create the model for grasp detection (if any)
@@ -637,7 +637,7 @@ bool ActionPrimitives::open(Property &opt)
 
     // open views
     polyHand.view(modCtrl);
-    polyHand.view(encCtrl);    
+    polyHand.view(encCtrl);
     polyHand.view(posCtrl);
     polyCart.view(cartCtrl);
 
@@ -667,7 +667,7 @@ bool ActionPrimitives::open(Property &opt)
     disableTorsoDof();
 
     jHandMin=7;                     // hand first joint
-    posCtrl->getAxes(&jHandMax);    // hand last joint
+    posCtrl->getAxes(jHandMax);    // hand last joint
 
     // hand joints set
     for (int j=jHandMin; j<jHandMax; j++)
@@ -776,7 +776,7 @@ bool ActionPrimitives::isHandSeqEnded()
 
                 // take joints belonging to the finger
                 pair<multimap<int,int>::iterator,multimap<int,int>::iterator> i=fingers2JntsMap.equal_range(fng);
-                
+
                 for (multimap<int,int>::iterator j=i.first; j!=i.second; ++j)
                 {
                     int jnt=j->second;
@@ -790,7 +790,7 @@ bool ActionPrimitives::isHandSeqEnded()
                         posCtrl->stop(jnt);
                         tmpSet.erase(jnt);
                     }
-                }                
+                }
             }
         }
     }
@@ -878,7 +878,7 @@ bool ActionPrimitives::_pushAction(const bool execArm, const Vector &x, const Ve
     {
         lock_guard<mutex> lck(mtx);
         Action action;
-    
+
         action.waitState=false;
         action.execArm=execArm;
         action.x=x;
@@ -924,7 +924,7 @@ bool ActionPrimitives::_pushAction(const Vector &x, const Vector &o,
                     // decompose hand action in sum of fingers sequences
                     for (i=1; i<q.size()-1; i++)
                         _pushAction(false,vectDummy,vectDummy,ACTIONPRIM_DISABLE_EXECTIME,false,true,q[i],false,NULL);
-    
+
                     // reserve the callback whenever the last hand WP is achieved
                     if (i<q.size())
                         _pushAction(false,vectDummy,vectDummy,ACTIONPRIM_DISABLE_EXECTIME,false,true,q[i],true,clb);
@@ -936,7 +936,7 @@ bool ActionPrimitives::_pushAction(const Vector &x, const Vector &o,
         else
         {
             printMessage(log::warning,"\"%s\" hand sequence key not found",
-                         handSeqKey.c_str());    
+                         handSeqKey.c_str());
 
             return false;
         }
@@ -1026,7 +1026,7 @@ bool ActionPrimitives::pushAction(const string &handSeqKey,
         else
         {
             printMessage(log::warning,"\"%s\" hand sequence key not found",
-                         handSeqKey.c_str());    
+                         handSeqKey.c_str());
 
             return false;
         }
@@ -1090,7 +1090,7 @@ bool ActionPrimitives::pushAction(const deque<ActionPrimitivesWayPoint> &wayPoin
                 action.wayPointsThr=thr;
                 action.clb=(q.size()==1?clb:NULL);
 
-                actionsQueue.push_back(action);                
+                actionsQueue.push_back(action);
 
                 if (q.size()>1)
                 {
@@ -1100,7 +1100,7 @@ bool ActionPrimitives::pushAction(const deque<ActionPrimitivesWayPoint> &wayPoin
                     // decompose hand action in sum of fingers sequences
                     for (i=1; i<q.size()-1; i++)
                         _pushAction(false,vectDummy,vectDummy,ACTIONPRIM_DISABLE_EXECTIME,false,true,q[i],false,NULL);
-    
+
                     // reserve the callback whenever the last hand WP is achieved
                     if (i<q.size())
                         _pushAction(false,vectDummy,vectDummy,ACTIONPRIM_DISABLE_EXECTIME,false,true,q[i],true,clb);
@@ -1112,7 +1112,7 @@ bool ActionPrimitives::pushAction(const deque<ActionPrimitivesWayPoint> &wayPoin
         else
         {
             printMessage(log::warning,"\"%s\" hand sequence key not found",
-                         handSeqKey.c_str());    
+                         handSeqKey.c_str());
             return false;
         }
     }
@@ -1134,7 +1134,7 @@ bool ActionPrimitives::pushWaitState(const double tmo, ActionPrimitivesCallback 
         action.execArm=false;
         action.execHand=false;
         action.handSeqTerminator=false;
-        action.execWayPoints=false;        
+        action.execWayPoints=false;
         action.clb=clb;
 
         actionsQueue.push_back(action);
@@ -1257,7 +1257,7 @@ bool ActionPrimitives::execPendingHandSequences()
 
         // if it is an hand-action then execute and update queue
         if (action.execHand && !action.execArm && !action.waitState)
-        {    
+        {
             actionsQueue.pop_front();
             cmdHand(action);
             exec=true;
@@ -1311,7 +1311,7 @@ void ActionPrimitives::run()
         }
 
         if (armMoveDone)
-        {    
+        {
             printMessage(log::no_info,"reaching complete");
             disableTorsoDof();
         }
@@ -1323,7 +1323,7 @@ void ActionPrimitives::run()
         // to a complete stop
         handMoveDone=isHandSeqEnded();
         if (handMoveDone)
-        {    
+        {
             printMessage(log::no_info,"hand WP reached");
 
             if (!handSeqTerminator)
@@ -1336,12 +1336,12 @@ void ActionPrimitives::run()
     latchHandMoveDone=handMoveDone;
 
     if (latchArmMoveDone && latchHandMoveDone && (t-latchTimerWait>waitTmo))
-    {    
+    {
         // execute action-end callback
         if (actionClb!=NULL)
         {
             printMessage(log::no_info,"executing action-end callback ...");
-            actionClb->exec();            
+            actionClb->exec();
             printMessage(log::no_info,"... action-end callback executed");
 
             actionClb=NULL;
@@ -1403,7 +1403,7 @@ void ActionPrimitives::disableTorsoDof()
 bool ActionPrimitives::wait(const Action &action)
 {
     if (configured)
-    {        
+    {
         printMessage(log::no_info,"wait for %g seconds",action.tmo);
         waitTmo=action.tmo;
         latchTimerWait=Time::now();
@@ -1436,7 +1436,7 @@ bool ActionPrimitives::cmdArm(const Action &action)
                 printMessage(log::error,"reach log::error");
                 return false;
             }
-            
+
             printMessage(log::no_info,"reach at %g [s] for [%s], [%s]",t,
                          x.toString(3,3).c_str(),
                          o.toString(3,3).c_str());
@@ -1495,7 +1495,7 @@ bool ActionPrimitives::cmdHand(const Action &action)
         const Vector &tols=action.handWP.tols;
         const Vector &thres=action.handWP.thres;
         const double &tmo=action.handWP.tmo;
-        
+
         fingersMovingJntsSet=fingersJntsSet;
         curHandFinalPoss=poss;
         curHandTols=tols;
@@ -1509,7 +1509,7 @@ bool ActionPrimitives::cmdHand(const Action &action)
             modCtrl->setControlMode(j,VOCAB_CM_POSITION);
             posCtrl->setTrajSpeed(j,vels[j-jHandMin]);
         }
-        
+
         posCtrl->positionMove((int)sz,fingersJnts.data(),poss.data());
 
         latchHandMoveDone=handMoveDone=false;
@@ -1545,7 +1545,7 @@ bool ActionPrimitives::addHandSeqWP(const string &handSeqKey, const Vector &poss
         handWP.tols=tols;
         handWP.thres=thres;
         handWP.tmo=tmo;
-    
+
         handSeqMap[handSeqKey].push_back(handWP);
 
         return true;
@@ -1664,7 +1664,7 @@ bool ActionPrimitives::removeHandSeq(const string &handSeqKey)
     map<string,deque<HandWayPoint> >::iterator itr=handSeqMap.find(handSeqKey);
 
     if (itr!=handSeqMap.end())
-    {    
+    {
         handSeqMap[handSeqKey].clear();
         return true;
     }
@@ -1698,7 +1698,7 @@ bool ActionPrimitives::getHandSequence(const string &handSeqKey, Bottle &sequenc
         Bottle &bNum=sequence.addList();
         bNum.addString("numWayPoints");
         bNum.addInt32((int)handWP.size());
-        
+
         // wayPoints parts
         for (unsigned int i=0; i<handWP.size(); i++)
         {
@@ -1740,7 +1740,7 @@ bool ActionPrimitives::getHandSequence(const string &handSeqKey, Bottle &sequenc
             Bottle &bTmo=bWP.addList();
             bTmo.addString("tmo");
             bTmo.addFloat64(handWP[i].tmo);
-        }       
+        }
 
         return true;
     }
@@ -1897,7 +1897,7 @@ bool ActionPrimitives::setDefaultExecTime(const double execTime)
 {
     if (configured && (execTime>0.0))
     {
-        default_exec_time=execTime; 
+        default_exec_time=execTime;
         return true;
     }
     else
@@ -2134,7 +2134,7 @@ void liftAndGraspCallback::exec()
         action->cartCtrl->getPose(x,o);
         action->printMessage(log::no_info,"logged 3-d pos: [%s]",
                              x.toString(3,3).c_str());
-    
+
         action->pushAction(x+action->grasp_d2,action->grasp_o);
     }
 
@@ -2170,7 +2170,7 @@ ActionPrimitivesLayer2::ActionPrimitivesLayer2(Property &opt) :
 
 /************************************************************************/
 void ActionPrimitivesLayer2::init()
-{    
+{
     skipFatherPart=false;
     configuredLayer2=false;
     contactDetectionOn=false;
@@ -2197,7 +2197,7 @@ void ActionPrimitivesLayer2::run()
 {
     // skip until this layer is configured
     if (!configuredLayer2)
-        return;    
+        return;
 
     // get the input from WBDYN
     if (Vector *wbdynWrench=wbdynPortIn.read(false))

--- a/src/libraries/iKin/src/iKinSlv.cpp
+++ b/src/libraries/iKin/src/iKinSlv.cpp
@@ -44,11 +44,11 @@ bool RpcProcessor::read(ConnectionReader &connection)
         Bottle cmd, reply;
         if (!cmd.read(connection))
             return false;
-    
+
         slv->respond(cmd,reply);
         if (ConnectionWriter *writer=connection.getWriter())
             reply.write(*writer);
-    
+
         return true;
     }
     else
@@ -245,7 +245,7 @@ void InputPort::onRead(Bottle &b)
 
     // shall be the last handling
     if (xdOptIn)
-    {    
+    {
         if (!handleTarget(b.find(Vocab32::decode(IKINSLV_VOCAB_OPT_XD)).asList()))
             yWarning("%s: expected %s data",slv->slvName.c_str(),
                      Vocab32::decode(IKINSLV_VOCAB_OPT_XD).c_str());
@@ -266,7 +266,7 @@ void SolverCallback::exec(const Vector &xd, const Vector &q)
 /************************************************************************/
 CartesianSolver::CartesianSolver(const string &_slvName) :
                                 PeriodicThread((double)CARTSLV_DEFAULT_PER/1000.0)
-{          
+{
     // initialization
     slvName=_slvName;
     configured=false;
@@ -299,7 +299,7 @@ CartesianSolver::CartesianSolver(const string &_slvName) :
 
 /************************************************************************/
 PolyDriver *CartesianSolver::waitPart(const Property &partOpt)
-{    
+{
     string partName=partOpt.find("part").asString();
     PolyDriver *pDrv=NULL;
 
@@ -341,14 +341,14 @@ bool CartesianSolver::alignJointsBounds()
 {
     hwLimits.resize(prt->chn->getN(),2);
     double min, max;
-    int cnt=0;    
-    
+    int cnt=0;
+
     yInfo("%s: aligning joints bounds ...",slvName.c_str());
     for (int i=0; i<prt->num; i++)
     {
         yInfo("part #%d: %s",i,prt->prp[i].find("part").asString().c_str());
         for (int j=0; j<jnt[i]; j++)
-        {               
+        {
             if (!lim[i]->getPosLimits(rmp[i][j],&min,&max))
             {
                 yError("joint #%d: failed getting limits!",cnt);
@@ -361,7 +361,7 @@ bool CartesianSolver::alignJointsBounds()
 
             hwLimits(cnt,0)=min;
             hwLimits(cnt,1)=max;
-        
+
             cnt++;
         }
     }
@@ -411,7 +411,7 @@ void CartesianSolver::latchUncontrolledJoints(Vector &joints)
     {
         joints.resize(unctrlJointsNum);
         int j=0;
-        
+
         for (unsigned int i=0; i<prt->chn->getN(); i++)
             if ((*prt->chn)[i].isBlocked())
                 joints[j++]=prt->chn->getAng(i);
@@ -428,7 +428,7 @@ void CartesianSolver::getFeedback(const bool wait)
     int chainCnt=0;
 
     for (int i=0; i<prt->num; i++)
-    {    
+    {
         bool ok=enc[i]->getEncoders(fbTmp.data());
         while (wait && !closing && !ok)
         {
@@ -437,21 +437,21 @@ void CartesianSolver::getFeedback(const bool wait)
         }
 
         if (ok)
-        {    
+        {
             for (int j=0; j<jnt[i]; j++)
             {
                 double tmp=CTRL_DEG2RAD*fbTmp[rmp[i][j]];
-            
+
                 if ((*prt->chn)[chainCnt].isBlocked())
                     prt->chn->setBlockingValue(chainCnt,tmp);
                 else
                     prt->chn->setAng(chainCnt,tmp);
-            
+
                 chainCnt++;
             }
         }
         else
-        {    
+        {
             yWarning("%s: timeout detected on part %s!",
                      slvName.c_str(),prt->prp[i].find("part").asString().c_str());
 
@@ -533,15 +533,15 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                         case IKINSLV_VOCAB_OPT_POSE:
                         {
                             reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
-                    
+
                             if (ctrlPose==IKINCTRL_POSE_FULL)
                                 reply.addVocab32(IKINSLV_VOCAB_VAL_POSE_FULL);
                             else
                                 reply.addVocab32(IKINSLV_VOCAB_VAL_POSE_XYZ);
-                    
+
                             break;
                         }
-                    
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_PRIO:
                         {
@@ -560,22 +560,22 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                         case IKINSLV_VOCAB_OPT_MODE:
                         {
                             reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
-                    
+
                             if (inPort->get_contMode())
                                 reply.addVocab32(IKINSLV_VOCAB_VAL_MODE_TRACK);
                             else
                                 reply.addVocab32(IKINSLV_VOCAB_VAL_MODE_SINGLE);
-                    
+
                             break;
                         }
-                    
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_LIM:
                         {
                             if (command.size()>2)
-                            {                    
+                            {
                                 int axis=command.get(2).asInt32();
-                    
+
                                 if (axis<(int)prt->chn->getN())
                                 {
                                     reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
@@ -587,23 +587,23 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                             }
                             else
                                 reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
-                    
+
                             break;
                         }
-                    
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_VERB:
                         {
                             reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
-                    
+
                             if (verbosity)
                                 reply.addVocab32(IKINSLV_VOCAB_VAL_ON);
                             else
                                 reply.addVocab32(IKINSLV_VOCAB_VAL_OFF);
-                    
+
                             break;
                         }
-                    
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_DOF:
                         {
@@ -612,7 +612,7 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                             fillDOFInfo(dofPart);
                             break;
                         }
-                    
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_REST_POS:
                         {
@@ -620,7 +620,7 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                             handleJointsRestPosition(NULL,&reply);
                             break;
                         }
-                    
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_REST_WEIGHTS:
                         {
@@ -628,14 +628,14 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                             handleJointsRestWeights(NULL,&reply);
                             break;
                         }
-                    
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_TASK2:
                         {
                             reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                             Bottle &payLoad=reply.addList();
                             payLoad.addInt32(slv->get2ndTaskChain().getN());
-            
+
                             Bottle &posPart=payLoad.addList();
                             for (size_t i=0; i<xd_2ndTask.length(); i++)
                                 posPart.addFloat64(xd_2ndTask[i]);
@@ -643,10 +643,10 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                             Bottle &weightsPart=payLoad.addList();
                             for (size_t i=0; i<w_2ndTask.length(); i++)
                                 weightsPart.addFloat64(w_2ndTask[i]);
-            
-                            break; 
+
+                            break;
                         }
-            
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_CONVERGENCE:
                         {
@@ -675,10 +675,10 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                 }
                 else
                     reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
-            
+
                 break;
             }
-            
+
             //-----------------
             case IKINSLV_VOCAB_CMD_SET:
             {
@@ -693,10 +693,10 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                                 reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                             else
                                 reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
-                    
+
                             break;
                         }
-                    
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_PRIO:
                         {
@@ -712,7 +712,7 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                                 reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                             }
                             else
-                                reply.addVocab32(IKINSLV_VOCAB_REP_NACK); 
+                                reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
 
                             break;
                         }
@@ -724,10 +724,10 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                                 reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                             else
                                 reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
-                    
+
                             break;
                         }
-                    
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_LIM:
                         {
@@ -736,7 +736,7 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                                 int axis=command.get(2).asInt32();
                                 double min=command.get(3).asFloat64();
                                 double max=command.get(4).asFloat64();
-                    
+
                                 if (setLimits(axis,min,max))
                                     reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                                 else
@@ -744,86 +744,86 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                             }
                             else
                                 reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
-                    
+
                             break;
                         }
-                    
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_VERB:
                         {
                             int sw=command.get(2).asVocab32();
-                    
+
                             if (sw==IKINSLV_VOCAB_VAL_ON)
                             {
-                                verbosity=true;    
+                                verbosity=true;
                                 reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                             }
                             else if (sw==IKINSLV_VOCAB_VAL_OFF)
-                            {   
-                                verbosity=false; 
+                            {
+                                verbosity=false;
                                 reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
                             }
-                    
+
                             break;
                         }
-                    
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_DOF:
                         {
                             if (inPort->handleDOF(command.get(2).asList()))
-                            {                                    
+                            {
                                 waitDOFHandling();  // sleep till dof handling is done
-                    
+
                                 reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                                 Bottle &dofPart=reply.addList();
                                 fillDOFInfo(dofPart);
                             }
                             else
                                 reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
-                    
+
                             break;
                         }
-                    
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_REST_POS:
                         {
                             Bottle restPart;
-                    
+
                             if (handleJointsRestPosition(command.get(2).asList(),&restPart))
                             {
                                 lock();
                                 prepareJointsRestTask();
                                 unlock();
-                    
+
                                 reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                                 reply.append(restPart);
                             }
                             else
                                 reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
-                    
+
                             break;
                         }
-                    
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_REST_WEIGHTS:
                         {
                             Bottle restPart;
-                    
+
                             if (handleJointsRestWeights(command.get(2).asList(),&restPart))
                             {
                                 lock();
                                 prepareJointsRestTask();
                                 unlock();
-                    
+
                                 reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                                 reply.append(restPart);
                             }
                             else
                                 reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
-                    
+
                             break;
                         }
-                    
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_TIP_FRAME:
                         {
@@ -834,27 +834,27 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                                     Vector x(3);
                                     for (size_t i=0; i<x.length(); i++)
                                         x[i]=tipPart->get(i).asFloat64();
-            
+
                                     Vector o(4);
                                     for (size_t i=0; i<o.length(); i++)
                                         o[i]=tipPart->get(i+x.length()).asFloat64();
-            
+
                                     Matrix HN=axis2dcm(o);
                                     HN.setSubcol(x,0,3);
 
                                     lock();
                                     prt->chn->setHN(HN);
                                     unlock();
-            
+
                                     reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                                     break;
                                 }
                             }
-            
+
                             reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
                             break;
                         }
-            
+
                         //-----------------
                         case IKINSLV_VOCAB_OPT_TASK2:
                         {
@@ -865,29 +865,29 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                                     int n=payLoad->get(0).asInt32();
                                     Bottle *posPart=payLoad->get(1).asList();
                                     Bottle *weightsPart=payLoad->get(2).asList();
-            
+
                                     if ((posPart!=NULL) && (weightsPart!=NULL))
                                     {
                                         if ((posPart->size()>=3) && (weightsPart->size()>=3))
                                         {
                                             for (size_t i=0; i<xd_2ndTask.length(); i++)
                                                 xd_2ndTask[i]=posPart->get(i).asFloat64();
-            
+
                                             for (size_t i=0; i<w_2ndTask.length(); i++)
                                                 w_2ndTask[i]=weightsPart->get(i).asFloat64();
-            
+
                                             if (n>=0)
                                                 slv->specify2ndTaskEndEff(n);
                                             else
                                                 slv->get2ndTaskChain().clear();
 
-                                            reply.addVocab32(IKINSLV_VOCAB_REP_ACK); 
+                                            reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                                             break;
                                         }
                                     }
                                 }
                             }
-           
+
                             reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
                             break;
                         }
@@ -931,35 +931,35 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                 }
                 else
                     reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
-            
+
                 break;
             }
-            
+
             //-----------------
             case IKINSLV_VOCAB_CMD_ASK:
             {
                 Bottle *b_xd=getTargetOption(command);
                 Bottle *b_q=getJointsOption(command);
-            
+
                 // some integrity checks
                 if (b_xd==NULL)
                 {
                     reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
                     break;
                 }
-                else if (b_xd->size()<3)    // at least the positional part must be given 
+                else if (b_xd->size()<3)    // at least the positional part must be given
                 {
                     reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
                     break;
                 }
-            
+
                 lock();
-            
+
                 // get the target
                 Vector xd(b_xd->size());
                 for (size_t i=0; i<xd.length(); i++)
                     xd[i]=b_xd->get(i).asFloat64();
-            
+
                 // accounts for the starting DOF
                 // if different from the actual one
                 if (b_q!=NULL)
@@ -970,49 +970,49 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                 }
                 else
                     getFeedback();  // otherwise get the current configuration
-            
-                // account for the pose 
+
+                // account for the pose
                 if (command.check(Vocab32::decode(IKINSLV_VOCAB_OPT_POSE)))
                 {
                     int pose=command.find(Vocab32::decode(IKINSLV_VOCAB_OPT_POSE)).asVocab32();
-            
+
                     if (pose==IKINSLV_VOCAB_VAL_POSE_FULL)
                         slv->set_ctrlPose(IKINCTRL_POSE_FULL);
                     else if (pose==IKINSLV_VOCAB_VAL_POSE_XYZ)
                         slv->set_ctrlPose(IKINCTRL_POSE_XYZ);
                 }
-            
+
                 // set things for the 3rd task
                 for (unsigned int i=0; i<prt->chn->getDOF(); i++)
                     if (idx_3rdTask[i]!=0.0)
                         qd_3rdTask[i]=(*prt->chn)(i).getAng();
-            
+
                 // call the solver to converge
                 double t0=Time::now();
                 Vector q=solve(xd);
                 double t1=Time::now();
-            
+
                 Vector x=prt->chn->EndEffPose(q);
-            
+
                 // change to degrees
                 q*=CTRL_RAD2DEG;
-            
+
                 // dump on screen
                 if (verbosity)
                     printInfo("ask",xd,x,q,t1-t0);
-            
+
                 // prepare the complete joints configuration
                 Vector _q(prt->chn->getN());
                 for (unsigned int i=0; i<prt->chn->getN(); i++)
                     _q[i]=CTRL_RAD2DEG*prt->chn->getAng(i);
-            
+
                 // fill the reply accordingly
                 reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                 addVectorOption(reply,IKINSLV_VOCAB_OPT_X,x);
                 addVectorOption(reply,IKINSLV_VOCAB_OPT_Q,_q);
 
                 unlock();
-            
+
                 break;
             }
 
@@ -1023,7 +1023,7 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                 reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                 break;
             }
-            
+
             //-----------------
             case IKINSLV_VOCAB_CMD_RUN:
             {
@@ -1034,11 +1034,11 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                 }
                 else
                     resume();
-            
+
                 reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                 break;
             }
-                        
+
             //-----------------
             case IKINSLV_VOCAB_CMD_STATUS:
             {
@@ -1049,7 +1049,7 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                     reply.addString("running");
                 else
                     reply.addString("not_started");
-                break; 
+                break;
             }
 
             //-----------------
@@ -1057,18 +1057,18 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
             {
                 Property options(command.toString().c_str());
                 yInfo("Configuring with options: %s",options.toString().c_str());
-            
+
                 if (open(options))
                     reply.addVocab32(IKINSLV_VOCAB_REP_ACK);
                 else
                     reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
-            
+
                 break;
             }
-            
+
             //-----------------
             case IKINSLV_VOCAB_CMD_HELP:
-            {                    
+            {
                 reply.addVocab32("many");
                 reply.addString("***** commands");
                 reply.addVocab32(IKINSLV_VOCAB_CMD_GET);
@@ -1103,7 +1103,7 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                 reply.addVocab32(IKINSLV_VOCAB_VAL_OFF);
                 break;
             }
-            
+
             //-----------------
             case IKINSLV_VOCAB_CMD_QUIT:
             {
@@ -1111,7 +1111,7 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
                 close();
                 break;
             }
-            
+
             //-----------------
             default:
                 reply.addVocab32(IKINSLV_VOCAB_REP_NACK);
@@ -1125,7 +1125,7 @@ void CartesianSolver::respond(const Bottle &command, Bottle &reply)
 /************************************************************************/
 void CartesianSolver::send(const Vector &xd, const Vector &x, const Vector &q,
                            double *tok)
-{       
+{
     Bottle &b=outPort->prepare();
     b.clear();
 
@@ -1197,7 +1197,7 @@ bool CartesianSolver::handleJointsRestPosition(const Bottle *options, Bottle *re
     bool ret=false;
 
     if (options!=NULL)
-    {            
+    {
         size_t len=std::min((size_t)options->size(),restJntPos.length());
         for (unsigned int i=0; i<len; i++)
         {
@@ -1228,7 +1228,7 @@ bool CartesianSolver::handleJointsRestWeights(const Bottle *options, Bottle *rep
     bool ret=false;
 
     if (options!=NULL)
-    {            
+    {
         size_t len=std::min((size_t)options->size(),restWeights.length());
         for (size_t i=0; i<len; i++)
         {
@@ -1268,7 +1268,7 @@ bool CartesianSolver::isNewDOF(const Vector &_dof)
 
 /************************************************************************/
 bool CartesianSolver::open(Searchable &options)
-{    
+{
     if (configured)
     {
         yWarning("%s already configured",slvName.c_str());
@@ -1284,7 +1284,7 @@ bool CartesianSolver::open(Searchable &options)
 
     Property DHTable; prt->lmb->toLinksProperties(DHTable);
     yInfo()<<"DH Table: "<<DHTable.toString();  // stream version to prevent long strings truncation
-    
+
     if (options.check("ping_robot_tmo"))
         ping_robot_tmo=options.find("ping_robot_tmo").asFloat64();
 
@@ -1302,7 +1302,7 @@ bool CartesianSolver::open(Searchable &options)
         if (!pDrv->isValid())
         {
             delete pDrv;
-            yError("Device driver not available!");            
+            yError("Device driver not available!");
             close();
             return false;
         }
@@ -1310,7 +1310,7 @@ bool CartesianSolver::open(Searchable &options)
         // create interfaces
         IControlLimits *pLim;
         IEncoders      *pEnc;
-        int             joints;
+        size_t             joints;
 
         if (!pDrv->view(pLim) || !pDrv->view(pEnc))
         {
@@ -1320,7 +1320,7 @@ bool CartesianSolver::open(Searchable &options)
             return false;
         }
 
-        pEnc->getAxes(&joints);
+        pEnc->getAxes(joints);
 
         // this is for allocating vector
         // to read data from the interface
@@ -1334,7 +1334,7 @@ bool CartesianSolver::open(Searchable &options)
         remainingJoints-=joints;
 
         int *rmpTmp=new int[joints];
-        for (int j=0; j<joints; j++)
+        for (size_t j=0; j<joints; j++)
             rmpTmp[j]=prt->rvs[i]?(joints-j-1):j;
 
         drv.push_back(pDrv);
@@ -1398,7 +1398,7 @@ bool CartesianSolver::open(Searchable &options)
     // instantiate the optimizer
     slv=new iKinIpOptMin(*prt->chn,ctrlPose,tol,constr_tol,maxIter);
 
-    // instantiate solver callback object if required    
+    // instantiate solver callback object if required
     if (options.check("interPoints"))
         if (options.find("interPoints").asVocab32()==IKINSLV_VOCAB_VAL_ON)
             clb=new SolverCallback(this);
@@ -1410,8 +1410,8 @@ bool CartesianSolver::open(Searchable &options)
     if (prt->cns!=NULL)
     {
         slv->attachLIC(*prt->cns);
-        
-        double lower_bound_inf, upper_bound_inf;        
+
+        double lower_bound_inf, upper_bound_inf;
         slv->getBoundsInf(lower_bound_inf,upper_bound_inf);
         slv->getLIC().getLowerBoundInf()=2.0*lower_bound_inf;
         slv->getLIC().getUpperBoundInf()=2.0*upper_bound_inf;
@@ -1425,14 +1425,14 @@ bool CartesianSolver::open(Searchable &options)
     // define input port
     inPort=new InputPort(this);
     inPort->useCallback();
-    
+
     // init input port data
     inPort->set_dof(dof);
     inPort->get_pose()=ctrlPose;
     inPort->get_contMode()=contModeOld=mode;
 
     // define output port
-    outPort=new BufferedPort<Bottle>;    
+    outPort=new BufferedPort<Bottle>;
 
     // count uncontrolled joints
     countUncontrolledJoints();
@@ -1490,7 +1490,7 @@ void CartesianSolver::prepareJointsRestTask()
 {
     unsigned int nDOF=prt->chn->getDOF();
     int offs=0;
-    
+
     qd_3rdTask.resize(nDOF);
     w_3rdTask.resize(nDOF,1.0);
     idx_3rdTask.resize(nDOF,1.0);
@@ -1498,7 +1498,7 @@ void CartesianSolver::prepareJointsRestTask()
     for (unsigned int i=0; i<prt->chn->getN(); i++)
     {
         if (!(*prt->chn)[i].isBlocked())
-        {            
+        {
             qd_3rdTask[offs]=restJntPos[i];
             if (restWeights[i]!=0.0)
             {
@@ -1621,7 +1621,7 @@ void CartesianSolver::suspend()
     else
     {
         PeriodicThread::suspend();
-        yInfo("%s suspended",slvName.c_str());        
+        yInfo("%s suspended",slvName.c_str());
     }
 }
 
@@ -1630,7 +1630,7 @@ void CartesianSolver::suspend()
 void CartesianSolver::resume()
 {
     if (isSuspended())
-    {        
+    {
         initPos();
         PeriodicThread::resume();
         yInfo("%s resumed",slvName.c_str());
@@ -1649,7 +1649,7 @@ void CartesianSolver::run()
     bool doSolve=false;
 
     // handle changeDOF()
-    changeDOF(inPort->get_dof());    
+    changeDOF(inPort->get_dof());
 
     // wake up sleeping threads
     postDOFHandling();
@@ -1670,7 +1670,7 @@ void CartesianSolver::run()
             unctrlJointsOld=unctrlJoints;
 
         // detect movements of uncontrolled joints
-        double distExtMoves=CTRL_RAD2DEG*norm(unctrlJoints-unctrlJointsOld);        
+        double distExtMoves=CTRL_RAD2DEG*norm(unctrlJoints-unctrlJointsOld);
 
         // run the solver if movements of uncontrolled joints
         // are detected and we are in continuous mode
@@ -1682,9 +1682,9 @@ void CartesianSolver::run()
 
     // run the solver if any input is received
     if (inPort->isNewDataEvent())
-    {    
+    {
         // update solver condition
-        doSolve=true;        
+        doSolve=true;
     }
 
     // solver part
@@ -1716,7 +1716,7 @@ void CartesianSolver::run()
         // q is the estimation of the real qd,
         // so that x is the actual achieved pose
         Vector x=prt->chn->EndEffPose(q);
-        
+
         // change to degrees
         q*=CTRL_RAD2DEG;
 
@@ -1729,7 +1729,7 @@ void CartesianSolver::run()
 
         // save the values of uncontrolled joints
         if (!fullDOF)
-            unctrlJointsOld=unctrlJoints; 
+            unctrlJointsOld=unctrlJoints;
     }
 
     contModeOld=inPort->get_contMode();
@@ -1740,7 +1740,7 @@ void CartesianSolver::run()
 
 /************************************************************************/
 void CartesianSolver::threadRelease()
-{    
+{
     yInfo("Stopping %s ...",slvName.c_str());
 }
 
@@ -1839,9 +1839,9 @@ bool iCubArmCartesianSolver::decodeDOF(const Vector &_dof)
         newDOF[i]=_dof[i];
 
     // check whether shoulder's axes are treated properly
-    if (!(((newDOF[3]!=0.0) && (newDOF[4]!=0)   && (newDOF[5]!=0)) || 
+    if (!(((newDOF[3]!=0.0) && (newDOF[4]!=0)   && (newDOF[5]!=0)) ||
           ((newDOF[3]==0.0) && (newDOF[4]==0.0) && (newDOF[5]==0.0))))
-    {        
+    {
         // restore previous condition:
         // they all shall be on or off
         newDOF[3]=newDOF[4]=newDOF[5]=dof[3];
@@ -1887,7 +1887,7 @@ PartDescriptor *iCubLegCartesianSolver::getPartDesc(Searchable &options)
     p->lmb=new iCubLeg(type);
     p->chn=p->lmb->asChain();
     p->cns=NULL;
-    p->prp.push_back(optLeg);   
+    p->prp.push_back(optLeg);
     p->rvs.push_back(false);
     p->num=1;
 

--- a/src/libraries/perceptiveModels/src/springyFingers.cpp
+++ b/src/libraries/perceptiveModels/src/springyFingers.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2011 Department of Robotics Brain and Cognitive Sciences - Istituto Italiano di Tecnologia
  * Author: Ugo Pattacini
  * email:  ugo.pattacini@iit.it
@@ -73,7 +73,7 @@ bool SpringyFinger::fromProperty(const Property &options)
         defaultCalibVel=60.0;
     }
     else
-        return false;    
+        return false;
 
     calibratingVelocity=options.check("calib_vel",Value(defaultCalibVel)).asFloat64();
     outputGain=options.check("output_gain",Value(1.0)).asFloat64();
@@ -236,7 +236,7 @@ bool SpringyFinger::calibrate(const Property &options)
     {
         Vector in,out;
         if (extractSensorsData(in,out))
-        {            
+        {
             in[0]=scaler.transform(in[0]);
             for (size_t i=0; i<out.length(); i++)
                 out[i]=scaler.transform(out[i]);
@@ -302,14 +302,14 @@ bool SpringyFingersModel::fromProperty(const Property &options)
         close();
         return false;
     }
-    
-    printMessage(log::info,1,"configuring joint encoders sensors ...");    
+
+    printMessage(log::info,1,"configuring joint encoders sensors ...");
     IEncoders *ienc; drvEncs.view(ienc);
-    int nAxes; ienc->getAxes(&nAxes);
+    size_t nAxes; ienc->getAxes(nAxes);
 
     Property propGen;
     propGen.put("name","In_0");
-    propGen.put("size",nAxes);
+    propGen.put("size",(int)nAxes);
 
     Property propThumb=propGen;  propThumb.put( "index",10);
     Property propIndex=propGen;  propIndex.put( "index",12);
@@ -518,18 +518,18 @@ bool SpringyFingersModel::calibrate(const Property &options)
         IEncoders        *ienc; drvEncs.view(ienc);
         IPositionControl *ipos; drvEncs.view(ipos);
 
-        int nAxes; ienc->getAxes(&nAxes);
+        size_t nAxes; ienc->getAxes(nAxes);
         Vector qmin(nAxes),qmax(nAxes),vel(nAxes),acc(nAxes);
 
         printMessage(log::info,1,"steering the hand to a suitable starting configuration");
-        for (int j=7; j<nAxes; j++)
+        for (size_t j=7; j<nAxes; j++)
         {
             imod->setControlMode(j,VOCAB_CM_POSITION);
-            ilim->getPosLimits(j,&qmin[j],&qmax[j]);            
+            ilim->getPosLimits(j,&qmin[j],&qmax[j]);
 
             ipos->getTrajAcceleration(j,&acc[j]);
             ipos->getTrajSpeed(j,&vel[j]);
-            
+
             ipos->setTrajAcceleration(j,std::numeric_limits<double>::max());
             ipos->setTrajSpeed(j,60.0);
             ipos->positionMove(j,(j==8)?qmax[j]:qmin[j]);   // thumb in opposition
@@ -598,7 +598,7 @@ bool SpringyFingersModel::calibrate(const Property &options)
                 {
                     if (singletons.find(tag)==singletons.end())
                     {
-                        CalibThread *thr=new CalibThread; 
+                        CalibThread *thr=new CalibThread;
                         thr->setInfo(this,fingers[0],10,qmin[10],qmax[10]);
                         thr->start();
                         db.push_back(thr);
@@ -671,7 +671,7 @@ bool SpringyFingersModel::calibrate(const Property &options)
             else
                 ok=false;
         }
-        
+
         if (!fng.isString() && !fng.isList())
             ok=false;
 
@@ -702,7 +702,7 @@ bool SpringyFingersModel::getOutput(Value &out) const
         fingers[2].getOutput(val[2]);
         fingers[3].getOutput(val[3]);
         fingers[4].getOutput(val[4]);
-        
+
         Bottle bOut; Bottle &ins=bOut.addList();
         ins.addFloat64(val[0].asFloat64());
         ins.addFloat64(val[1].asFloat64());
@@ -797,7 +797,7 @@ void SpringyFingersModel::calibrateFinger(SpringyFinger &finger, const int joint
         }
     }
 
-    printMessage(log::info,1,"training finger %s ...",finger.getName().c_str());    
+    printMessage(log::info,1,"training finger %s ...",finger.getName().c_str());
     finger.calibrate(train);
     printMessage(log::info,1,"finger %s trained!",finger.getName().c_str());
 }

--- a/src/modules/actionsRenderingEngine/src/MotorThread.cpp
+++ b/src/modules/actionsRenderingEngine/src/MotorThread.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
 * Copyright (C) 2010 RobotCub Consortium, European Commission FP6 Project IST-004370
 * Author: Carlo Ciliberto, Vadim Tikhanoff
 * email:   carlo.ciliberto@iit.it vadim.tikhanoff@iit.it
@@ -192,7 +192,7 @@ int MotorThread::checkArm(int arm, Vector &xd, const bool applyOffset)
 
     if (applyOffset)
     {
-        xd[0]+=currentKinematicOffset[armInUse][0]; 
+        xd[0]+=currentKinematicOffset[armInUse][0];
         xd[1]+=currentKinematicOffset[armInUse][1];
         xd[2]+=currentKinematicOffset[armInUse][2];
     }
@@ -304,7 +304,7 @@ int MotorThread::setStereoToCartesianMode(const int mode, Bottle &reply)
             break;
         }
     }
-    
+
     //get left offsets
     if(!bKinOffsets.find("left").asList()->check(Vocab32::decode(modeS2C)))
     {
@@ -348,7 +348,7 @@ bool MotorThread::targetToCartesian(Bottle *bTarget, Vector &xd)
     // if the tartget's cartesian coordinates was specified, use them.
     if(!found && bTarget!=NULL && bTarget->check("cartesian") && bTarget->find("cartesian").asList()->size()>=3)
     {
-        Bottle *bCartesian=bTarget->find("cartesian").asList(); 
+        Bottle *bCartesian=bTarget->find("cartesian").asList();
         xd.clear();
         for(int i=0; i<bCartesian->size(); i++)
             xd.push_back(bCartesian->get(i).asFloat64());
@@ -446,7 +446,7 @@ bool MotorThread::loadExplorationPoses(const string &file_name)
             v[j]=b->get(j).asFloat64();
         handPoses.push_back(v);
     }
-    
+
     Bottle &tmpHead=optExpl.findGroup("head");
     for(int i=1; i<tmpHead.size(); i++)
     {
@@ -540,7 +540,7 @@ bool MotorThread::stereoToCartesianDisparity(const Vector &stereo, Vector &xd)
     {
         xd.resize(3);
         xd[0]=bX.get(0).asFloat64();
-        xd[1]=bX.get(1).asFloat64();    
+        xd[1]=bX.get(1).asFloat64();
         xd[2]=bX.get(2).asFloat64();
     }
 
@@ -620,7 +620,7 @@ bool MotorThread::loadKinematicOffsets()
 
         bKinList.addList();
     }
-    
+
     if (!bKinOffsets.check("right"))
     {
         Bottle &bKinList=bKinOffsets.addList();
@@ -828,7 +828,7 @@ bool MotorThread::getArmOptions(Bottle &b, const int &arm)
         shiftPos[arm].resize(3);
         shiftPos[arm]=0.0;
     }
-    
+
     if (Bottle *pB=b.find("expect_position").asList())
     {
         expectPos[arm].resize(pB->size());
@@ -887,7 +887,7 @@ void MotorThread::close()
 
     //set the system back to velocity mode
     setImpedance(false);
-    
+
     delete drv_head;
     drv_head=NULL;
 
@@ -896,7 +896,7 @@ void MotorThread::close()
 
     delete drv_arm[LEFT];
     drv_arm[LEFT]=NULL;
-    
+
     delete drv_arm[RIGHT];
     drv_arm[RIGHT]=NULL;
 
@@ -1006,10 +1006,10 @@ bool MotorThread::threadInit()
     {
         drv_arm[LEFT]=new PolyDriver;
         if(!drv_arm[LEFT]->open(optLeftArm))
-        {   
+        {
             close();
             return false;
-        }        
+        }
 
         drv_arm[LEFT]->view(ctrl_mode_arm[LEFT]);
         drv_arm[LEFT]->view(int_mode_arm[LEFT]);
@@ -1027,10 +1027,10 @@ bool MotorThread::threadInit()
     {
         drv_arm[RIGHT]=new PolyDriver;
         if(!drv_arm[RIGHT]->open(optRightArm))
-        {   
+        {
             close();
             return false;
-        }        
+        }
 
         drv_arm[RIGHT]->view(ctrl_mode_arm[RIGHT]);
         drv_arm[RIGHT]->view(int_mode_arm[RIGHT]);
@@ -1080,7 +1080,7 @@ bool MotorThread::threadInit()
 
     Bottle &bTs=stereoOpt.addList();
     bTs.addString("Ts");
-    bTs.addFloat64(0.05); 
+    bTs.addFloat64(0.05);
 
     Bottle &bDominantEye=stereoOpt.addList();
     bDominantEye.addString("dominantEye");
@@ -1189,7 +1189,7 @@ bool MotorThread::threadInit()
     vector<double> torso_stiffness(0),torso_damping(0);
     Bottle *bImpedanceTorsoStiff=bMotor.find("impedence_torso_stiffness").asList();
     Bottle *bImpedanceTorsoDamp=bMotor.find("impedence_torso_damping").asList();
-    
+
     for(int i=0; i<bImpedanceTorsoStiff->size(); i++)
     {
         torso_stiffness.push_back(bImpedanceTorsoStiff->get(i).asFloat64());
@@ -1203,7 +1203,7 @@ bool MotorThread::threadInit()
     vector<double> arm_stiffness(0),arm_damping(0);
     Bottle *bImpedanceArmStiff=bMotor.find("impedence_arm_stiffness").asList();
     Bottle *bImpedanceArmDamp=bMotor.find("impedence_arm_damping").asList();
-    
+
     for(int i=0; i<bImpedanceArmStiff->size(); i++)
     {
         arm_stiffness.push_back(bImpedanceArmStiff->get(i).asFloat64());
@@ -1331,7 +1331,7 @@ bool MotorThread::threadInit()
     grasp_state=GRASP_STATE_IDLE;
 
     Rand::init();
-    
+
     head_mode=HEAD_MODE_IDLE;
     arm_mode=ARM_MODE_IDLE;
 
@@ -1397,7 +1397,7 @@ void MotorThread::run()
 
                     Vector px(2);
                     px[0]=stereo[2*eye_in_use];
-                    px[1]=stereo[2*eye_in_use+1];                    
+                    px[1]=stereo[2*eye_in_use+1];
                     ctrl_gaze->lookAtMonoPixel(dominant_eye,px,0.4);
                 }
             }
@@ -1433,7 +1433,7 @@ void MotorThread::run()
             force[1]=wrench[1];
             force[2]=wrench[2];
 
-            Vector x,o;        
+            Vector x,o;
             dragger.ctrl->getPose(x,o);
 
             if(Time::now()-dragger.t0 > dragger.samplingRate)
@@ -1480,7 +1480,7 @@ void MotorThread::run()
                     force=0.0;
                 else
                     D/=5.0;
-                
+
                 Vector b=force/dragger.inertia;
                 Vector c=D*dragger.I->get();
                 Vector a=force/dragger.inertia-D*dragger.I->get();
@@ -1522,17 +1522,17 @@ void MotorThread::run()
                     {
                         Vector x,o;
                         action[arm]->getPose(x,o);
-                        
+
                         Vector head_x,head_o;
                         ctrl_gaze->getHeadPose(head_x,head_o);
-                        
+
                         if(fabs(x[1]-head_x[1])<0.2)
                             x[1]=head_x[1]+sign(x[1]-head_x[1])*0.2;
 
                         ICartesianControl *tmp_ctrl;
                         action[arm]->getCartesianIF(tmp_ctrl);
                         x[2]=avoid_table_height[arm];
-                        
+
                         tmp_ctrl->goToPosition(x);
                     }
                 }
@@ -1614,7 +1614,7 @@ bool MotorThread::reach(Bottle &options)
         tmpDisp=reachSideDisp[arm];
     }
     else
-    {        
+    {
         tmpOrient=(checkOptions(options,"take")?
                    reachAboveOrient[arm]:
                    reachAboveCata[arm]);
@@ -1625,7 +1625,7 @@ bool MotorThread::reach(Bottle &options)
     }
 
     restoreContext(arm);
-    
+
     wbdRecalibration();
     if (auto* p = dynamic_cast<ActionPrimitivesLayer2*>(action[arm]))
         p->enableContactDetection();
@@ -1702,7 +1702,7 @@ bool MotorThread::powerGrasp(Bottle &options)
     {
         if (Bottle *bApproach=options.find("approach").asList())
         {
-            size_t sz=std::min(approach_data.size(),(size_t)bApproach->size()); 
+            size_t sz=std::min(approach_data.size(),(size_t)bApproach->size());
             for (size_t i=0; i<sz; i++)
                 approach_data[i]=bApproach->get(i).asFloat64();
         }
@@ -1750,7 +1750,7 @@ bool MotorThread::push(Bottle &options)
     Vector xd;
     if (!targetToCartesian(options.find("target").asList(),xd))
         return false;
-    arm=checkArm(arm,xd);    
+    arm=checkArm(arm,xd);
 
     if (!checkOptions(options,"no_head") && !checkOptions(options,"no_gaze"))
     {
@@ -1842,7 +1842,7 @@ bool MotorThread::point(Bottle &options)
 bool MotorThread::point_far(Bottle &options)
 {
     Vector xd;
-    Bottle *bTarget=options.find("target").asList();    
+    Bottle *bTarget=options.find("target").asList();
     if (!targetToCartesian(bTarget,xd))
         return false;
 
@@ -1859,8 +1859,8 @@ bool MotorThread::point_far(Bottle &options)
     action[arm]->getCartesianIF(iarm);
 
     Property requirements;
-    Bottle point; point.addList().read(xd);    
-    requirements.put("point",point.get(0));    
+    Bottle point; point.addList().read(xd);
+    requirements.put("point",point.get(0));
 
     Bottle pointing_sequence;
     if (action[arm]->getHandSequence("pointing_hand",pointing_sequence))
@@ -1913,13 +1913,13 @@ bool MotorThread::look(Bottle &options)
         if(checkOptions(options,"left") || checkOptions(options,"right"))
             arm=checkOptions(options,"left")?LEFT:RIGHT;
 
-        arm=checkArm(arm);        
-        lookAtHand(options);        
+        arm=checkArm(arm);
+        lookAtHand(options);
     }
     else
     {
         Vector xd;
-        Bottle *bTarget=options.find("target").asList();        
+        Bottle *bTarget=options.find("target").asList();
         if (!targetToCartesian(bTarget,xd))
             return false;
 
@@ -1967,7 +1967,7 @@ bool MotorThread::takeTool(Bottle &options)
     bool contact_detected=false;
     Vector wrench(6);
     double t=Time::now();
-    
+
     while (!contact_detected && (Time::now()-t<5.0))
     {
         if (auto* p = dynamic_cast<ActionPrimitivesLayer2*>(action[arm]))
@@ -2005,11 +2005,11 @@ bool MotorThread::expect(Bottle &options)
 
     bool f;
     action[arm]->checkActionsDone(f,true);
-    
+
     double force_thresh;
     if (auto* p = dynamic_cast<ActionPrimitivesLayer2*>(action[arm]))
         p->getExtForceThres(force_thresh);
-    
+
     bool contact_detected=false;
     Vector wrench(6);
     double t=Time::now();
@@ -2022,8 +2022,8 @@ bool MotorThread::expect(Bottle &options)
             contact_detected=true;
 
         Time::delay(0.1);
-    }    
-    
+    }
+
     if(!checkOptions(options,"no_head") && !checkOptions(options,"no_gaze"))
         setGazeIdle();
 
@@ -2110,7 +2110,7 @@ bool MotorThread::hand(const Bottle &options, const string &type,
         bool f;
         action[arm]->checkActionsDone(f,true);
         if (holding!=NULL)
-            *holding=isHolding(options); 
+            *holding=isHolding(options);
         return true;
     }
     else
@@ -2184,7 +2184,7 @@ bool MotorThread::changeExecTime(const int arm, const double execTime)
 {
     if (execTime>0.0)
     {
-        default_exec_time=execTime; 
+        default_exec_time=execTime;
         reachingTimeout=std::max(2.0*default_exec_time,4.0);
         if ((arm==LEFT) || (arm==RIGHT))
         {
@@ -2218,7 +2218,7 @@ bool MotorThread::changeExecTime(const int arm, const double execTime)
 }
 
 
-void MotorThread::goWithTorsoUpright(ActionPrimitives *action, 
+void MotorThread::goWithTorsoUpright(ActionPrimitives *action,
                                      const Vector &xin, const Vector &oin)
 {
     ICartesianControl *ctrl;
@@ -2300,7 +2300,7 @@ bool MotorThread::goHome(Bottle &options)
         }
 
         for (size_t i=0; i<2; i++)
-        {            
+        {
             if (exec_arm[i] && (action[which_arm[i]]!=NULL))
             {
                 if (hand_home)
@@ -2424,7 +2424,7 @@ bool MotorThread::drawNear(Bottle &options)
     if (checkOptions(options,"left") ||
         checkOptions(options,"right"))
         arm=checkOptions(options,"left")?LEFT:RIGHT;
-    
+
     arm=checkArm(arm);
     goWithTorsoUpright(action[arm],drawNearPos[arm],drawNearOrient[arm]);
 
@@ -2510,7 +2510,7 @@ bool MotorThread::calibTable(Bottle &options)
         arm=checkOptions(options,"left")?LEFT:RIGHT;
 
     arm=checkArm(arm);
-    
+
     Vector deployZone=deployPos[arm];
     deployZone=deployZone+randomDeployOffset();
 
@@ -2578,7 +2578,7 @@ bool MotorThread::calibTable(Bottle &options)
         opcPort.setTableHeight(table_height);
 
         yWarning("########## Table height found: %f",table_height);
-        
+
         //adjust the table height accordingly to a specified tolerance
         table_height+=table_height_tolerance;
     }
@@ -2735,7 +2735,7 @@ bool MotorThread::exploreTorso(Bottle &options)
 
     //random walk!
     while(this->isRunning() && !interrupted && Time::now()-init_walking_time<walking_time)
-    {    
+    {
         //generate next random step
         Vector random_pos=cart_init_pos;
         if (Rand::scalar(0.0,3.0)>2.0)  // 1/3 => lean forward
@@ -2860,8 +2860,8 @@ bool MotorThread::exploreHand(Bottle &options)
 
     double max_step_time=2.0;
 
-    int nJnts;
-    enc_arm[arm]->getAxes(&nJnts);
+    size_t nJnts;
+    enc_arm[arm]->getAxes(nJnts);
 
     vector<yarp::dev::SelectableControlModeEnum> modes(nJnts,yarp::dev::SelectableControlModeEnum::VOCAB_CM_POSITION);
     ctrl_mode_arm[arm]->setControlModes(modes);
@@ -2899,7 +2899,7 @@ bool MotorThread::exploreHand(Bottle &options)
             Time::delay(0.05);
         }
     }
-    
+
     if (!checkOptions(options,"no_head") && !checkOptions(options,"no_gaze"))
         setGazeIdle();
 
@@ -2909,7 +2909,7 @@ bool MotorThread::exploreHand(Bottle &options)
         action[arm]->unlockActions();
         action[arm]->syncCheckReinstate();
     }
-    
+
     return true;
 }
 
@@ -3048,7 +3048,7 @@ bool MotorThread::imitateAction(Bottle &options)
     restoreContext(arm);
 
     ICartesianControl *ctrl;
-    action[arm]->getCartesianIF(ctrl);    
+    action[arm]->getCartesianIF(ctrl);
 
     Vector newPos;
     ctrl->getDOF(newPos);
@@ -3137,7 +3137,7 @@ bool MotorThread::startLearningModeKinOffset(Bottle &options)
 
     Bottle look_options;
     look_options.addString("hand");
-    look_options.addString(dragger.arm==LEFT?"left":"right");    
+    look_options.addString(dragger.arm==LEFT?"left":"right");
     look(look_options);
 
     return true;
@@ -3274,7 +3274,7 @@ void MotorThread::update()
         table.resize(4,0.0);
         table[2]=1.0;
         table[3]=-table_height;
-        
+
         //adjust the table height accordingly to a specified tolerance
         table_height+=table_height_tolerance;
     }

--- a/src/modules/iKinGazeCtrl/include/iCub/controller.h
+++ b/src/modules/iKinGazeCtrl/include/iCub/controller.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2010 RobotCub Consortium, European Commission FP6 Project IST-004370
  * Author: Ugo Pattacini, Alessandro Roncone
  * email:  ugo.pattacini@iit.it, alessandro.roncone@iit.it
@@ -60,7 +60,7 @@ protected:
     IControlMode       *modHead;
     IPositionControl   *posHead;
     IVelocityControl   *velHead;
-    IPositionDirect    *posNeck;    
+    IPositionDirect    *posNeck;
     ExchangeData       *commData;
 
     minJerkVelCtrl     *mjCtrlNeck;
@@ -92,10 +92,10 @@ protected:
     bool motionDone;
     bool reliableGyro;
     bool stabilizeGaze;
-    int nJointsTorso;
-    int nJointsHead;
+    size_t nJointsTorso;
+    size_t nJointsHead;
     double ctrlActiveRisingEdgeTime;
-    double saccadeStartTime;    
+    double saccadeStartTime;
     double printAccTime;
     double neckTime;
     double eyesTime;
@@ -138,7 +138,7 @@ public:
     void   resetCtrlEyes();
     void   doSaccade(const Vector &ang, const Vector &vel);
     bool   look(const Vector &x);
-    void   stopControl();    
+    void   stopControl();
     void   printIter(Vector &xd, Vector &fp, Vector &qd, Vector &q, Vector &v, double printTime);
     bool   threadInit() override;
     void   threadRelease() override;

--- a/src/modules/iKinGazeCtrl/include/iCub/solver.h
+++ b/src/modules/iKinGazeCtrl/include/iCub/solver.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2010 RobotCub Consortium, European Commission FP6 Project IST-004370
  * Author: Ugo Pattacini, Alessandro Roncone
  * email:  ugo.pattacini@iit.it, alessandro.roncone@iit.it
@@ -60,7 +60,7 @@ class EyePinvRefGen : public GazeComponent, public PeriodicThread
 protected:
     iCubHeadCenter       *neck;
     iCubInertialSensor   *imu;
-    iKinChain            *chainNeck, *chainEyeL, *chainEyeR;    
+    iKinChain            *chainNeck, *chainEyeL, *chainEyeR;
     PolyDriver           *drvTorso, *drvHead;
     ExchangeData         *commData;
     Controller           *ctrl;
@@ -71,17 +71,17 @@ protected:
     double                orig_eye_tilt_max;
     double                orig_eye_pan_min;
     double                orig_eye_pan_max;
-    
+
     unsigned int period;
     bool   saccadeUnderWayOld;
     bool   genOn;
-    int    nJointsTorso;
-    int    nJointsHead;
+    size_t    nJointsTorso;
+    size_t    nJointsHead;
     int    saccadesRxTargets;
     double saccadesClock;
     double eyesHalfBaseline;
     double Ts;
-    
+
     Matrix orig_lim,lim;
     Vector fbTorso;
     Vector fbHead;
@@ -118,21 +118,21 @@ public:
 // on IPOPT computation.
 class Solver : public GazeComponent, public PeriodicThread
 {
-protected:    
+protected:
     iCubHeadCenter     *neck;
     iCubInertialSensor *imu;
-    iKinChain          *chainNeck, *chainEyeL, *chainEyeR;    
+    iKinChain          *chainNeck, *chainEyeL, *chainEyeR;
     GazeIpOptMin       *invNeck;
     PolyDriver         *drvTorso, *drvHead;
     ExchangeData       *commData;
     EyePinvRefGen      *eyesRefGen;
     Localizer          *loc;
-    Controller         *ctrl;    
+    Controller         *ctrl;
     mutex               mtx;
 
     unsigned int period;
-    int nJointsTorso;
-    int nJointsHead;
+    size_t nJointsTorso;
+    size_t nJointsHead;
     double neckAngleUserTolerance;
     double Ts;
 
@@ -171,7 +171,7 @@ public:
     void   clearNeckRoll();
     void   clearNeckYaw();
     double getNeckAngleUserTolerance() const;
-    void   setNeckAngleUserTolerance(const double angle);    
+    void   setNeckAngleUserTolerance(const double angle);
     bool   threadInit() override;
     void   threadRelease() override;
     void   afterStart(bool s) override;

--- a/src/modules/iKinGazeCtrl/src/controller.cpp
+++ b/src/modules/iKinGazeCtrl/src/controller.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2010 RobotCub Consortium, European Commission FP6 Project IST-004370
  * Author: Ugo Pattacini, Alessandro Roncone
  * email:  ugo.pattacini@iit.it, alessandro.roncone@iit.it
@@ -67,13 +67,13 @@ Controller::Controller(PolyDriver *_drvTorso, PolyDriver *_drvHead, ExchangeData
     if (drvTorso!=nullptr)
     {
         IEncoders *encTorso; drvTorso->view(encTorso);
-        encTorso->getAxes(&nJointsTorso);
+        encTorso->getAxes(nJointsTorso);
     }
     else
         nJointsTorso=3;
-    
+
     IEncoders *encHead; drvHead->view(encHead);
-    encHead->getAxes(&nJointsHead);
+    encHead->getAxes(nJointsHead);
 
     drvHead->view(modHead);
     drvHead->view(posHead);
@@ -183,7 +183,7 @@ void Controller::findMinimumAllowedVergence()
         cl(cl.getDOF()-1).setAng(ver/2.0);
         cr(cr.getDOF()-1).setAng(-ver/2.0);
 
-        Vector fp;        
+        Vector fp;
         if (CartesianHelper::computeFixationPointData(cl,cr,fp))
         {
             // impose homogeneous coordinates
@@ -241,7 +241,7 @@ void Controller::motionOngoingEventsHandling()
     {
         double curCheckPoint=*motionOngoingEventsCurrent.begin();
         if (pathPerc>=curCheckPoint)
-        {            
+        {
             notifyEvent("motion-ongoing",curCheckPoint);
             motionOngoingEventsCurrent.erase(curCheckPoint);
         }
@@ -366,7 +366,7 @@ bool Controller::threadInit()
     port_event.open(commData->localStemName+"/events:o");
 
     if (commData->debugInfoEnabled)
-        port_debug.open(commData->localStemName+"/dbg:o");        
+        port_debug.open(commData->localStemName+"/dbg:o");
 
     yInfo("Starting Controller at %d ms",period);
     q_stamp=Time::now();
@@ -415,13 +415,13 @@ Vector Controller::computedxFP(const Matrix &H, const Vector &v,
     Matrix H_=H;
     Vector w_=w;
     w_.push_back(1.0);
-    
+
     H_(0,3)=x_FP[0]-H_(0,3);
     H_(1,3)=x_FP[1]-H_(1,3);
     H_(2,3)=x_FP[2]-H_(2,3);
     Vector dx_FP_pos=v+(w_[0]*cross(H_,0,H_,3)+
                         w_[1]*cross(H_,1,H_,3)+
-                        w_[2]*cross(H_,2,H_,3));    
+                        w_[2]*cross(H_,2,H_,3));
 
     H_(0,3)=H_(1,3)=H_(2,3)=0.0;
     Vector dx_FP_rot=H_*w_;
@@ -439,7 +439,7 @@ Vector Controller::computeNeckVelFromdxFP(const Vector &fp, const Vector &dfp)
     fpR.push_back(1.0);
     Vector fpE=SE3inv(chainNeck->getH())*fpR;
 
-    // compute the Jacobian of the head joints alone 
+    // compute the Jacobian of the head joints alone
     // (by adding the new fixation point beforehand)
     Matrix HN=eye(4,4);
     HN(0,3)=fpE[0];
@@ -608,7 +608,7 @@ bool Controller::setGazeStabilization(const bool f)
             {
                 if (!commData->ctrlActive)
                 {
-                    IntPlan->reset(fbNeck); 
+                    IntPlan->reset(fbNeck);
                     IntStabilizer->reset(zeros((int)vNeck.length()));
                 }
                 notifyEvent("stabilization-on");
@@ -642,7 +642,7 @@ bool Controller::getGazeStabilization() const
 void Controller::run()
 {
     lock_guard<mutex> lg(mutexRun);
-    
+
     mutexCtrl.lock();
     bool jointsHealthy=areJointsHealthyAndSet();
     mutexCtrl.unlock();
@@ -668,7 +668,7 @@ void Controller::run()
             notifyEvent("saccade-done");
     }
     mutexCtrl.unlock();
-    
+
     // get data
     double x_stamp;
     Vector xd=commData->get_xd();
@@ -680,7 +680,7 @@ void Controller::run()
     if (!getFeedback(fbTorso,fbHead,drvTorso,drvHead,commData,&q_stamp))
     {
         yError("Communication timeout detected!");
-        notifyEvent("comm-timeout");        
+        notifyEvent("comm-timeout");
         suspend();
         return;
     }
@@ -701,7 +701,7 @@ void Controller::run()
             chainEyeR->setAng(nJointsTorso+i,fbHead[i]);
         }
 
-        chainEyeL->setAng(nJointsTorso+3,fbHead[3]);               
+        chainEyeL->setAng(nJointsTorso+3,fbHead[3]);
         chainEyeL->setAng(nJointsTorso+4,fbHead[4]+fbHead[5]/2.0);
         chainEyeR->setAng(nJointsTorso+3,fbHead[3]);
         chainEyeR->setAng(nJointsTorso+4,fbHead[4]-fbHead[5]/2.0);
@@ -751,11 +751,11 @@ void Controller::run()
             else
             {
                 event="motion-done";
-                mutexCtrl.lock(); 
+                mutexCtrl.lock();
                 stopLimb(false);
                 mutexCtrl.unlock();
             }
-        }        
+        }
     }
     else if (jointsHealthy)
     {
@@ -780,12 +780,12 @@ void Controller::run()
             }
             else
             {
-                mjCtrlNeck->reset(zeros((int)fbNeck.length())); 
+                mjCtrlNeck->reset(zeros((int)fbNeck.length()));
                 mjCtrlEyes->reset(zeros((int)fbEyes.length()));
                 IntStabilizer->reset(zeros((int)vNeck.length()));
                 IntPlan->reset(fbNeck);
             }
-            
+
             reliableGyro=true;
 
             event="motion-onset";
@@ -878,7 +878,7 @@ void Controller::run()
         }
         IntPlan->integrate(vNeck);
     }
-    else 
+    else
     {
         vNeck=0.0;
         vEyes=0.0;
@@ -952,7 +952,7 @@ void Controller::run()
 
     // print info
     if (commData->verbose)
-        printIter(xd,x,qddeg,qdeg,vdeg,1.0); 
+        printIter(xd,x,qddeg,qdeg,vdeg,1.0);
 
     // send x,q through YARP ports
     Vector q(nJointsTorso+nJointsHead);
@@ -1001,9 +1001,9 @@ void Controller::run()
 void Controller::suspend()
 {
     lock_guard<mutex> lg(mutexCtrl);
-    PeriodicThread::suspend();    
+    PeriodicThread::suspend();
     stopLimb();
-    commData->saccadeUnderway=false;    
+    commData->saccadeUnderway=false;
     yInfo("Controller has been suspended!");
     notifyEvent("suspended");
 }
@@ -1015,7 +1015,7 @@ void Controller::resume()
     getFeedback(fbTorso,fbHead,drvTorso,drvHead,commData);
     fbNeck=fbHead.subVector(0,2);
     fbEyes=fbHead.subVector(3,5);
-    
+
     PeriodicThread::resume();
     yInfo("Controller has been resumed!");
     notifyEvent("resumed");
@@ -1041,7 +1041,7 @@ void Controller::setTneck(const double execTime)
 {
     double lowerThresNeck=eyesTime+0.2;
     if (execTime<lowerThresNeck)
-    {        
+    {
         yWarning("neck execution time is under the lower bound!");
         yWarning("a new neck execution time of %g s is chosen",lowerThresNeck);
         neckTime=lowerThresNeck;
@@ -1056,7 +1056,7 @@ void Controller::setTeyes(const double execTime)
 {
     double lowerThresEyes=10.0*Ts;
     if (execTime<lowerThresEyes)
-    {        
+    {
         yWarning("eyes execution time is under the lower bound!");
         yWarning("a new eyes execution time of %g s is chosen",lowerThresEyes);
         eyesTime=lowerThresEyes;
@@ -1081,7 +1081,7 @@ bool Controller::isMotionDone()
 void Controller::setTrackingMode(const bool f)
 {
     if (commData->trackingModeOn!=f)
-    {        
+    {
         if (f)
             look(commData->get_x());
 
@@ -1094,7 +1094,7 @@ void Controller::setTrackingMode(const bool f)
 
 
 /************************************************************************/
-bool Controller::getTrackingMode() const 
+bool Controller::getTrackingMode() const
 {
     return commData->trackingModeOn;
 }

--- a/src/modules/iKinGazeCtrl/src/solver.cpp
+++ b/src/modules/iKinGazeCtrl/src/solver.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2010 RobotCub Consortium, European Commission FP6 Project IST-004370
  * Author: Ugo Pattacini, Alessandro Roncone
  * email:  ugo.pattacini@iit.it, alessandro.roncone@iit.it
@@ -69,18 +69,18 @@ EyePinvRefGen::EyePinvRefGen(PolyDriver *_drvTorso, PolyDriver *_drvHead,
 
     // get the length of the half of the eyes baseline
     eyesHalfBaseline=0.5*norm(eyeL->EndEffPose().subVector(0,2)-eyeR->EndEffPose().subVector(0,2));
-    
+
     // read number of joints
     if (drvTorso!=nullptr)
     {
         IEncoders *encTorso; drvTorso->view(encTorso);
-        encTorso->getAxes(&nJointsTorso);
+        encTorso->getAxes(nJointsTorso);
     }
     else
         nJointsTorso=3;
 
     IEncoders *encHead; drvHead->view(encHead);
-    encHead->getAxes(&nJointsHead);
+    encHead->getAxes(nJointsHead);
 
     // joints bounds alignment
     lim=alignJointsBounds(chainNeck,drvTorso,drvHead,commData);
@@ -183,7 +183,7 @@ bool EyePinvRefGen::clearEyes()
 {
     lock_guard<mutex> lck(mtx);
     if (commData->eyesBoundVer>=0.0)
-    {        
+    {
         commData->eyesBoundVer=-1.0;
 
         // reinstate pan bound of the left eye
@@ -352,7 +352,7 @@ void EyePinvRefGen::run()
                 {
                     double L,R;
 
-                    // estimate geometrically the target vergence Vg=L-R                    
+                    // estimate geometrically the target vergence Vg=L-R
                     if (fph[0]>=eyesHalfBaseline)
                     {
                         L=M_PI/2.0-atan2(fph[2],fph[0]+eyesHalfBaseline);
@@ -404,7 +404,7 @@ void EyePinvRefGen::run()
                 commData->set_counterv(zeros((int)qd.length()));
             else
                 commData->set_counterv(getEyesCounterVelocity(eyesJ,fp));
-            
+
             // reset eyes controller and integral upon saccades transition on=>off
             if (saccadeUnderWayOld && !commData->saccadeUnderway)
             {
@@ -442,7 +442,7 @@ void EyePinvRefGen::run()
 
 /************************************************************************/
 void EyePinvRefGen::suspend()
-{    
+{
     PeriodicThread::suspend();
     yInfo("Pseudoinverse Reference Generator has been suspended!");
 }
@@ -450,7 +450,7 @@ void EyePinvRefGen::suspend()
 
 /************************************************************************/
 void EyePinvRefGen::resume()
-{    
+{
     PeriodicThread::resume();
     yInfo("Pseudoinverse Reference Generator has been resumed!");
 }
@@ -469,7 +469,7 @@ Solver::Solver(PolyDriver *_drvTorso, PolyDriver *_drvHead, ExchangeData *_commD
     eyeL=new iCubEye("left_v"+commData->head_version.get_version());
     eyeR=new iCubEye("right_v"+commData->head_version.get_version());
     imu=new iCubInertialSensor(commData->head_version.get_version());
-    torsoVel=new AWLinEstimator(16,0.5);    
+    torsoVel=new AWLinEstimator(16,0.5);
 
     // remove constraints on the links: logging purpose
     imu->setAllConstraints(false);
@@ -481,7 +481,7 @@ Solver::Solver(PolyDriver *_drvTorso, PolyDriver *_drvHead, ExchangeData *_commD
 
     // Get the chain objects
     chainNeck=neck->asChain();
-    chainEyeL=eyeL->asChain();        
+    chainEyeL=eyeL->asChain();
     chainEyeR=eyeR->asChain();
 
     invNeck=new GazeIpOptMin(*chainNeck,1e-3,1e-3,20);
@@ -501,13 +501,13 @@ Solver::Solver(PolyDriver *_drvTorso, PolyDriver *_drvHead, ExchangeData *_commD
     if (drvTorso!=nullptr)
     {
         IEncoders *encTorso; drvTorso->view(encTorso);
-        encTorso->getAxes(&nJointsTorso);
+        encTorso->getAxes(nJointsTorso);
     }
     else
         nJointsTorso=3;
 
     IEncoders *encHead; drvHead->view(encHead);
-    encHead->getAxes(&nJointsHead);
+    encHead->getAxes(nJointsHead);
 
     // joints bounds alignment
     alignJointsBounds(chainNeck,drvTorso,drvHead,commData);
@@ -573,7 +573,7 @@ void Solver::bindNeckPitch(const double min_deg, const double max_deg)
     double max_rad=sat(CTRL_DEG2RAD*max_deg,neckPitchMin,neckPitchMax);
 
     (*chainNeck)(0).setMin(min_rad);
-    (*chainNeck)(0).setMax(max_rad);    
+    (*chainNeck)(0).setMax(max_rad);
 
     yInfo("neck pitch constrained in [%g,%g] deg",min_deg,max_deg);
 }
@@ -732,7 +732,7 @@ bool Solver::threadInit()
 {
     // Initialization
     Vector fp;
-    CartesianHelper::computeFixationPointData(*chainEyeL,*chainEyeR,fp);    
+    CartesianHelper::computeFixationPointData(*chainEyeL,*chainEyeR,fp);
 
     // init commData structure
     commData->port_xd->init(fp);
@@ -743,7 +743,7 @@ bool Solver::threadInit()
     commData->set_torso(fbTorso);
     commData->resize_v((int)fbHead.length(),0.0);
     commData->resize_counterv(3,0.0);
-    commData->set_fpFrame(chainNeck->getH());    
+    commData->set_fpFrame(chainNeck->getH());
 
     // use eyes pseudoinverse reference generator
     eyesRefGen->enable();
@@ -781,7 +781,7 @@ void Solver::run()
     // get the current target
     Vector xd=commData->port_xd->get_xdDelayed();
 
-    // update the target straightaway 
+    // update the target straightaway
     commData->set_xd(xd);
 
     // read encoders
@@ -837,7 +837,7 @@ void Solver::run()
         Vector xdUserTol=computeTargetUserTolerance(xd);
         neckPos=invNeck->solve(neckPos,xdUserTol,gDir);
 
-        // update neck pitch,roll,yaw        
+        // update neck pitch,roll,yaw
         commData->set_qd(0,neckPos[0]);
         commData->set_qd(1,neckPos[1]);
         commData->set_qd(2,neckPos[2]);
@@ -886,7 +886,7 @@ void Solver::resume()
     getFeedback(fbTorso,fbHead,drvTorso,drvHead,commData);
     updateTorsoBlockedJoints(chainNeck,fbTorso);
     updateTorsoBlockedJoints(chainEyeL,fbTorso);
-    updateTorsoBlockedJoints(chainEyeR,fbTorso);        
+    updateTorsoBlockedJoints(chainEyeR,fbTorso);
 
     // update kinematics
     updateAngles();
@@ -896,7 +896,7 @@ void Solver::resume()
     chainEyeL->setAng(nJointsTorso+3,gazePos[0]);                chainEyeR->setAng(nJointsTorso+3,gazePos[0]);
     chainEyeL->setAng(nJointsTorso+4,gazePos[1]+gazePos[2]/2.0); chainEyeR->setAng(nJointsTorso+4,gazePos[1]-gazePos[2]/2.0);
 
-    torsoVel->reset();       
+    torsoVel->reset();
     commData->port_xd->unlock();
 
     PeriodicThread::resume();

--- a/src/modules/iKinGazeCtrl/src/utils.cpp
+++ b/src/modules/iKinGazeCtrl/src/utils.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2010 RobotCub Consortium, European Commission FP6 Project IST-004370
  * Author: Ugo Pattacini, Alessandro Roncone
  * email:  ugo.pattacini@iit.it, alessandro.roncone@iit.it
@@ -34,7 +34,7 @@ constexpr int32_t MUTEX_FPFRAME  = 7;
 
 /************************************************************************/
 xdPort::xdPort(void *_slv) : slv(_slv)
-{   
+{
     isNewDelayed=isNew=false;
     locked=false;
     closing=false;
@@ -67,7 +67,7 @@ void xdPort::onRead(Bottle &b)
     lock_guard<mutex> lg(mutex_0);
     if (locked)
         return;
-        
+
     size_t n=std::min(b.size(),xd.length());
     for (size_t i=0; i<n; i++)
         xd[i]=b.get(i).asFloat64();
@@ -143,7 +143,7 @@ ExchangeData::ExchangeData()
     ctrlActive=false;
     trackingModeOn=false;
     saccadeUnderway=false;
-    minAllowedVergence=0.0;    
+    minAllowedVergence=0.0;
     eyesBoundVer=-1.0;
     neckSolveCnt=0;
 
@@ -535,16 +535,16 @@ Matrix alignJointsBounds(iKinChain *chain, PolyDriver *drvTorso,
     IControlLimits *lims;
 
     double min, max;
-    int nJointsTorso=3;    
+    size_t nJointsTorso=3;
 
     if (drvTorso!=nullptr)
     {
         drvTorso->view(encs);
-        drvTorso->view(lims);        
-        encs->getAxes(&nJointsTorso);
+        drvTorso->view(lims);
+        encs->getAxes(nJointsTorso);
 
         for (int i=0; i<nJointsTorso; i++)
-        {   
+        {
             if (lims->getPosLimits(i,&min,&max))
             {
                 if (commData->head_version<iKinLimbVersion("3.0"))
@@ -565,12 +565,12 @@ Matrix alignJointsBounds(iKinChain *chain, PolyDriver *drvTorso,
 
     drvHead->view(encs);
     drvHead->view(lims);
-    int nJointsHead;
-    encs->getAxes(&nJointsHead);
+    size_t nJointsHead;
+    encs->getAxes(nJointsHead);
     Matrix lim(nJointsHead,2);
 
     for (int i=0; i<nJointsHead; i++)
-    {   
+    {
         if (lims->getPosLimits(i,&min,&max))
         {
             // limit eye's tilt due to eyelids
@@ -642,7 +642,7 @@ bool getFeedback(Vector &fbTorso, Vector &fbHead, PolyDriver *drvTorso,
     Vector fb(std::max(nJointsTorso,nJointsHead));
     Vector stamps(nJointsTorso+nJointsHead,0.0);
     bool ret=true;
-    
+
     if (drvTorso!=nullptr)
     {
         drvTorso->view(encs);
@@ -665,11 +665,11 @@ bool getFeedback(Vector &fbTorso, Vector &fbHead, PolyDriver *drvTorso,
     }
     else
         ret=false;
-    
+
     // impose vergence != 0.0
     if (commData!=nullptr)
         fbHead[nJointsHead-1]=std::max(fbHead[nJointsHead-1],commData->minAllowedVergence);
-    
+
     // retrieve the highest encoders time stamp
     if (timeStamp!=nullptr)
         *timeStamp=findMax(stamps);

--- a/src/tools/depth2kin/include/module.h
+++ b/src/tools/depth2kin/include/module.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2014 iCub Facility - Istituto Italiano di Tecnologia
  * Author: Ugo Pattacini
  * email:  ugo.pattacini@iit.it
@@ -75,7 +75,7 @@ protected:
     IEncoderArrays    *iencarray;
     ICartesianControl *iarm;
     IGazeControl      *igaze;
-        
+
     mutex mtx;
     iCubFinger finger;
     Vector curExplorationCenter;
@@ -93,12 +93,12 @@ protected:
     double exploration_intargettol;
     double touch_intargettol;
     int    roi_side;
-    int    nEncs;
+    size_t    nEncs;
     int    test;
     bool   enabled;
     bool   calibrated;
     bool   isSaved;
-    bool   closing;    
+    bool   closing;
     bool   exp_depth2kin;
     bool   exp_aligneyes;
     bool   touchWithExperts;

--- a/src/tools/depth2kin/src/module.cpp
+++ b/src/tools/depth2kin/src/module.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2014 iCub Facility - Istituto Italiano di Tecnologia
  * Author: Ugo Pattacini
  * email:  ugo.pattacini@iit.it
@@ -69,7 +69,7 @@ bool CalibModule::createTargets(const Vector &c, const Vector &size)
 {
     if ((c.length()<3) || (size.length()<2))
         return false;
-    
+
     double a=std::max(fabs(size[0]),0.04);
     double b=std::max(fabs(size[1]),0.02);
 
@@ -139,7 +139,7 @@ Calibrator *CalibModule::factory(const string &type)
 /************************************************************************/
 bool CalibModule::factory(Value &v)
 {
-    if (!v.check("arm") || !v.check("type")) 
+    if (!v.check("arm") || !v.check("type"))
         return false;
 
     string arm=v.find("arm").asString();
@@ -154,8 +154,8 @@ bool CalibModule::factory(Value &v)
 
         Calibrator *c=factory(type);
         if (c->fromProperty(info))
-        {            
-            c->toProperty(info); 
+        {
+            c->toProperty(info);
             yInfo("loaded %s calibrator: %s",arm.c_str(),info.toString().c_str());
             ((arm=="left")?expertsL:expertsR)<<*c;
             return true;
@@ -175,7 +175,7 @@ cv::Rect CalibModule::extractFingerTip(ImageOf<PixelMono> &imgIn, ImageOf<PixelB
     // produce a colored image
     imgOut.resize(imgIn);
     cv::Mat imgOutMat=toCvMat(imgOut);
-    
+
     // proceed iff the center is within the image plane
     if ((c[0]<10.0) || (c[0]>imgIn.width()-10) ||
         (c[1]<10.0) || (c[1]>imgIn.height()-10))
@@ -195,7 +195,7 @@ cv::Rect CalibModule::extractFingerTip(ImageOf<PixelMono> &imgIn, ImageOf<PixelB
     br.y=std::max(1,br.y); br.y=std::min(br.y,(int)imgIn.height()-1);
     cv::Rect rect(tl,br);
 
-    // run Otsu algorithm to segment out the finger    
+    // run Otsu algorithm to segment out the finger
     cv::Mat imgInMatRoi(imgInMat,rect);
     cv::threshold(imgInMatRoi,imgInMatRoi,0,255,cv::THRESH_BINARY|cv::THRESH_OTSU);
     cv::cvtColor(imgInMat,imgOutMat,CV_GRAY2BGR);
@@ -246,7 +246,7 @@ bool CalibModule::getGazeParams(const string &eye, const string &type, Matrix &M
     Bottle info;
     igaze->getInfo(info);
     if (Bottle *pB=info.find("camera_"+type+"_"+eye).asList())
-    {        
+    {
         M.resize((type=="intrinsics")?3:4,4);
 
         int cnt=0;
@@ -305,7 +305,7 @@ bool CalibModule::getDepth(const Vector &px, Vector &x, Vector &pxr)
 /************************************************************************/
 bool CalibModule::getDepthAveraged(const Vector &px, Vector &x, Vector &pxr,
                                    const int maxSamples)
-{        
+{
     x.resize(3,0.0);
     pxr.resize(2,0.0);
 
@@ -320,7 +320,7 @@ bool CalibModule::getDepthAveraged(const Vector &px, Vector &x, Vector &pxr,
             cnt+=1.0;
         }
     }
-    
+
     if (norm(x)==0.0)
         return false;
 
@@ -545,7 +545,7 @@ void CalibModule::prepareRobot()
     {
         Time::delay(1.0);
         iposs->checkMotionDone(i0+4,done);
-    }    
+    }
 
     Vector encs(nEncs);
     iencs->getEncoders(encs.data());
@@ -561,7 +561,7 @@ void CalibModule::prepareRobot()
     Vector xf=finger.getH(CTRL_DEG2RAD*joints).getCol(3);
 
     iarm->storeContext(&context_arm);
-    
+
     Vector dof;
     iarm->getDOF(dof);
     dof=1.0;
@@ -728,7 +728,7 @@ void CalibModule::doTouch(const Vector &xd)
     yInfo("moving to xd=(%s); od=(%s)",x.toString(3,3).c_str(),od.toString(3,3).c_str());
     iarm->setInTargetTol(exploration_intargettol);
     iarm->goToPoseSync(x,od);
-    iarm->waitMotionDone();    
+    iarm->waitMotionDone();
 
     x[0]=-0.35;
     x[1]=(arm=="left"?-0.2:0.2);
@@ -761,7 +761,7 @@ void CalibModule::doTest()
     x_rad[3]=CTRL_DEG2RAD*0.0;
     x_rad[4]=CTRL_DEG2RAD*5.0;
     x_rad[5]=CTRL_DEG2RAD*2.3;
-    
+
     Vector x_deg=x_rad.subVector(0,2);
     x_deg=cat(x_deg,CTRL_RAD2DEG*x_rad.subVector(3,5));
     Matrix H=computeH(x_rad);
@@ -807,7 +807,7 @@ void CalibModule::doTest()
                 p2d+=NormRand::vector(2,0.0,5.0);   // add up some noise
 
                 aligner.addPoints(p2d,p3d);
-            }   
+            }
 
             Matrix H1; double error;
             ok=aligner.calibrate(H1,error);
@@ -893,7 +893,7 @@ bool CalibModule::configure(ResourceFinder &rf)
     string robot=rf.check("robot",Value("icub")).asString();
     string name=rf.check("name",Value("depth2kin")).asString();
     string type=rf.check("type",Value("se3+scale")).asString();
-    test=rf.check("test",Value(-1)).asInt32();    
+    test=rf.check("test",Value(-1)).asInt32();
     max_dist=fabs(rf.check("max_dist",Value(0.25)).asFloat64());
     roi_side=abs(rf.check("roi_side",Value(100)).asInt32());
     block_eyes=fabs(rf.check("block_eyes",Value(5.0)).asFloat64());
@@ -916,7 +916,7 @@ bool CalibModule::configure(ResourceFinder &rf)
         yError("Unknown method %s!",type.c_str());
         return false;
     }
-    
+
     load();
     calibrator=factory(type);
 
@@ -934,7 +934,7 @@ bool CalibModule::configure(ResourceFinder &rf)
     {
         Matrix K=eye(3,4);
         K(0,0)=257.34; K(1,1)=257.34;
-        K(0,2)=160.0;  K(1,2)=120.0; 
+        K(0,2)=160.0;  K(1,2)=120.0;
 
         aligner.setProjection(K);
         return true;
@@ -982,7 +982,7 @@ bool CalibModule::configure(ResourceFinder &rf)
     optionGaze.put("local","/"+name+"/gaze");
     if (!drvGaze.open(optionGaze))
         yWarning("Gaze controller not available!");
-    
+
     // set up some global vars
     useArmL=(drvArmL.isValid() && drvMAIS_L.isValid() && drvCartL.isValid());
     useArmR=(drvArmR.isValid() && drvMAIS_R.isValid() && drvCartR.isValid());
@@ -1007,9 +1007,9 @@ bool CalibModule::configure(ResourceFinder &rf)
     (arm=="left")?drvArmL.view(iposs):drvArmR.view(iposs);
     (arm=="left")?drvArmL.view(ilim):drvArmR.view(ilim);
     (arm=="left")?drvMAIS_L.view(iencarray):drvMAIS_R.view(iencarray);
-    (arm=="left")?drvCartL.view(iarm):drvCartR.view(iarm);    
+    (arm=="left")?drvCartL.view(iarm):drvCartR.view(iarm);
     drvGaze.view(igaze);
-    iencs->getAxes(&nEncs);
+    iencs->getAxes(nEncs);
 
     Matrix Prj;
     if (!getGazeParams("left","intrinsics",Prj))
@@ -1059,7 +1059,7 @@ void CalibModule::onRead(ImageOf<PixelMono> &imgIn)
 
     ImageOf<PixelBgr> imgOut;
     cv::Rect rect=extractFingerTip(imgIn,imgOut,c,tipl);
-    
+
     bool holdImg=false;
     if (motorExplorationState==motorExplorationStateLog)
     {
@@ -1125,7 +1125,7 @@ void CalibModule::onRead(ImageOf<PixelMono> &imgIn)
         motorExplorationState=motorExplorationStateTrigger;
         holdImg=true;
     }
-    
+
     if (depthOutPort.getOutputCount()>0)
     {
         depthOutPort.prepare()=imgOut;
@@ -1163,7 +1163,7 @@ bool CalibModule::load()
         return false;
     }
 
-    Property data; data.fromConfigFile(fileName); 
+    Property data; data.fromConfigFile(fileName);
     Bottle b; b.read(data);
 
     lock_guard<mutex> lck(mtx);
@@ -1184,12 +1184,12 @@ bool CalibModule::save()
         string contextPath=rf->getHomeContextPath();
         string fileName=rf->find("calibrationFile").asString();
         fileName=contextPath+"/"+fileName;
-        
+
         yInfo("saving experts into file: %s",fileName.c_str());
         fout.open(fileName.c_str());
-        
+
         if (fout.is_open())
-        {        
+        {
             for (size_t i=0; i<expertsL.size(); i++)
             {
                 Property info;
@@ -1208,7 +1208,7 @@ bool CalibModule::save()
                 ostringstream entry;
                 entry<<"expert_right_"<<i;
                 fout<<entry.str()<<" "<<info.toString()<<endl;
-            }        
+            }
 
             fout.close();
             isSaved=true;
@@ -1392,7 +1392,7 @@ bool CalibModule::setCalibrationType(const string &type, const string &extrapola
         (extrapolation=="auto")?calibrator->setExtrapolation(type!="lssvm"):
                                 calibrator->setExtrapolation(extrapolation=="true");
 
-        return true; 
+        return true;
     }
     else
         return false;
@@ -1553,7 +1553,7 @@ PointReq CalibModule::getPoint(const string &arm, const double x, const double y
 
 
 /************************************************************************/
-vector<PointReq> CalibModule::getPoints(const string &arm, 
+vector<PointReq> CalibModule::getPoints(const string &arm,
                                         const vector<double> &coordinates)
 {
     LocallyWeightedExperts *experts=&(arm=="left"?expertsL:expertsR);
@@ -1573,7 +1573,7 @@ vector<PointReq> CalibModule::getPoints(const string &arm,
             point.result="ok";
             point.x=out[0];
             point.y=out[1];
-            point.z=out[2];            
+            point.z=out[2];
         }
 
         reply.push_back(point);
@@ -1589,7 +1589,7 @@ bool CalibModule::setExperiment(const string &exp, const string &v)
     if ((v!="on") && (v!="off"))
         return false;
 
-    if (exp=="depth2kin") 
+    if (exp=="depth2kin")
     {
         exp_depth2kin=(v=="on");
         return true;
@@ -1692,7 +1692,7 @@ bool CalibModule::setExplorationSpace(const double cx, const double cy,
     c[2]=cz;
     size[0]=a;
     size[1]=b;
-    
+
     return createTargets(c,size);
 }
 
@@ -1708,7 +1708,7 @@ bool CalibModule::setExplorationSpaceDelta(const double dcx, const double dcy,
     dc[2]=dcz;
     dsize[0]=da;
     dsize[1]=db;
-    
+
     Vector c(3),size(2);
     c[0]=-0.4; c[1]=0.0; c[2]=0.05;
     size[0]=0.10; size[1]=0.05;
@@ -1737,7 +1737,7 @@ bool CalibModule::clearExplorationData()
 {
     lock_guard<mutex> lck(mtx);
     if (exp_depth2kin)
-        calibrator->clearPoints(); 
+        calibrator->clearPoints();
 
     if (exp_aligneyes)
         aligner.clearPoints();
@@ -1787,7 +1787,7 @@ void CalibModule::terminate()
 {
     if (!touchInPort.isClosed())
     {
-        touchInPort.close();        
+        touchInPort.close();
         depthInPort.close();
         depthOutPort.close();
         depthRpcPort.close();


### PR DESCRIPTION
A set of fixes for `getAxes` calls on different components of the repo:
- ActionPrimitives
- iKinSlv
- springyFingers
- MotorThread
- iKinGazeCtrl Solver and Controller
- depth2kin module