### PR TITLE
[DRAFT] Build against OpenCV 5 while keeping compatibility with OpenCV 4

### DIFF
--- a/conf/iCubFindDependencies.cmake
+++ b/conf/iCubFindDependencies.cmake
@@ -31,6 +31,16 @@ find_package(icub_firmware_shared QUIET)
 find_package(GSL)
 find_package(GLUT)
 find_package(OpenCV)
+
+# YARP_cv versions built against OpenCV 5 development snapshots can retain
+# opencv_cvv in their transitive link interface even though that module was
+# removed from the final OpenCV 5 package.  Treat the removed, unused module as
+# an empty interface target so consumers of YARP_cv do not fall back to
+# searching for a non-existent -lopencv_cvv.
+if(OpenCV_VERSION VERSION_GREATER_EQUAL 5 AND NOT TARGET opencv_cvv)
+  add_library(opencv_cvv INTERFACE IMPORTED)
+endif()
+
 find_package(OpenGL)
 find_package(SDL)
 find_package(ACE)

--- a/src/libraries/learningMachine/CMakeLists.txt
+++ b/src/libraries/learningMachine/CMakeLists.txt
@@ -64,11 +64,10 @@ if(YARP_gsl_FOUND)
   add_library(ICUB::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
   target_include_directories(${LM_LIB} PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
-                                              "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>"
-                                              ${GSL_INCLUDE_DIRS})
+                                              "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
 
-  target_link_libraries(${LM_LIB} PUBLIC  YARP::YARP_os YARP::YARP_sig YARP::YARP_math
-                                  PRIVATE YARP::YARP_gsl ${GSL_LIBRARIES})
+  target_link_libraries(${LM_LIB} PUBLIC  YARP::YARP_os YARP::YARP_sig YARP::YARP_math GSL::gsl
+                                  PRIVATE YARP::YARP_gsl)
   set_target_properties(${PROJECT_NAME} PROPERTIES
                                         PUBLIC_HEADER "${LM_HEADER}")
 
@@ -88,7 +87,7 @@ if(YARP_gsl_FOUND)
                                    DEPENDENCIES YARP_os
                                                 YARP_sig
                                                 YARP_math
-                                   PRIVATE_DEPENDENCIES YARP_gsl
-                                                        GSL)
+                                                GSL
+                                   PRIVATE_DEPENDENCIES YARP_gsl)
 endif()
   

--- a/src/modules/actionsRenderingEngine/include/iCub/VisuoThread.h
+++ b/src/modules/actionsRenderingEngine/include/iCub/VisuoThread.h
@@ -28,7 +28,7 @@
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Image.h>
 
-#include <opencv2/core/core_c.h>
+#include <opencv2/core.hpp>
 
 #include <mutex>
 #include <string>
@@ -124,12 +124,12 @@ private:
     {
         double  t;
         double  size;
-        CvPoint p;
+        cv::Point p;
     };
 
     deque<Item>                 buffer[2];
-    //map<string,CvPoint>         locations[2];
-    map<string,CvPoint>         locations;
+    //map<string,cv::Point>       locations[2];
+    map<string,cv::Point>       locations;
 
 
     bool getFixation(Bottle &bStereo);
@@ -199,5 +199,3 @@ public:
 };
 
 #endif
-
-

--- a/src/modules/actionsRenderingEngine/src/VisuoThread.cpp
+++ b/src/modules/actionsRenderingEngine/src/VisuoThread.cpp
@@ -15,6 +15,7 @@
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
 * Public License for more details
 */
+#include <cmath>
 #include <utility>
 #include <yarp/os/Time.h>
 #include <yarp/cv/Cv.h>
@@ -147,13 +148,13 @@ void VisuoThread::startTracker(const Vector &stereo, const int &side)
         tpl.resize(side,side);
         cv::Mat tplMat=yarp::cv::toCvMat(tpl);
 
-        int x=stereo[2*eye_in_use]-0.5*side<0?0:cvRound(stereo[2*eye_in_use]-0.5*side);
-        int y=stereo[2*eye_in_use+1]-0.5*side<0?0:cvRound(stereo[2*eye_in_use+1]-0.5*side);
+        int x=stereo[2*eye_in_use]-0.5*side<0?0:static_cast<int>(std::lround(stereo[2*eye_in_use]-0.5*side));
+        int y=stereo[2*eye_in_use+1]-0.5*side<0?0:static_cast<int>(std::lround(stereo[2*eye_in_use+1]-0.5*side));
         int width=stereo[2*eye_in_use]+0.5*side>=imgMat.cols?imgMat.cols-x:side;
         int height=stereo[2*eye_in_use+1]+0.5*side>=imgMat.rows?imgMat.rows-y:side;
         
         imgMat(cv::Rect(x,y,width,height)).copyTo(tplMat);
-        cv::cvtColor(tplMat,tplMat,CV_BGR2RGB);
+        cv::cvtColor(tplMat,tplMat,cv::COLOR_BGR2RGB);
 
         pftOutPort.write(tpl);
     }
@@ -212,7 +213,7 @@ void VisuoThread::updateLocationsMIL()
         for(int i=0; i<bLocations->get(0).asList()->size(); i++)
         {
             Bottle *b=bLocations->get(0).asList()->get(i).asList();
-            locations[b->get(0).asString()]=cvPoint(b->get(1).asInt32(),b->get(2).asInt32());
+            locations[b->get(0).asString()]=cv::Point(b->get(1).asInt32(),b->get(2).asInt32());
         }
     }
 }
@@ -245,7 +246,7 @@ void VisuoThread::updateMotionCUT()
             Item item;
             item.t=Time::now();
             item.size=bMotion[cam]->get(0).asList()->get(2).asFloat64();
-            item.p=cvPoint(bMotion[cam]->get(0).asList()->get(0).asInt32(),bMotion[cam]->get(0).asList()->get(1).asInt32());
+            item.p=cv::Point(bMotion[cam]->get(0).asList()->get(0).asInt32(),bMotion[cam]->get(0).asList()->get(1).asInt32());
             buffer[cam].push_back(item);
 
             stereo[2*cam]=bMotion[cam]->get(0).asList()->get(0).asFloat64();
@@ -304,24 +305,24 @@ void VisuoThread::updatePFTracker()
         if(stereoTracker.vec.size()==12)
         {
             cv::Mat tmpL=yarp::cv::toCvMat(drawImg[LEFT]);
-            cv::circle(tmpL,cv::Point(cvRound(stereoTracker.vec[0]),cvRound(stereoTracker.vec[1])),3,cv::Scalar(0,255),3);
-            cv::rectangle(tmpL,cv::Point(cvRound(stereoTracker.vec[2]),cvRound(stereoTracker.vec[3])),
-                          cv::Point(cvRound(stereoTracker.vec[4]),cvRound(stereoTracker.vec[5])),cv::Scalar(0,255),3);
+            cv::circle(tmpL,cv::Point(static_cast<int>(std::lround(stereoTracker.vec[0])),static_cast<int>(std::lround(stereoTracker.vec[1]))),3,cv::Scalar(0,255),3);
+            cv::rectangle(tmpL,cv::Point(static_cast<int>(std::lround(stereoTracker.vec[2])),static_cast<int>(std::lround(stereoTracker.vec[3]))),
+                          cv::Point(static_cast<int>(std::lround(stereoTracker.vec[4])),static_cast<int>(std::lround(stereoTracker.vec[5]))),cv::Scalar(0,255),3);
 
             cv::Mat tmpR=yarp::cv::toCvMat(drawImg[RIGHT]);
-            cv::circle(tmpR,cv::Point(cvRound(stereoTracker.vec[6]),cvRound(stereoTracker.vec[7])),3,cv::Scalar(0,255),3);
-            cv::rectangle(tmpR,cv::Point(cvRound(stereoTracker.vec[8]),cvRound(stereoTracker.vec[9])),
-                          cv::Point(cvRound(stereoTracker.vec[10]),cvRound(stereoTracker.vec[11])),cv::Scalar(0,255),3);
+            cv::circle(tmpR,cv::Point(static_cast<int>(std::lround(stereoTracker.vec[6])),static_cast<int>(std::lround(stereoTracker.vec[7]))),3,cv::Scalar(0,255),3);
+            cv::rectangle(tmpR,cv::Point(static_cast<int>(std::lround(stereoTracker.vec[8])),static_cast<int>(std::lround(stereoTracker.vec[9]))),
+                          cv::Point(static_cast<int>(std::lround(stereoTracker.vec[10])),static_cast<int>(std::lround(stereoTracker.vec[11]))),cv::Scalar(0,255),3);
 
             Bottle v;
             v.clear();
             Bottle &vl=v.addList();
-            vl.addInt32(cvRound(stereoTracker.vec[0]));
-            vl.addInt32(cvRound(stereoTracker.vec[1]));
+            vl.addInt32(static_cast<int>(std::lround(stereoTracker.vec[0])));
+            vl.addInt32(static_cast<int>(std::lround(stereoTracker.vec[1])));
             vl.addInt32(stereoTracker.side);
             Bottle &vr=v.addList();
-            vr.addInt32(cvRound(stereoTracker.vec[6]));
-            vr.addInt32(cvRound(stereoTracker.vec[7]));
+            vr.addInt32(static_cast<int>(std::lround(stereoTracker.vec[6])));
+            vr.addInt32(static_cast<int>(std::lround(stereoTracker.vec[7])));
             vr.addInt32(stereoTracker.side);
 
             boundMILPort.write(v);
@@ -617,7 +618,7 @@ bool VisuoThread::getMotion(Bottle &bStereo)
                 size+=size_cam;
             }
 
-            int side=cvRound(2*sqrt(size/3.1415)*2);
+            int side=static_cast<int>(std::lround(2*sqrt(size/3.1415)*2));
 
             if (p[LEFT].size()==2 && p[RIGHT].size()==2)
             {
@@ -627,7 +628,7 @@ bool VisuoThread::getMotion(Bottle &bStereo)
                 stereo[2]=p[RIGHT][0];
                 stereo[3]=p[RIGHT][1];
                 
-                startTracker(stereo,cvRound(side));
+                startTracker(stereo,side);
 
                 ok=true;
             }
@@ -864,5 +865,3 @@ void VisuoThread::reinstate()
 
     interrupted=false;
 }
-
-

--- a/src/modules/camCalib/include/iCub/CamCalibModule.h
+++ b/src/modules/camCalib/include/iCub/CamCalibModule.h
@@ -12,9 +12,6 @@
  // std
 #include <stdio.h>
 
-// opencv
-#include <opencv2/core/core_c.h>
-
 // yarp
 #include <yarp/os/all.h>
 #include <yarp/sig/all.h>

--- a/src/modules/camCalib/include/iCub/PinholeCalibTool.h
+++ b/src/modules/camCalib/include/iCub/PinholeCalibTool.h
@@ -16,9 +16,8 @@
 #include <math.h>
 
 // opencv
-#include <opencv2/core/core_c.h>
-#include <opencv2/calib3d/calib3d_c.h>
 #include <opencv2/calib3d.hpp>
+#include <opencv2/core.hpp>
 
 // yarp
 //#include <yarp/sig/Image.h>
@@ -39,21 +38,21 @@ class PinholeCalibTool : public ICalibTool
 {
  private:
     
-    CvMat           *_intrinsic_matrix;
-    CvMat           *_intrinsic_matrix_scaled;
-    CvMat           *_distortion_coeffs;;
+    cv::Mat         _intrinsic_matrix;
+    cv::Mat         _intrinsic_matrix_scaled;
+    cv::Mat         _distortion_coeffs;
 
-    IplImage        *_mapUndistortX;
-    IplImage        *_mapUndistortY;
+    cv::Mat         _mapUndistortX;
+    cv::Mat         _mapUndistortY;
 
     bool _needInit;
 
-    CvSize          _calibImgSize;
-    CvSize          _oldImgSize;
+    cv::Size        _calibImgSize;
+    cv::Size        _oldImgSize;
 
     bool _drawCenterCross;
 
-    bool init(CvSize currImgSize, CvSize calibImgSize);
+    bool init(cv::Size currImgSize, cv::Size calibImgSize);
 
 public:
 

--- a/src/modules/camCalib/include/iCub/SphericalCalibTool.h
+++ b/src/modules/camCalib/include/iCub/SphericalCalibTool.h
@@ -15,7 +15,7 @@
 #include <yarp/os/Value.h>
 
 // opencv
-#include <opencv2/core/core_c.h>
+#include <opencv2/core.hpp>
 
 // iCub
 #include <iCub/ICalibTool.h>
@@ -29,8 +29,8 @@ class SphericalCalibTool : public ICalibTool
 {
 private:
 
-    IplImage        *_mapX;
-    IplImage        *_mapY;
+    cv::Mat         _mapX;
+    cv::Mat         _mapY;
 
     double          _fx, _fx_scaled;
     double          _fy, _fy_scaled;
@@ -43,12 +43,12 @@ private:
 
     bool _needInit;
 
-    CvSize          _calibImgSize;
-    CvSize          _oldImgSize;
+    cv::Size        _calibImgSize;
+    cv::Size        _oldImgSize;
 
     bool _drawCenterCross;
 
-    bool init(CvSize currImgSize, CvSize calibImgSize);
+    bool init(cv::Size currImgSize, cv::Size calibImgSize);
 
 public:
 

--- a/src/modules/camCalib/src/PinholeCalibTool.cpp
+++ b/src/modules/camCalib/src/PinholeCalibTool.cpp
@@ -14,13 +14,10 @@ using namespace yarp::sig;
 using namespace yarp::cv;
 
 PinholeCalibTool::PinholeCalibTool(){
-    _mapUndistortX = NULL;
-    _mapUndistortY = NULL;
-    _intrinsic_matrix = cvCreateMat(3,3, CV_32F);
-    _intrinsic_matrix_scaled = cvCreateMat(3,3, CV_32F);
-    _distortion_coeffs = cvCreateMat(1, 4, CV_32F);
-    _oldImgSize.width = -1;
-    _oldImgSize.height = -1;
+    _intrinsic_matrix = cv::Mat::eye(3, 3, CV_32F);
+    _intrinsic_matrix_scaled = cv::Mat::eye(3, 3, CV_32F);
+    _distortion_coeffs = cv::Mat::zeros(1, 4, CV_32F);
+    _oldImgSize = cv::Size(-1, -1);
     _needInit = true;
 }
 
@@ -29,15 +26,11 @@ PinholeCalibTool::~PinholeCalibTool(){
 }
 
 bool PinholeCalibTool::close(){
-    if (_mapUndistortX != NULL)
-        cvReleaseImage(&_mapUndistortX);
-    _mapUndistortX = NULL;
-    if (_mapUndistortY != NULL)
-        cvReleaseImage(&_mapUndistortY);
-    _mapUndistortY = NULL;
-    cvReleaseMat(&_intrinsic_matrix);
-    cvReleaseMat(&_intrinsic_matrix_scaled);
-    cvReleaseMat(&_distortion_coeffs);
+    _mapUndistortX.release();
+    _mapUndistortY.release();
+    _intrinsic_matrix.release();
+    _intrinsic_matrix_scaled.release();
+    _distortion_coeffs.release();
     return true;
 }
 
@@ -65,24 +58,24 @@ bool PinholeCalibTool::configure (Searchable &config){
                                     "Draw a cross at calibration center (int [0|1]).").asInt32()!=0;
 
 
-    CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 0) = (float)config.check("fx",
+    _intrinsic_matrix.at<float>(0, 0) = (float)config.check("fx",
                                                         Value(320.0),
                                                         "Focal length x (double)").asFloat64();
 
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 0, 1) = 0.0f;
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 0, 2) = (float)config.check("cx",
+    _intrinsic_matrix.at<float>(0, 1) = 0.0f;
+    _intrinsic_matrix.at<float>(0, 2) = (float)config.check("cx",
                                                         Value(160.0),
                                                         "Principal point x (double)").asFloat64();
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 1, 0) = 0.0f;
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 1, 1) = (float)config.check("fy",
+    _intrinsic_matrix.at<float>(1, 0) = 0.0f;
+    _intrinsic_matrix.at<float>(1, 1) = (float)config.check("fy",
                                                         Value(320.0),
                                                         "Focal length y (double)").asFloat64();
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 1, 2) = (float)config.check("cy",
+    _intrinsic_matrix.at<float>(1, 2) = (float)config.check("cy",
                                                         Value(120.0),
                                                         "Principal point y (double)").asFloat64();
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 2, 0) = 0.0f;
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 2, 1) = 0.0f;
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 2, 2) = 1.0f;
+    _intrinsic_matrix.at<float>(2, 0) = 0.0f;
+    _intrinsic_matrix.at<float>(2, 1) = 0.0f;
+    _intrinsic_matrix.at<float>(2, 2) = 1.0f;
 
 
     //check to see if the value is read correctly without caring about the default values.
@@ -105,28 +98,19 @@ bool PinholeCalibTool::configure (Searchable &config){
     fprintf(stdout,"cy=%g\n",config.find("cy").asFloat64());
 
 
-    // copy to scaled matrix ;)
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 0);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 1);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 2);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 0);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 1);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 2);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 0);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 1);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 2);
+    _intrinsic_matrix.copyTo(_intrinsic_matrix_scaled);
 
      /* init the distortion coeffs */
-    CV_MAT_ELEM( *_distortion_coeffs, float, 0, 0) = (float)config.check("k1",
+    _distortion_coeffs.at<float>(0, 0) = (float)config.check("k1",
                                                         Value(0.0),
                                                         "Radial distortion 1(double)").asFloat64();
-    CV_MAT_ELEM( *_distortion_coeffs, float, 0, 1) = (float)config.check("k2",
+    _distortion_coeffs.at<float>(0, 1) = (float)config.check("k2",
                                                         Value(0.0),
                                                         "Radial distortion 2(double)").asFloat64();
-    CV_MAT_ELEM( *_distortion_coeffs, float, 0, 2) = (float)config.check("p1",
+    _distortion_coeffs.at<float>(0, 2) = (float)config.check("p1",
                                                         Value(0.0),
                                                         "Tangential distortion 1(double)").asFloat64();
-    CV_MAT_ELEM( *_distortion_coeffs, float, 0, 3) = (float)config.check("p2",
+    _distortion_coeffs.at<float>(0, 3) = (float)config.check("p2",
                                                         Value(0.0),
                                                         "Tangential distortion 2(double)").asFloat64();
     _needInit = true;
@@ -135,16 +119,7 @@ bool PinholeCalibTool::configure (Searchable &config){
 }
 
 
-bool PinholeCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
-
-    if (_mapUndistortX != NULL)
-        cvReleaseImage(&_mapUndistortX);
-    _mapUndistortX = NULL;
-    if (_mapUndistortY != NULL)
-        cvReleaseImage(&_mapUndistortY);
-    _mapUndistortY = NULL;
-
-
+bool PinholeCalibTool::init(cv::Size currImgSize, cv::Size calibImgSize){
     // Scale the intrinsics if required:
     // if current image size is not the same as the size for
     // which calibration parameters are specified we need to
@@ -153,35 +128,20 @@ bool PinholeCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
         currImgSize.height != calibImgSize.height){
         float scaleX = (float)currImgSize.width / (float)calibImgSize.width;
         float scaleY = (float)currImgSize.height / (float)calibImgSize.height;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 0) * scaleX;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 2) * scaleX;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 1) * scaleY;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 2) * scaleY;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 2);
+        _intrinsic_matrix.copyTo(_intrinsic_matrix_scaled);
+        _intrinsic_matrix_scaled.at<float>(0, 0) *= scaleX;
+        _intrinsic_matrix_scaled.at<float>(0, 2) *= scaleX;
+        _intrinsic_matrix_scaled.at<float>(1, 1) *= scaleY;
+        _intrinsic_matrix_scaled.at<float>(1, 2) *= scaleY;
     }
     else{
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 2);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 2);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 2);
+        _intrinsic_matrix.copyTo(_intrinsic_matrix_scaled);
     }
     
-    _mapUndistortX = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
-    _mapUndistortY = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
-
     /* init the undistortion matrices */
-    cv::initUndistortRectifyMap(cv::cvarrToMat(_intrinsic_matrix_scaled), cv::cvarrToMat(_distortion_coeffs), cv::Mat(),
-                                cv::cvarrToMat(_intrinsic_matrix_scaled), cv::Size(currImgSize.width, currImgSize.height),
-                                CV_32FC1,cv::cvarrToMat(_mapUndistortX), cv::cvarrToMat(_mapUndistortY));
+    cv::initUndistortRectifyMap(_intrinsic_matrix_scaled, _distortion_coeffs, cv::Mat(),
+                                _intrinsic_matrix_scaled, currImgSize,
+                                CV_32FC1, _mapUndistortX, _mapUndistortY);
 
     _needInit = false;
     return true;
@@ -189,7 +149,7 @@ bool PinholeCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
 
 void PinholeCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & out){
 
-    CvSize inSize = cvSize(in.width(),in.height());
+    cv::Size inSize(in.width(), in.height());
 
     // check if reallocation required
     if ( inSize.width  != _oldImgSize.width || 
@@ -199,15 +159,15 @@ void PinholeCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & o
 
     cv::Mat outMat;
     cv::remap( toCvMat(const_cast<ImageOf<PixelRgb>&>(in)), outMat,
-               cv::cvarrToMat(_mapUndistortX), cv::cvarrToMat(_mapUndistortY),
+               _mapUndistortX, _mapUndistortY,
                cv::INTER_LINEAR );
     out=fromCvMat<PixelRgb>(outMat);
 
     // painting crosshair at calibration center
     if (_drawCenterCross){
         yarp::sig::PixelRgb pix = yarp::sig::PixelRgb(255,255,255);
-        yarp::sig::draw::addCrossHair(out, pix, (int)CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 2),
-                                            (int)CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 2),
+        yarp::sig::draw::addCrossHair(out, pix, (int)_intrinsic_matrix_scaled.at<float>(0, 2),
+                                            (int)_intrinsic_matrix_scaled.at<float>(1, 2),
                                             10);
     }
 
@@ -215,4 +175,3 @@ void PinholeCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & o
     _oldImgSize.width  = inSize.width;
     _oldImgSize.height = inSize.height;
 }
-

--- a/src/modules/camCalib/src/SphericalCalibTool.cpp
+++ b/src/modules/camCalib/src/SphericalCalibTool.cpp
@@ -17,10 +17,7 @@ using namespace yarp::sig;
 using namespace yarp::cv;
 
 SphericalCalibTool::SphericalCalibTool(){
-    _mapX = NULL;
-    _mapY = NULL;
-    _oldImgSize.width = -1;
-    _oldImgSize.height = -1;
+    _oldImgSize = cv::Size(-1, -1);
     _needInit = true;
 }
 
@@ -33,12 +30,8 @@ bool SphericalCalibTool::open(Searchable &config){
 }
 
 bool SphericalCalibTool::close(){
-    if (_mapX != NULL)
-        cvReleaseImage(&_mapX);
-    _mapX = NULL;
-    if (_mapY != NULL)
-        cvReleaseImage(&_mapY);
-    _mapY = NULL;
+    _mapX.release();
+    _mapY.release();
     return true;
 }
 
@@ -93,15 +86,7 @@ bool SphericalCalibTool::configure (Searchable &config){
 }
 
 
-bool SphericalCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
-
-     if (_mapX != NULL)
-        cvReleaseImage(&_mapX);
-    _mapX = NULL;
-    if (_mapY != NULL)
-        cvReleaseImage(&_mapY);
-    _mapY = NULL;
-
+bool SphericalCalibTool::init(cv::Size currImgSize, cv::Size calibImgSize){
     // Scale the intrinsics if required:
     // if current image size is not the same as the size for
     // which calibration parameters are specified we need to
@@ -122,8 +107,8 @@ bool SphericalCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
         _cy_scaled = _cy;
     }
 
-    _mapX = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
-    _mapY = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
+    _mapX.create(currImgSize, CV_32FC1);
+    _mapY.create(currImgSize, CV_32FC1);
 
     
 
@@ -131,7 +116,7 @@ bool SphericalCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
                        currImgSize.height, currImgSize.width,
                         _fx_scaled, _fy_scaled, _cx_scaled, _cy_scaled, 
                         _k1, _k2, _p1, _p2, 
-                        (float*)_mapX->imageData, (float*)_mapY->imageData))
+                        _mapX.ptr<float>(), _mapY.ptr<float>()))
         return false;
 
     _needInit = false;
@@ -140,7 +125,7 @@ bool SphericalCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
 
 void SphericalCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & out){
 
-    CvSize inSize = cvSize(in.width(),in.height());
+    cv::Size inSize(in.width(), in.height());
 
     // check if reallocation required
     if ( inSize.width  != _oldImgSize.width || 
@@ -152,7 +137,7 @@ void SphericalCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> &
 
     cv::Mat outMat=toCvMat(out);
     cv::remap( toCvMat(const_cast<ImageOf<PixelRgb>&>(in)), outMat,
-               cv::cvarrToMat(_mapX), cv::cvarrToMat(_mapY),
+               _mapX, _mapY,
                cv::INTER_LINEAR );
     out=fromCvMat<PixelRgb>(outMat);
 

--- a/src/modules/camCalib/src/main.cpp
+++ b/src/modules/camCalib/src/main.cpp
@@ -132,9 +132,6 @@
 #include <iCub/SphericalCalibTool.h>
 #include <iCub/CamCalibModule.h>
 
-// OpenCV
-#include <opencv2/core/core_c.h>
-
 using namespace std;
 using namespace yarp::os;
 using namespace yarp::sig;

--- a/src/modules/camCalibWithPose/include/iCub/CamCalibModule.h
+++ b/src/modules/camCalibWithPose/include/iCub/CamCalibModule.h
@@ -14,9 +14,6 @@
 #include <stdio.h>
 #include <map>
 
-// opencv
-#include <opencv2/core/core_c.h>
-
 // yarp
 #include <yarp/os/all.h>
 #include <yarp/sig/all.h>

--- a/src/modules/camCalibWithPose/include/iCub/PinholeCalibTool.h
+++ b/src/modules/camCalibWithPose/include/iCub/PinholeCalibTool.h
@@ -16,9 +16,8 @@
 #include <math.h>
 
 // opencv
-#include <opencv2/core/core_c.h>
-#include <opencv2/calib3d/calib3d_c.h>
 #include <opencv2/calib3d.hpp>
+#include <opencv2/core.hpp>
 
 // yarp
 //#include <yarp/sig/Image.h>
@@ -39,21 +38,21 @@ class PinholeCalibTool : public ICalibTool
 {
  private:
     
-    CvMat           *_intrinsic_matrix;
-    CvMat           *_intrinsic_matrix_scaled;
-    CvMat           *_distortion_coeffs;;
+    cv::Mat         _intrinsic_matrix;
+    cv::Mat         _intrinsic_matrix_scaled;
+    cv::Mat         _distortion_coeffs;
 
-    IplImage        *_mapUndistortX;
-    IplImage        *_mapUndistortY;
+    cv::Mat         _mapUndistortX;
+    cv::Mat         _mapUndistortY;
 
     bool _needInit;
 
-    CvSize          _calibImgSize;
-    CvSize          _oldImgSize;
+    cv::Size        _calibImgSize;
+    cv::Size        _oldImgSize;
 
     bool _drawCenterCross;
 
-    bool init(CvSize currImgSize, CvSize calibImgSize);
+    bool init(cv::Size currImgSize, cv::Size calibImgSize);
 
 public:
 

--- a/src/modules/camCalibWithPose/include/iCub/SphericalCalibTool.h
+++ b/src/modules/camCalibWithPose/include/iCub/SphericalCalibTool.h
@@ -15,7 +15,7 @@
 #include <yarp/os/Value.h>
 
 // opencv
-#include <opencv2/core/core_c.h>
+#include <opencv2/core.hpp>
 
 // iCub
 #include <iCub/ICalibTool.h>
@@ -29,8 +29,8 @@ class SphericalCalibTool : public ICalibTool
 {
 private:
 
-    IplImage        *_mapX;
-    IplImage        *_mapY;
+    cv::Mat         _mapX;
+    cv::Mat         _mapY;
 
     double          _fx, _fx_scaled;
     double          _fy, _fy_scaled;
@@ -43,12 +43,12 @@ private:
 
     bool _needInit;
 
-    CvSize          _calibImgSize;
-    CvSize          _oldImgSize;
+    cv::Size        _calibImgSize;
+    cv::Size        _oldImgSize;
 
     bool _drawCenterCross;
 
-    bool init(CvSize currImgSize, CvSize calibImgSize);
+    bool init(cv::Size currImgSize, cv::Size calibImgSize);
 
 public:
 

--- a/src/modules/camCalibWithPose/src/PinholeCalibTool.cpp
+++ b/src/modules/camCalibWithPose/src/PinholeCalibTool.cpp
@@ -14,13 +14,10 @@ using namespace yarp::sig;
 using namespace yarp::cv;
 
 PinholeCalibTool::PinholeCalibTool(){
-    _mapUndistortX = NULL;
-    _mapUndistortY = NULL;
-    _intrinsic_matrix = cvCreateMat(3,3, CV_32F);
-    _intrinsic_matrix_scaled = cvCreateMat(3,3, CV_32F);
-    _distortion_coeffs = cvCreateMat(1, 4, CV_32F);
-    _oldImgSize.width = -1;
-    _oldImgSize.height = -1;
+    _intrinsic_matrix = cv::Mat::eye(3, 3, CV_32F);
+    _intrinsic_matrix_scaled = cv::Mat::eye(3, 3, CV_32F);
+    _distortion_coeffs = cv::Mat::zeros(1, 4, CV_32F);
+    _oldImgSize = cv::Size(-1, -1);
     _needInit = true;
 }
 
@@ -29,15 +26,11 @@ PinholeCalibTool::~PinholeCalibTool(){
 }
 
 bool PinholeCalibTool::close(){
-    if (_mapUndistortX != NULL)
-        cvReleaseImage(&_mapUndistortX);
-    _mapUndistortX = NULL;
-    if (_mapUndistortY != NULL)
-        cvReleaseImage(&_mapUndistortY);
-    _mapUndistortY = NULL;
-    cvReleaseMat(&_intrinsic_matrix);
-    cvReleaseMat(&_intrinsic_matrix_scaled);
-    cvReleaseMat(&_distortion_coeffs);
+    _mapUndistortX.release();
+    _mapUndistortY.release();
+    _intrinsic_matrix.release();
+    _intrinsic_matrix_scaled.release();
+    _distortion_coeffs.release();
     return true;
 }
 
@@ -65,24 +58,24 @@ bool PinholeCalibTool::configure (Searchable &config){
                                     "Draw a cross at calibration center (int [0|1]).").asInt32()!=0;
 
 
-    CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 0) = (float)config.check("fx",
+    _intrinsic_matrix.at<float>(0, 0) = (float)config.check("fx",
                                                         Value(320.0),
                                                         "Focal length x (double)").asFloat64();
 
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 0, 1) = 0.0f;
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 0, 2) = (float)config.check("cx",
+    _intrinsic_matrix.at<float>(0, 1) = 0.0f;
+    _intrinsic_matrix.at<float>(0, 2) = (float)config.check("cx",
                                                         Value(160.0),
                                                         "Principal point x (double)").asFloat64();
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 1, 0) = 0.0f;
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 1, 1) = (float)config.check("fy",
+    _intrinsic_matrix.at<float>(1, 0) = 0.0f;
+    _intrinsic_matrix.at<float>(1, 1) = (float)config.check("fy",
                                                         Value(320.0),
                                                         "Focal length y (double)").asFloat64();
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 1, 2) = (float)config.check("cy",
+    _intrinsic_matrix.at<float>(1, 2) = (float)config.check("cy",
                                                         Value(120.0),
                                                         "Principal point y (double)").asFloat64();
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 2, 0) = 0.0f;
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 2, 1) = 0.0f;
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 2, 2) = 1.0f;
+    _intrinsic_matrix.at<float>(2, 0) = 0.0f;
+    _intrinsic_matrix.at<float>(2, 1) = 0.0f;
+    _intrinsic_matrix.at<float>(2, 2) = 1.0f;
 
 
     //check to see if the value is read correctly without caring about the default values.
@@ -105,28 +98,19 @@ bool PinholeCalibTool::configure (Searchable &config){
     fprintf(stdout,"cy=%g\n",config.find("cy").asFloat64());
 
 
-    // copy to scaled matrix ;)
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 0);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 1);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 2);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 0);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 1);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 2);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 0);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 1);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 2);
+    _intrinsic_matrix.copyTo(_intrinsic_matrix_scaled);
 
      /* init the distortion coeffs */
-    CV_MAT_ELEM( *_distortion_coeffs, float, 0, 0) = (float)config.check("k1",
+    _distortion_coeffs.at<float>(0, 0) = (float)config.check("k1",
                                                         Value(0.0),
                                                         "Radial distortion 1(double)").asFloat64();
-    CV_MAT_ELEM( *_distortion_coeffs, float, 0, 1) = (float)config.check("k2",
+    _distortion_coeffs.at<float>(0, 1) = (float)config.check("k2",
                                                         Value(0.0),
                                                         "Radial distortion 2(double)").asFloat64();
-    CV_MAT_ELEM( *_distortion_coeffs, float, 0, 2) = (float)config.check("p1",
+    _distortion_coeffs.at<float>(0, 2) = (float)config.check("p1",
                                                         Value(0.0),
                                                         "Tangential distortion 1(double)").asFloat64();
-    CV_MAT_ELEM( *_distortion_coeffs, float, 0, 3) = (float)config.check("p2",
+    _distortion_coeffs.at<float>(0, 3) = (float)config.check("p2",
                                                         Value(0.0),
                                                         "Tangential distortion 2(double)").asFloat64();
     _needInit = true;
@@ -135,16 +119,7 @@ bool PinholeCalibTool::configure (Searchable &config){
 }
 
 
-bool PinholeCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
-
-    if (_mapUndistortX != NULL)
-        cvReleaseImage(&_mapUndistortX);
-    _mapUndistortX = NULL;
-    if (_mapUndistortY != NULL)
-        cvReleaseImage(&_mapUndistortY);
-    _mapUndistortY = NULL;
-
-
+bool PinholeCalibTool::init(cv::Size currImgSize, cv::Size calibImgSize){
     // Scale the intrinsics if required:
     // if current image size is not the same as the size for
     // which calibration parameters are specified we need to
@@ -153,35 +128,20 @@ bool PinholeCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
         currImgSize.height != calibImgSize.height){
         float scaleX = (float)currImgSize.width / (float)calibImgSize.width;
         float scaleY = (float)currImgSize.height / (float)calibImgSize.height;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 0) * scaleX;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 2) * scaleX;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 1) * scaleY;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 2) * scaleY;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 2);
+        _intrinsic_matrix.copyTo(_intrinsic_matrix_scaled);
+        _intrinsic_matrix_scaled.at<float>(0, 0) *= scaleX;
+        _intrinsic_matrix_scaled.at<float>(0, 2) *= scaleX;
+        _intrinsic_matrix_scaled.at<float>(1, 1) *= scaleY;
+        _intrinsic_matrix_scaled.at<float>(1, 2) *= scaleY;
     }
     else{
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 2);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 2);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 2);
+        _intrinsic_matrix.copyTo(_intrinsic_matrix_scaled);
     }
 
-    _mapUndistortX = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
-    _mapUndistortY = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
-
     /* init the undistortion matrices */
-    cv::initUndistortRectifyMap(cv::cvarrToMat(_intrinsic_matrix_scaled), cv::cvarrToMat(_distortion_coeffs), cv::Mat(),
-                                cv::cvarrToMat(_intrinsic_matrix_scaled), cv::Size(currImgSize.width, currImgSize.height),
-                                CV_32FC1,cv::cvarrToMat(_mapUndistortX), cv::cvarrToMat(_mapUndistortY));
+    cv::initUndistortRectifyMap(_intrinsic_matrix_scaled, _distortion_coeffs, cv::Mat(),
+                                _intrinsic_matrix_scaled, currImgSize,
+                                CV_32FC1, _mapUndistortX, _mapUndistortY);
 
     _needInit = false;
     return true;
@@ -189,7 +149,7 @@ bool PinholeCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
 
 void PinholeCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & out){
 
-    CvSize inSize = cvSize(in.width(),in.height());
+    cv::Size inSize(in.width(), in.height());
 
     // check if reallocation required
     if ( inSize.width  != _oldImgSize.width ||
@@ -199,15 +159,15 @@ void PinholeCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & o
 
     cv::Mat outMat;
     cv::remap( toCvMat(const_cast<ImageOf<PixelRgb>&>(in)), outMat,
-               cv::cvarrToMat(_mapUndistortX), cv::cvarrToMat(_mapUndistortY),
+               _mapUndistortX, _mapUndistortY,
                cv::INTER_LINEAR );
     out=fromCvMat<PixelRgb>(outMat);
 
     // painting crosshair at calibration center
     if (_drawCenterCross){
         yarp::sig::PixelRgb pix = yarp::sig::PixelRgb(255,255,255);
-        yarp::sig::draw::addCrossHair(out, pix, (int)CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 2),
-                                            (int)CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 2),
+        yarp::sig::draw::addCrossHair(out, pix, (int)_intrinsic_matrix_scaled.at<float>(0, 2),
+                                            (int)_intrinsic_matrix_scaled.at<float>(1, 2),
                                             10);
     }
 
@@ -215,4 +175,3 @@ void PinholeCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & o
     _oldImgSize.width  = inSize.width;
     _oldImgSize.height = inSize.height;
 }
-

--- a/src/modules/camCalibWithPose/src/SphericalCalibTool.cpp
+++ b/src/modules/camCalibWithPose/src/SphericalCalibTool.cpp
@@ -17,10 +17,7 @@ using namespace yarp::sig;
 using namespace yarp::cv;
 
 SphericalCalibTool::SphericalCalibTool(){
-    _mapX = NULL;
-    _mapY = NULL;
-    _oldImgSize.width = -1;
-    _oldImgSize.height = -1;
+    _oldImgSize = cv::Size(-1, -1);
     _needInit = true;
 }
 
@@ -33,12 +30,8 @@ bool SphericalCalibTool::open(Searchable &config){
 }
 
 bool SphericalCalibTool::close(){
-    if (_mapX != NULL)
-        cvReleaseImage(&_mapX);
-    _mapX = NULL;
-    if (_mapY != NULL)
-        cvReleaseImage(&_mapY);
-    _mapY = NULL;
+    _mapX.release();
+    _mapY.release();
     return true;
 }
 
@@ -93,15 +86,7 @@ bool SphericalCalibTool::configure (Searchable &config){
 }
 
 
-bool SphericalCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
-
-     if (_mapX != NULL)
-        cvReleaseImage(&_mapX);
-    _mapX = NULL;
-    if (_mapY != NULL)
-        cvReleaseImage(&_mapY);
-    _mapY = NULL;
-
+bool SphericalCalibTool::init(cv::Size currImgSize, cv::Size calibImgSize){
     // Scale the intrinsics if required:
     // if current image size is not the same as the size for
     // which calibration parameters are specified we need to
@@ -122,8 +107,8 @@ bool SphericalCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
         _cy_scaled = _cy;
     }
 
-    _mapX = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
-    _mapY = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
+    _mapX.create(currImgSize, CV_32FC1);
+    _mapY.create(currImgSize, CV_32FC1);
 
 
 
@@ -131,7 +116,7 @@ bool SphericalCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
                        currImgSize.height, currImgSize.width,
                         _fx_scaled, _fy_scaled, _cx_scaled, _cy_scaled,
                         _k1, _k2, _p1, _p2,
-                        (float*)_mapX->imageData, (float*)_mapY->imageData))
+                        _mapX.ptr<float>(), _mapY.ptr<float>()))
         return false;
 
     _needInit = false;
@@ -140,7 +125,7 @@ bool SphericalCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
 
 void SphericalCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & out){
 
-    CvSize inSize = cvSize(in.width(),in.height());
+    cv::Size inSize(in.width(), in.height());
 
     // check if reallocation required
     if ( inSize.width  != _oldImgSize.width ||
@@ -152,7 +137,7 @@ void SphericalCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> &
 
     cv::Mat outMat=toCvMat(out);
     cv::remap( toCvMat(const_cast<ImageOf<PixelRgb>&>(in)), outMat,
-               cv::cvarrToMat(_mapX), cv::cvarrToMat(_mapY),
+               _mapX, _mapY,
                cv::INTER_LINEAR );
     out=fromCvMat<PixelRgb>(outMat);
 

--- a/src/modules/camCalibWithPose/src/main.cpp
+++ b/src/modules/camCalibWithPose/src/main.cpp
@@ -132,9 +132,6 @@
 #include <iCub/SphericalCalibTool.h>
 #include <iCub/CamCalibModule.h>
 
-// OpenCV
-#include <opencv2/core/core_c.h>
-
 using namespace std;
 using namespace yarp::os;
 using namespace yarp::sig;

--- a/src/modules/dualCamCalib/include/iCub/DualCamCalibModule.h
+++ b/src/modules/dualCamCalib/include/iCub/DualCamCalibModule.h
@@ -7,9 +7,6 @@
 #ifndef __DUALCAMCALIBMODULE__
 #define __DUALCAMCALIBMODULE__
 
-// opencv
-#include <opencv2/core/core_c.h>
-
 // yarp
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/RFModule.h>

--- a/src/modules/dualCamCalib/include/iCub/PinholeCalibTool.h
+++ b/src/modules/dualCamCalib/include/iCub/PinholeCalibTool.h
@@ -16,9 +16,8 @@
 #include <math.h>
 
 // opencv
-#include <opencv2/core/core_c.h>
-#include <opencv2/calib3d/calib3d_c.h>
 #include <opencv2/calib3d.hpp>
+#include <opencv2/core.hpp>
 
 // yarp
 //#include <yarp/sig/Image.h>
@@ -39,21 +38,21 @@ class PinholeCalibTool : public ICalibTool
 {
  private:
     
-    CvMat           *_intrinsic_matrix;
-    CvMat           *_intrinsic_matrix_scaled;
-    CvMat           *_distortion_coeffs;;
+    cv::Mat         _intrinsic_matrix;
+    cv::Mat         _intrinsic_matrix_scaled;
+    cv::Mat         _distortion_coeffs;
 
-    IplImage        *_mapUndistortX;
-    IplImage        *_mapUndistortY;
+    cv::Mat         _mapUndistortX;
+    cv::Mat         _mapUndistortY;
 
     bool _needInit;
 
-    CvSize          _calibImgSize;
-    CvSize          _oldImgSize;
+    cv::Size        _calibImgSize;
+    cv::Size        _oldImgSize;
 
     bool _drawCenterCross;
 
-    bool init(CvSize currImgSize, CvSize calibImgSize);
+    bool init(cv::Size currImgSize, cv::Size calibImgSize);
 
 public:
 

--- a/src/modules/dualCamCalib/include/iCub/SphericalCalibTool.h
+++ b/src/modules/dualCamCalib/include/iCub/SphericalCalibTool.h
@@ -15,7 +15,7 @@
 #include <yarp/os/Value.h>
 
 // opencv
-#include <opencv2/core/core_c.h>
+#include <opencv2/core.hpp>
 
 // iCub
 #include <iCub/ICalibTool.h>
@@ -29,8 +29,8 @@ class SphericalCalibTool : public ICalibTool
 {
 private:
 
-    IplImage        *_mapX;
-    IplImage        *_mapY;
+    cv::Mat         _mapX;
+    cv::Mat         _mapY;
 
     double          _fx, _fx_scaled;
     double          _fy, _fy_scaled;
@@ -43,12 +43,12 @@ private:
 
     bool _needInit;
 
-    CvSize          _calibImgSize;
-    CvSize          _oldImgSize;
+    cv::Size        _calibImgSize;
+    cv::Size        _oldImgSize;
 
     bool _drawCenterCross;
 
-    bool init(CvSize currImgSize, CvSize calibImgSize);
+    bool init(cv::Size currImgSize, cv::Size calibImgSize);
 
 public:
 

--- a/src/modules/dualCamCalib/src/PinholeCalibTool.cpp
+++ b/src/modules/dualCamCalib/src/PinholeCalibTool.cpp
@@ -14,13 +14,10 @@ using namespace yarp::sig;
 using namespace yarp::cv;
 
 PinholeCalibTool::PinholeCalibTool(){
-    _mapUndistortX = NULL;
-    _mapUndistortY = NULL;
-    _intrinsic_matrix = cvCreateMat(3,3, CV_32F);
-    _intrinsic_matrix_scaled = cvCreateMat(3,3, CV_32F);
-    _distortion_coeffs = cvCreateMat(1, 4, CV_32F);
-    _oldImgSize.width = -1;
-    _oldImgSize.height = -1;
+    _intrinsic_matrix = cv::Mat::eye(3, 3, CV_32F);
+    _intrinsic_matrix_scaled = cv::Mat::eye(3, 3, CV_32F);
+    _distortion_coeffs = cv::Mat::zeros(1, 4, CV_32F);
+    _oldImgSize = cv::Size(-1, -1);
     _needInit = true;
 }
 
@@ -29,15 +26,11 @@ PinholeCalibTool::~PinholeCalibTool(){
 }
 
 bool PinholeCalibTool::close(){
-    if (_mapUndistortX != NULL)
-        cvReleaseImage(&_mapUndistortX);
-    _mapUndistortX = NULL;
-    if (_mapUndistortY != NULL)
-        cvReleaseImage(&_mapUndistortY);
-    _mapUndistortY = NULL;
-    cvReleaseMat(&_intrinsic_matrix);
-    cvReleaseMat(&_intrinsic_matrix_scaled);
-    cvReleaseMat(&_distortion_coeffs);
+    _mapUndistortX.release();
+    _mapUndistortY.release();
+    _intrinsic_matrix.release();
+    _intrinsic_matrix_scaled.release();
+    _distortion_coeffs.release();
     return true;
 }
 
@@ -65,24 +58,24 @@ bool PinholeCalibTool::configure (Searchable &config){
                                     "Draw a cross at calibration center (int [0|1]).").asInt32()!=0;
 
 
-    CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 0) = (float)config.check("fx",
+    _intrinsic_matrix.at<float>(0, 0) = (float)config.check("fx",
                                                         Value(320.0),
                                                         "Focal length x (double)").asFloat64();
 
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 0, 1) = 0.0f;
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 0, 2) = (float)config.check("cx",
+    _intrinsic_matrix.at<float>(0, 1) = 0.0f;
+    _intrinsic_matrix.at<float>(0, 2) = (float)config.check("cx",
                                                         Value(160.0),
                                                         "Principal point x (double)").asFloat64();
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 1, 0) = 0.0f;
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 1, 1) = (float)config.check("fy",
+    _intrinsic_matrix.at<float>(1, 0) = 0.0f;
+    _intrinsic_matrix.at<float>(1, 1) = (float)config.check("fy",
                                                         Value(320.0),
                                                         "Focal length y (double)").asFloat64();
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 1, 2) = (float)config.check("cy",
+    _intrinsic_matrix.at<float>(1, 2) = (float)config.check("cy",
                                                         Value(120.0),
                                                         "Principal point y (double)").asFloat64();
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 2, 0) = 0.0f;
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 2, 1) = 0.0f;
-    CV_MAT_ELEM( *_intrinsic_matrix, float, 2, 2) = 1.0f;
+    _intrinsic_matrix.at<float>(2, 0) = 0.0f;
+    _intrinsic_matrix.at<float>(2, 1) = 0.0f;
+    _intrinsic_matrix.at<float>(2, 2) = 1.0f;
 
 
     //check to see if the value is read correctly without caring about the default values.
@@ -105,28 +98,19 @@ bool PinholeCalibTool::configure (Searchable &config){
     fprintf(stdout,"cy=%g\n",config.find("cy").asFloat64());
 
 
-    // copy to scaled matrix ;)
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 0);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 1);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 2);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 0);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 1);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 2);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 0);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 1);
-    CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 2);
+    _intrinsic_matrix.copyTo(_intrinsic_matrix_scaled);
 
      /* init the distortion coeffs */
-    CV_MAT_ELEM( *_distortion_coeffs, float, 0, 0) = (float)config.check("k1",
+    _distortion_coeffs.at<float>(0, 0) = (float)config.check("k1",
                                                         Value(0.0),
                                                         "Radial distortion 1(double)").asFloat64();
-    CV_MAT_ELEM( *_distortion_coeffs, float, 0, 1) = (float)config.check("k2",
+    _distortion_coeffs.at<float>(0, 1) = (float)config.check("k2",
                                                         Value(0.0),
                                                         "Radial distortion 2(double)").asFloat64();
-    CV_MAT_ELEM( *_distortion_coeffs, float, 0, 2) = (float)config.check("p1",
+    _distortion_coeffs.at<float>(0, 2) = (float)config.check("p1",
                                                         Value(0.0),
                                                         "Tangential distortion 1(double)").asFloat64();
-    CV_MAT_ELEM( *_distortion_coeffs, float, 0, 3) = (float)config.check("p2",
+    _distortion_coeffs.at<float>(0, 3) = (float)config.check("p2",
                                                         Value(0.0),
                                                         "Tangential distortion 2(double)").asFloat64();
     _needInit = true;
@@ -135,16 +119,7 @@ bool PinholeCalibTool::configure (Searchable &config){
 }
 
 
-bool PinholeCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
-
-    if (_mapUndistortX != NULL)
-        cvReleaseImage(&_mapUndistortX);
-    _mapUndistortX = NULL;
-    if (_mapUndistortY != NULL)
-        cvReleaseImage(&_mapUndistortY);
-    _mapUndistortY = NULL;
-
-
+bool PinholeCalibTool::init(cv::Size currImgSize, cv::Size calibImgSize){
     // Scale the intrinsics if required:
     // if current image size is not the same as the size for
     // which calibration parameters are specified we need to
@@ -153,42 +128,27 @@ bool PinholeCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
         currImgSize.height != calibImgSize.height){
         float scaleX = (float)currImgSize.width / (float)calibImgSize.width;
         float scaleY = (float)currImgSize.height / (float)calibImgSize.height;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 0) * scaleX;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 2) * scaleX;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 1) * scaleY;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 2) * scaleY;
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 2);
+        _intrinsic_matrix.copyTo(_intrinsic_matrix_scaled);
+        _intrinsic_matrix_scaled.at<float>(0, 0) *= scaleX;
+        _intrinsic_matrix_scaled.at<float>(0, 2) *= scaleX;
+        _intrinsic_matrix_scaled.at<float>(1, 1) *= scaleY;
+        _intrinsic_matrix_scaled.at<float>(1, 2) *= scaleY;
     }
     else{
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 0, 2);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 1, 2);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 0) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 0);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 1) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 1);
-        CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 2, 2) = CV_MAT_ELEM( *_intrinsic_matrix , float, 2, 2);
+        _intrinsic_matrix.copyTo(_intrinsic_matrix_scaled);
     }
     
-    _mapUndistortX = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
-    _mapUndistortY = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
-
     /* init the undistortion matrices */
-    cv::initUndistortRectifyMap(cv::cvarrToMat(_intrinsic_matrix_scaled), cv::cvarrToMat(_distortion_coeffs), cv::Mat(),
-                                cv::cvarrToMat(_intrinsic_matrix_scaled), cv::Size(currImgSize.width, currImgSize.height),
-                                CV_32FC1,cv::cvarrToMat(_mapUndistortX), cv::cvarrToMat(_mapUndistortY));
+    cv::initUndistortRectifyMap(_intrinsic_matrix_scaled, _distortion_coeffs, cv::Mat(),
+                                _intrinsic_matrix_scaled, currImgSize,
+                                CV_32FC1, _mapUndistortX, _mapUndistortY);
     _needInit = false;
     return true;
 }
 
 void PinholeCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & out){
 
-    CvSize inSize = cvSize(in.width(),in.height());
+    cv::Size inSize(in.width(), in.height());
 
     // check if reallocation required
     if ( inSize.width  != _oldImgSize.width || 
@@ -198,15 +158,15 @@ void PinholeCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & o
 
     cv::Mat outMat;
     cv::remap( toCvMat(const_cast<ImageOf<PixelRgb>&>(in)), outMat,
-             cv::cvarrToMat(_mapUndistortX), cv::cvarrToMat(_mapUndistortY),
+             _mapUndistortX, _mapUndistortY,
              cv::INTER_LINEAR );
     out=fromCvMat<PixelRgb>(outMat);
 
     // painting crosshair at calibration center
     if (_drawCenterCross){
         yarp::sig::PixelRgb pix = yarp::sig::PixelRgb(255,255,255);
-        yarp::sig::draw::addCrossHair(out, pix, (int)CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 0, 2),
-                                            (int)CV_MAT_ELEM( *_intrinsic_matrix_scaled , float, 1, 2),
+        yarp::sig::draw::addCrossHair(out, pix, (int)_intrinsic_matrix_scaled.at<float>(0, 2),
+                                            (int)_intrinsic_matrix_scaled.at<float>(1, 2),
                                             10);
     }
 
@@ -214,4 +174,3 @@ void PinholeCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & o
     _oldImgSize.width  = inSize.width;
     _oldImgSize.height = inSize.height;
 }
-

--- a/src/modules/dualCamCalib/src/SphericalCalibTool.cpp
+++ b/src/modules/dualCamCalib/src/SphericalCalibTool.cpp
@@ -17,10 +17,7 @@ using namespace yarp::sig;
 using namespace yarp::cv;
 
 SphericalCalibTool::SphericalCalibTool(){
-    _mapX = NULL;
-    _mapY = NULL;
-    _oldImgSize.width = -1;
-    _oldImgSize.height = -1;
+    _oldImgSize = cv::Size(-1, -1);
     _needInit = true;
 }
 
@@ -33,12 +30,8 @@ bool SphericalCalibTool::open(Searchable &config){
 }
 
 bool SphericalCalibTool::close(){
-    if (_mapX != NULL)
-        cvReleaseImage(&_mapX);
-    _mapX = NULL;
-    if (_mapY != NULL)
-        cvReleaseImage(&_mapY);
-    _mapY = NULL;
+    _mapX.release();
+    _mapY.release();
     return true;
 }
 
@@ -93,15 +86,7 @@ bool SphericalCalibTool::configure (Searchable &config){
 }
 
 
-bool SphericalCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
-
-     if (_mapX != NULL)
-        cvReleaseImage(&_mapX);
-    _mapX = NULL;
-    if (_mapY != NULL)
-        cvReleaseImage(&_mapY);
-    _mapY = NULL;
-
+bool SphericalCalibTool::init(cv::Size currImgSize, cv::Size calibImgSize){
     // Scale the intrinsics if required:
     // if current image size is not the same as the size for
     // which calibration parameters are specified we need to
@@ -122,8 +107,8 @@ bool SphericalCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
         _cy_scaled = _cy;
     }
 
-    _mapX = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
-    _mapY = cvCreateImage(currImgSize, IPL_DEPTH_32F, 1);
+    _mapX.create(currImgSize, CV_32FC1);
+    _mapY.create(currImgSize, CV_32FC1);
 
     
 
@@ -131,7 +116,7 @@ bool SphericalCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
                        currImgSize.height, currImgSize.width,
                         _fx_scaled, _fy_scaled, _cx_scaled, _cy_scaled, 
                         _k1, _k2, _p1, _p2, 
-                        (float*)_mapX->imageData, (float*)_mapY->imageData))
+                        _mapX.ptr<float>(), _mapY.ptr<float>()))
         return false;
 
     _needInit = false;
@@ -140,7 +125,7 @@ bool SphericalCalibTool::init(CvSize currImgSize, CvSize calibImgSize){
 
 void SphericalCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> & out){
 
-    CvSize inSize = cvSize(in.width(),in.height());
+    cv::Size inSize(in.width(), in.height());
 
     // check if reallocation required
     if ( inSize.width  != _oldImgSize.width || 
@@ -152,7 +137,7 @@ void SphericalCalibTool::apply(const ImageOf<PixelRgb> & in, ImageOf<PixelRgb> &
 
     cv::Mat outMat=toCvMat(out);
     cv::remap( toCvMat(const_cast<ImageOf<PixelRgb>&>(in)), outMat,
-               cv::cvarrToMat(_mapX), cv::cvarrToMat(_mapY),
+               _mapX, _mapY,
                cv::INTER_LINEAR );
     out=fromCvMat<PixelRgb>(outMat);
 

--- a/src/modules/dualCamCalib/src/main.cpp
+++ b/src/modules/dualCamCalib/src/main.cpp
@@ -16,8 +16,6 @@
 #include <iCub/DualCamCalibModule.h>
 
 // OpenCV
-#include <opencv2/core/core_c.h>
-
 using namespace std;
 using namespace yarp::os;
 using namespace yarp::sig;

--- a/src/modules/motionCUT/main.cpp
+++ b/src/modules/motionCUT/main.cpp
@@ -222,7 +222,7 @@ public:
                         nodesPrev[cnt++]=Point2f((float)x,(float)y);
 
                 // convert to gray-scale
-                cvtColor(toCvMat(*pImgBgrIn),toCvMat(imgMonoPrev),CV_BGR2GRAY);
+                cvtColor(toCvMat(*pImgBgrIn),toCvMat(imgMonoPrev),cv::COLOR_BGR2GRAY);
 
                 if (verbosity)
                 {
@@ -236,7 +236,7 @@ public:
             }
 
             // convert the input image to gray-scale
-            cvtColor(toCvMat(*pImgBgrIn),toCvMat(imgMonoIn),CV_BGR2GRAY);
+            cvtColor(toCvMat(*pImgBgrIn),toCvMat(imgMonoIn),cv::COLOR_BGR2GRAY);
 
             // copy input image into output image
             ImageOf<PixelBgr> imgBgrOut=*pImgBgrIn;

--- a/src/modules/templatePFTracker/include/iCub/particleFilter.h
+++ b/src/modules/templatePFTracker/include/iCub/particleFilter.h
@@ -40,8 +40,10 @@
 #include <iostream>
 #include <iomanip>
 #include <deque>
-#include <opencv2/core/core_c.h>
-#include <opencv2/imgproc/imgproc_c.h>
+#include <vector>
+
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
 
 /* default number of particles */
 #define PARTICLES 1000
@@ -121,24 +123,21 @@ private:
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelBgr> >  imageOut;
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelMono> > imageOutBlob;
 
-    CvPoint minloc, maxloc;
-    double  minval, maxval;
-
     bool init;
     bool getImage, getTemplate, gotTemplate, sendTarget;
     yarp::sig::ImageOf<yarp::sig::PixelRgb> *iCubImage;
-    
-    IplImage *temp, *res_left, *res_right, *res;
+
+    cv::Mat temp;
     yarp::sig::ImageOf<yarp::sig::PixelRgb> *tpl;
 
-    IplImage* frame, *frame_blob;
-    int width, height, tpl_width, tpl_height, res_width, res_height;
-    double scale;
-    IplImage* img_hsv;
+    cv::Mat frame;
+    cv::Mat frame_blob;
+    int width, height, tpl_width, tpl_height;
+    cv::Mat img_hsv;
     gsl_rng* rng;
     bool firstFrame;
-    CvScalar color;
-    CvRect** regions;
+    cv::Scalar color;
+    std::vector<cv::Rect> regions;
     int num_objects;
     float s;
     int i, j, k, w, h, x, y;
@@ -154,45 +153,28 @@ private:
     TemplateStruct              bestTempl;
     yarp::os::Stamp             targetStamp;
 
-    typedef struct params 
-    {
-        CvPoint loc1[MAX_OBJECTS];
-        CvPoint loc2[MAX_OBJECTS];
-        IplImage* objects[MAX_OBJECTS];
-        char* win_name;
-        IplImage* orig_img;
-        IplImage* cur_img;
-        int n;
-    } params;
-    
-    int total;
-
     histogram** ref_histos;
     particle* particles, * new_particles;    
 
     void free_histos( histogram** histo, int n );
-    void free_regions( CvRect** regions, int n);
 
-    histogram** compute_ref_histos( IplImage* img, CvRect* rect, int n );
-    histogram* calc_histogram( IplImage** imgs, int n );
+    histogram** compute_ref_histos( const cv::Mat& img, const std::vector<cv::Rect>& rects );
+    histogram* calc_histogram( const cv::Mat* imgs, int n );
     particle transition( const particle &p, int w, int h, gsl_rng* rng );
-    particle* init_distribution( CvRect* regions, histogram** histos, int n, int p);
-    IplImage* bgr2hsv( IplImage* bgr );
-    float likelihood( IplImage* img, int r, int c, int w, int h, histogram* ref_histo );
+    particle* init_distribution( const std::vector<cv::Rect>& regions, histogram** histos, int n, int p);
+    cv::Mat bgr2hsv( const cv::Mat& bgr );
+    float likelihood( const cv::Mat& img, int r, int c, int w, int h, histogram* ref_histo );
     void normalize_weights( particle* particles, int n );
     float histo_dist_sq( histogram* h1, histogram* h2 );
     int histo_bin( float h, float s, float v );
-    float pixval32f(IplImage* img, int r, int c);
-    void setpix32f(IplImage* img, int r, int c, float val);
-    int get_regions( IplImage* frame, CvRect** regions );
-    int get_regionsImage( IplImage* frame, CvRect** regions );
+    int get_regionsImage( const cv::Mat& frame, std::vector<cv::Rect>& regions );
     particle* resample( particle* particles, int n );
-    void display_particle( IplImage* img, const particle &p, CvScalar color, yarp::sig::Vector& target );
-    void display_particleBlob( IplImage* img, const particle &p, yarp::sig::Vector& target );
-    void trace_template( IplImage* img, const particle &p );
+    void display_particle( cv::Mat& img, const particle &p, const cv::Scalar& color, yarp::sig::Vector& target );
+    void display_particleBlob( cv::Mat& img, const particle &p, yarp::sig::Vector& target );
+    void trace_template( const cv::Mat& img, const particle &p );
     void normalize_histogram( histogram* histo );
     void initAll();
-    void runAll(IplImage *img);
+    void runAll(cv::Mat& img);
    
 
 public:
@@ -266,4 +248,3 @@ public:
 };
 #endif
 //empty line to make gcc happy
-

--- a/src/modules/templatePFTracker/src/particleFilter.cpp
+++ b/src/modules/templatePFTracker/src/particleFilter.cpp
@@ -19,6 +19,10 @@
  * Public License for more details
  */
 
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
 #include <utility>
 #include <yarp/cv/Cv.h>
 #include <iCub/particleFilter.h>
@@ -45,19 +49,10 @@ int particle_cmp( const void* p1, const void* p2 )
 PARTICLEThread::~PARTICLEThread() 
 {
     cout << "deleting dynamic objects" << endl;
-    if(regions!=NULL)
-        free_regions ( regions, num_objects );
-
     gsl_rng_free ( rng );
     free_histos ( ref_histos, num_objects);  
     if(particles != NULL)
         free ( particles);
-
-    if (temp)
-    {
-        cout << "releasing temp" << endl;        
-        cvReleaseImage(&temp);
-    }
     cout << "finished particle thread" << endl;
 }
 /**********************************************************/
@@ -65,7 +60,6 @@ PARTICLEThread::PARTICLEThread()
 {
     firstFrame = true;
     num_objects = 0;
-    regions = (CvRect **) malloc(sizeof(CvRect*));
     num_particles = PARTICLES;    /* number of particles */
     rng = gsl_rng_alloc( gsl_rng_mt19937 );
     gsl_rng_set( rng, (unsigned long)time(NULL) );
@@ -76,10 +70,9 @@ PARTICLEThread::PARTICLEThread()
     getImage = false;
     particles = NULL;
     new_particles = NULL;
-    temp = NULL;
     ref_histos = NULL;
     tpl = NULL;
-    total = 0;
+    average = 0.0f;
 }
 /**********************************************************/
 void PARTICLEThread::setName(string module) 
@@ -132,24 +125,25 @@ void PARTICLEThread::run()
                 imageIn.getEnvelope(targetTemp);
             }
  
-            frame = cvCreateImage(cvSize(width,height),IPL_DEPTH_8U, 3 );           
-            cv::cvtColor(toCvMat(*iCubImage), cv::cvarrToMat(frame), CV_RGB2BGR);
-            frame_blob = cvCreateImage(cvSize(width,height),IPL_DEPTH_8U, 1 );
+            cv::cvtColor(toCvMat(*iCubImage), frame, cv::COLOR_RGB2BGR);
+            frame_blob = cv::Mat::zeros(height, width, CV_8UC1);
 
             if ( tpl != NULL )
             {
                 cv::Mat tplMat=toCvMat(*tpl);
                 tpl_width  = tpl->width();
                 tpl_height = tpl->height();
-                res_width  = width - tpl_width + 1;
-                res_height = height - tpl_height + 1;
-                cvReleaseImage(&temp);
-                temp = cvCreateImage(cvSize(tplMat.size().width,tplMat.size().height),tplMat.depth(),tplMat.channels() );
-                cv::cvtColor(tplMat, cv::cvarrToMat(temp), CV_RGB2BGR);
+                cv::cvtColor(tplMat, temp, cv::COLOR_RGB2BGR);
                 gotTemplate = true;
                 firstFrame = true;
-                if (num_objects>0)
-                    free(*regions);
+                free_histos(ref_histos, num_objects);
+                ref_histos = NULL;
+                if (particles != NULL)
+                {
+                    free(particles);
+                    particles = NULL;
+                }
+                regions.clear();
                 num_objects = 0;
                 delete tpl;
                 tpl = NULL;
@@ -176,18 +170,16 @@ void PARTICLEThread::run()
             {
                 ImageOf<PixelBgr> &img = imageOut.prepare();
                 img.resize(width,height);
-                cv::cvarrToMat(frame).copyTo(toCvMat(img));
+                frame.copyTo(toCvMat(img));
                 imageOut.write();
             }
             if (imageOutBlob.getOutputCount()>0)
             {
                 ImageOf<PixelMono> &imgBlob = imageOutBlob.prepare();
                 imgBlob.resize(width,height);
-                cv::cvarrToMat(frame_blob).copyTo(toCvMat(imgBlob));
+                frame_blob.copyTo(toCvMat(imgBlob));
                 imageOutBlob.write();
             }
-            cvReleaseImage(&frame);
-            cvReleaseImage(&frame_blob);
         }
     } //while
 }
@@ -225,28 +217,29 @@ void PARTICLEThread::initAll()
     init = false;
 }
 /**********************************************************/
-void PARTICLEThread::runAll(IplImage *img)
+void PARTICLEThread::runAll(cv::Mat& img)
 {
     img_hsv = bgr2hsv( img );
     if (firstFrame)
     {
-        w = img->width;
-        h = img->height;
+        w = img.cols;
+        h = img.rows;
             
-        while( num_objects == 0 )
+        num_objects = get_regionsImage(img, regions);
+        if (num_objects == 0)
         {
-            num_objects = get_regionsImage( img, regions );
-            if( num_objects == 0 )
-                fprintf( stderr, "Problem! seg has issues\n" );
-        }   
+            fprintf(stderr, "Unable to initialize the tracker: the template is empty or larger than the input image\n");
+            gotTemplate = false;
+            return;
+        }
         if (ref_histos!=NULL)
             free_histos ( ref_histos, num_objects);        
 
-        ref_histos = compute_ref_histos( img_hsv, *regions, num_objects );
+        ref_histos = compute_ref_histos( img_hsv, regions );
         if (particles != NULL)
             free (particles);
 
-        particles= init_distribution( *regions, ref_histos, num_objects, num_particles );
+        particles= init_distribution( regions, ref_histos, num_objects, num_particles );
     }
     else
     {
@@ -255,10 +248,10 @@ void PARTICLEThread::runAll(IplImage *img)
         {
             particles[j] = transition( particles[j], w, h, rng );
             s = particles[j].s;
-            particles[j].w = likelihood( img_hsv, cvRound(particles[j].y),
-            cvRound( particles[j].x ),
-            cvRound( particles[j].width * s ),
-            cvRound( particles[j].height * s ),
+            particles[j].w = likelihood( img_hsv, static_cast<int>(std::lround(particles[j].y)),
+            static_cast<int>(std::lround( particles[j].x )),
+            static_cast<int>(std::lround( particles[j].width * s )),
+            static_cast<int>(std::lround( particles[j].height * s )),
             particles[j].histo );
         }
         // normalize weights and resample a set of unweighted particles
@@ -270,6 +263,7 @@ void PARTICLEThread::runAll(IplImage *img)
     qsort( particles, num_particles, sizeof( PARTICLEThread::particle ), &particle_cmp );
 
     averageMutex.lock();
+    average = 0.0f;
     for( j = 0; j < num_particles; j++ ) 
         average += particles[j].w;
         
@@ -277,7 +271,7 @@ void PARTICLEThread::runAll(IplImage *img)
     averageMutex.unlock();
 
     //display most likely particle ------------------
-    color = cvScalar(255,0,0);
+    color = cv::Scalar(255,0,0);
     targetMutex.lock();
     targetTemp.clear();
     //if (imageOut.getOutputCount()>0)
@@ -287,8 +281,6 @@ void PARTICLEThread::runAll(IplImage *img)
         display_particleBlob( frame_blob, particles[0], targetTemp );
     targetMutex.unlock();
     trace_template( frame, particles[0] );
-
-    cvReleaseImage(&img_hsv);
 }
 /**********************************************************/
 void PARTICLEThread::setTemplate(ImageOf<PixelRgb> *_tpl)
@@ -313,64 +305,41 @@ float PARTICLEThread::getAverage()
     return tmpAv;
 }
 /**********************************************************/
-int PARTICLEThread::get_regionsImage( IplImage* frame, CvRect** regions ) 
+int PARTICLEThread::get_regionsImage( const cv::Mat& frame, std::vector<cv::Rect>& regions )
 {
     firstFrame = false;
-    params p;
-    CvRect* r;
-    int i; //x1, y1, x2, y2, w, h;
+    if (temp.empty() || temp.cols > frame.cols || temp.rows > frame.rows)
+        return 0;
 
-    p.orig_img = cvCloneImage( frame );
-    p.cur_img = NULL;
-    p.n = 0;
+    cv::Mat result;
+    cv::matchTemplate(frame, temp, result, cv::TM_SQDIFF);
 
-    res = cvCreateImage( cvSize( res_width, res_height ), IPL_DEPTH_32F, 1 );
+    cv::Point minloc;
+    cv::minMaxLoc(result, nullptr, nullptr, &minloc, nullptr);
 
-    cvMatchTemplate( frame, temp, res, CV_TM_SQDIFF );
-    cvMinMaxLoc( res, &minval, &maxval, &minloc, &maxloc, 0 );
-
-    cvReleaseImage( &(p.orig_img) );    //what was the purpose of this image?
-    cvReleaseImage( &res );
-    if( p.cur_img )
-        cvReleaseImage( &(p.cur_img) );
-    p.n = 1;
-    // extract regions defined by user; store as an array of rectangles ----------
-    
-    r = (CvRect*) malloc ( p.n * sizeof( CvRect ) );
-
-    for( i = 0; i < p.n; i++ )
-        r[i] = cvRect( minloc.x, minloc.y, tpl_width, tpl_height );
-        
-    *regions = r;
-    
-    return p.n;
+    regions.clear();
+    regions.emplace_back(minloc.x, minloc.y, tpl_width, tpl_height);
+    return static_cast<int>(regions.size());
 }
 /**********************************************************/
-PARTICLEThread::histogram** PARTICLEThread::compute_ref_histos( IplImage* frame, CvRect* regions, int n )
+PARTICLEThread::histogram** PARTICLEThread::compute_ref_histos(const cv::Mat& frame,
+                                                               const std::vector<cv::Rect>& regions)
 {
-    histogram** histos = (histogram**) malloc( n * sizeof( histogram* ) );
-    IplImage* tmp;
-    int i;
+    histogram** histos = (histogram**) malloc(regions.size() * sizeof(histogram*));
 
     // extract each region from frame and compute its histogram 
-    for( i = 0; i < n; i++ )
+    for(size_t i = 0; i < regions.size(); i++)
     {
-        cvSetImageROI( frame, regions[i]);
-        tmp = cvCreateImage( cvGetSize(frame), IPL_DEPTH_32F, 3 );
-        cvCopy( frame, tmp, NULL );
-        cvResetImageROI( frame );
+        cv::Mat tmp = frame(regions[i]).clone();
         histos[i] = calc_histogram( &tmp, 1 );
         normalize_histogram( histos[i] );
-        cvReleaseImage( &tmp );
     }
     return histos;
 }
 /**********************************************************/
-PARTICLEThread::histogram* PARTICLEThread::calc_histogram( IplImage** imgs, int n ) 
+PARTICLEThread::histogram* PARTICLEThread::calc_histogram(const cv::Mat* imgs, int n)
 {
-    IplImage* img;
     histogram* histo;
-    IplImage* h, * s, * v;
     float* hist;
     int i, r, c, bin;
     histo = (histogram*) malloc( sizeof(histogram) );
@@ -379,43 +348,27 @@ PARTICLEThread::histogram* PARTICLEThread::calc_histogram( IplImage** imgs, int 
     memset( hist, 0, histo->n * sizeof(float) );
     for( i = 0; i < n; i++ )
     {
-        // extract individual HSV planes from image 
-        img = imgs[i];
-        h = cvCreateImage( cvGetSize(img), IPL_DEPTH_32F, 1 );
-        s = cvCreateImage( cvGetSize(img), IPL_DEPTH_32F, 1 );
-        v = cvCreateImage( cvGetSize(img), IPL_DEPTH_32F, 1 );
-        cvSplit( img, h, s, v, NULL );
-
         // increment appropriate histogram bin for each pixel 
-        for( r = 0; r < img->height; r++ )
-            for( c = 0; c < img->width; c++ )
+        for( r = 0; r < imgs[i].rows; r++ )
+            for( c = 0; c < imgs[i].cols; c++ )
             {
-                bin = histo_bin( pixval32f( h, r, c ),
-                pixval32f( s, r, c ),
-                pixval32f( v, r, c ) );
+                const cv::Vec3f& pixel = imgs[i].at<cv::Vec3f>(r, c);
+                bin = histo_bin(pixel[0], pixel[1], pixel[2]);
                 hist[bin] += 1;
             }
-        cvReleaseImage( &h );
-        cvReleaseImage( &s );
-        cvReleaseImage( &v );
     }
     return histo;
 }
 /**********************************************************/
 void PARTICLEThread::free_histos( PARTICLEThread::histogram** histo, int n) 
 {
+    if (histo == NULL)
+        return;
+
     for (int i = 0; i < n; i++)    
         free (histo[i]);
 
     free(histo);
-}
-/**********************************************************/
-void PARTICLEThread::free_regions( CvRect** regions, int n) 
-{
-    for (int i = 0; i < n; i++)    
-        free (regions[i]);
-
-   free(regions);
 }
 /**********************************************************/
 void PARTICLEThread::normalize_histogram( PARTICLEThread::histogram* histo ) 
@@ -440,17 +393,20 @@ int PARTICLEThread::histo_bin( float h, float s, float v )
     int hd, sd, vd;
 
     // if S or V is less than its threshold, return a "colorless" bin 
-    vd = MIN( (int)(v * NV / V_MAX), NV-1 );
+    vd = std::min( (int)(v * NV / V_MAX), NV-1 );
     if( s < S_THRESH  ||  v < V_THRESH )
         return NH * NS + vd;
 
     // otherwise determine "colorful" bin 
-    hd = MIN( (int)(h * NH / H_MAX), NH-1 );
-    sd = MIN( (int)(s * NS / S_MAX), NS-1 );
+    hd = std::min( (int)(h * NH / H_MAX), NH-1 );
+    sd = std::min( (int)(s * NS / S_MAX), NS-1 );
     return sd * NH + hd;
 }
 /**********************************************************/
-PARTICLEThread::particle* PARTICLEThread::init_distribution( CvRect* regions, histogram** histos, int n, int p) 
+PARTICLEThread::particle* PARTICLEThread::init_distribution(const std::vector<cv::Rect>& regions,
+                                                            histogram** histos,
+                                                            int n,
+                                                            int p)
 {
     particle* particles;
     int np;
@@ -505,13 +461,13 @@ PARTICLEThread::particle PARTICLEThread::transition( const PARTICLEThread::parti
     // sample new state using second-order autoregressive dynamics 
     x = pfot_A1 * ( p.x - p.x0 ) + pfot_A2 * ( p.xp - p.x0 ) +
     pfot_B0 * (float)(gsl_ran_gaussian( rng, TRANS_X_STD )) + p.x0;
-    pn.x = MAX( 0.0f, MIN( (float)w - 1.0f, x ) );
+    pn.x = std::max( 0.0f, std::min( (float)w - 1.0f, x ) );
     y = pfot_A1 * ( p.y - p.y0 ) + pfot_A2 * ( p.yp - p.y0 ) +
     pfot_B0 * (float)(gsl_ran_gaussian( rng, TRANS_Y_STD )) + p.y0;
-    pn.y = MAX( 0.0f, MIN( (float)h - 1.0f, y ) );
+    pn.y = std::max( 0.0f, std::min( (float)h - 1.0f, y ) );
     s = pfot_A1 * ( p.s - 1.0f ) + pfot_A2 * ( p.sp - 1.0f ) +
     pfot_B0 * (float)(gsl_ran_gaussian( rng, TRANS_S_STD )) + 1.0f;
-    pn.s = MAX( 0.1f, s );
+    pn.s = std::max( 0.1f, s );
 
     pn.xp = p.x;
     pn.yp = p.y;
@@ -526,19 +482,19 @@ PARTICLEThread::particle PARTICLEThread::transition( const PARTICLEThread::parti
     return pn;
 }
 /**********************************************************/
-float PARTICLEThread::likelihood( IplImage* img, int r, int c, int w, int h, histogram* ref_histo ) 
+float PARTICLEThread::likelihood(const cv::Mat& img, int r, int c, int w, int h, histogram* ref_histo)
 {
-    IplImage* tmp;
     histogram* histo;
     float d_sq;
 
     // extract region around (r,c) and compute and normalize its histogram 
-    cvSetImageROI( img, cvRect( c - w / 2, r - h / 2, w, h ) );
-    tmp = cvCreateImage( cvGetSize(img), IPL_DEPTH_32F, 3 );
-    cvCopy( img, tmp, NULL );
-    cvResetImageROI( img );
+    cv::Rect region(c - w / 2, r - h / 2, w, h);
+    region &= cv::Rect(0, 0, img.cols, img.rows);
+    if (region.empty())
+        return 0.0f;
+
+    cv::Mat tmp = img(region).clone();
     histo = calc_histogram( &tmp, 1 );
-    cvReleaseImage( &tmp );
     normalize_histogram( histo );
 
     // compute likelihood as e^{\lambda D^2(h, h^*)} 
@@ -579,6 +535,15 @@ void PARTICLEThread::normalize_weights( particle* particles, int n )
 
     for( i = 0; i < n; i++ )
         sum += particles[i].w;
+
+    if (sum <= 0.0f)
+    {
+        const float uniform_weight = 1.0f / n;
+        for (i = 0; i < n; i++)
+            particles[i].w = uniform_weight;
+        return;
+    }
+
     for( i = 0; i < n; i++ )
         particles[i].w /= sum;
 }
@@ -594,7 +559,7 @@ PARTICLEThread::particle* PARTICLEThread::resample( particle* particles, int n )
 
     for( i = 0; i < n; i++ ) 
     {
-        np = cvRound( particles[i].w * n );
+        np = static_cast<int>(std::lround( particles[i].w * n ));
         for( j = 0; j < np; j++ ) 
         {
             _new_particles[k++] = particles[i];
@@ -609,19 +574,22 @@ PARTICLEThread::particle* PARTICLEThread::resample( particle* particles, int n )
     return _new_particles;
 }
 /**********************************************************/
-void PARTICLEThread::display_particle( IplImage* img, const PARTICLEThread::particle &p, CvScalar color, Vector& target ) 
+void PARTICLEThread::display_particle(cv::Mat& img,
+                                      const PARTICLEThread::particle &p,
+                                      const cv::Scalar& color,
+                                      Vector& target)
 {
     int x0, y0, x1, y1;
-    x0 = cvRound( p.x - 0.5 * p.s * p.width );
-    y0 = cvRound( p.y - 0.5 * p.s * p.height );
-    x1 = x0 + cvRound( p.s * p.width );
-    y1 = y0 + cvRound( p.s * p.height );
+    x0 = static_cast<int>(std::lround( p.x - 0.5 * p.s * p.width ));
+    y0 = static_cast<int>(std::lround( p.y - 0.5 * p.s * p.height ));
+    x1 = x0 + static_cast<int>(std::lround( p.s * p.width ));
+    y1 = y0 + static_cast<int>(std::lround( p.s * p.height ));
 
-    cvRectangle( img, cvPoint( x0, y0 ), cvPoint( x1, y1 ), color, 1, 8, 0 );
+    cv::rectangle(img, cv::Point(x0, y0), cv::Point(x1, y1), color, 1, cv::LINE_8);
     
-    cvCircle (img, cvPoint((x0+x1)/2, (y0+y1)/2), 3, cvScalar(255,0 ,0),1);
-    cvCircle (img, cvPoint( x0, y0), 3, cvScalar(0, 255 ,0),1);
-    cvCircle (img, cvPoint( x1, y1), 3, cvScalar(0, 255 ,0),1);
+    cv::circle(img, cv::Point((x0+x1)/2, (y0+y1)/2), 3, cv::Scalar(255,0,0), 1);
+    cv::circle(img, cv::Point(x0, y0), 3, cv::Scalar(0,255,0), 1);
+    cv::circle(img, cv::Point(x1, y1), 3, cv::Scalar(0,255,0), 1);
 
     target.push_back((x0+x1)/2);
     target.push_back((y0+y1)/2);
@@ -631,51 +599,45 @@ void PARTICLEThread::display_particle( IplImage* img, const PARTICLEThread::part
     target.push_back(y1);
 }
 /**********************************************************/
-void PARTICLEThread::display_particleBlob( IplImage* img, const PARTICLEThread::particle &p, Vector& target ) 
+void PARTICLEThread::display_particleBlob(cv::Mat& img,
+                                          const PARTICLEThread::particle &p,
+                                          Vector& target)
 {
     int x0, y0, x1, y1;
-    x0 = cvRound( p.x - 0.5 * p.s * p.width );
-    y0 = cvRound( p.y - 0.5 * p.s * p.height );
-    x1 = x0 + cvRound( p.s * p.width );
-    y1 = y0 + cvRound( p.s * p.height );
+    x0 = static_cast<int>(std::lround( p.x - 0.5 * p.s * p.width ));
+    y0 = static_cast<int>(std::lround( p.y - 0.5 * p.s * p.height ));
+    x1 = x0 + static_cast<int>(std::lround( p.s * p.width ));
+    y1 = y0 + static_cast<int>(std::lround( p.s * p.height ));
 
-    int step       = img->widthStep/sizeof(uchar);
-    uchar* data    = (uchar *)img->imageData;
-    
-    for (int i=0; i<img->height; i++)
-    {
-        for (int j=0; j<img->width; j++)
-        {   
-            data[i*step+j] = 0;
-        }
-    }
-    cvRectangle(img, cvPoint(x0,y0), cvPoint(x1,y1), cvScalar(255,255, 255), CV_FILLED);
+    img.setTo(cv::Scalar(0));
+    cv::rectangle(img, cv::Point(x0, y0), cv::Point(x1, y1), cv::Scalar(255), cv::FILLED);
 }
 /**********************************************************/
-void PARTICLEThread::trace_template( IplImage* img, const particle &p )
+void PARTICLEThread::trace_template(const cv::Mat& img, const particle &p)
 {
     if (p.w>TEMP_LIST_PARTICLE_THRES_HIGH)
     {
-        //create the template image
-        TemplateStruct t;
-        t.w=p.w;
-        t.templ=new ImageOf<PixelRgb>;
-        t.templ->resize(cvRound(p.s*p.width),cvRound(p.s*p.height));
-
-        cv::Mat imgMat(cv::cvarrToMat(img),cv::Rect(cvRound(p.x-0.5*p.s*p.width),
-                                                    cvRound(p.y-0.5*p.s*p.height),
-                                                    cvRound(p.s*p.width),
-                                                    cvRound(p.s*p.height)));
-
-        cv::cvtColor(imgMat,toCvMat(*t.templ),CV_BGR2RGB);
-
-        cvResetImageROI(img);
-
-        tempList.push_front(t);
-        if (tempList.size()>TEMP_LIST_SIZE)
+        cv::Rect region(static_cast<int>(std::lround(p.x - 0.5 * p.s * p.width)),
+                        static_cast<int>(std::lround(p.y - 0.5 * p.s * p.height)),
+                        static_cast<int>(std::lround(p.s * p.width)),
+                        static_cast<int>(std::lround(p.s * p.height)));
+        region &= cv::Rect(0, 0, img.cols, img.rows);
+        if (!region.empty())
         {
-            delete tempList.back().templ;
-            tempList.pop_back();
+            //create the template image
+            TemplateStruct t;
+            t.w=p.w;
+            t.templ=new ImageOf<PixelRgb>;
+            t.templ->resize(region.width, region.height);
+
+            cv::cvtColor(img(region), toCvMat(*t.templ), cv::COLOR_BGR2RGB);
+
+            tempList.push_front(t);
+            if (tempList.size()>TEMP_LIST_SIZE)
+            {
+                delete tempList.back().templ;
+                tempList.pop_back();
+            }
         }
     }
     //keep in check the best template
@@ -709,20 +671,13 @@ void PARTICLEThread::trace_template( IplImage* img, const particle &p )
     }
 }
 /**********************************************************/
-float PARTICLEThread::pixval32f(IplImage* img, int r, int c) 
+cv::Mat PARTICLEThread::bgr2hsv(const cv::Mat& bgr)
 {
-    return ( (float*)(img->imageData + img->widthStep*r) )[c];
-}
-/**********************************************************/
-IplImage* PARTICLEThread::bgr2hsv( IplImage* bgr ) 
-{
-    IplImage* bgr32f, * hsv;
+    cv::Mat bgr32f;
+    cv::Mat hsv;
 
-    bgr32f = cvCreateImage( cvGetSize(bgr), IPL_DEPTH_32F, 3 );
-    hsv = cvCreateImage( cvGetSize(bgr), IPL_DEPTH_32F, 3 );
-    cvConvertScale( bgr, bgr32f, 1.0 / 255.0, 0 );
-    cvCvtColor( bgr32f, hsv, CV_BGR2HSV );
-    cvReleaseImage( &bgr32f );
+    bgr.convertTo(bgr32f, CV_32FC3, 1.0 / 255.0);
+    cv::cvtColor(bgr32f, hsv, cv::COLOR_BGR2HSV);
     return hsv;
 }
 /**********************************************************/
@@ -967,5 +922,3 @@ double PARTICLEModule::getPeriod()
 {
     return 0.1;
 }
-
-

--- a/src/tools/depth2kin/src/module.cpp
+++ b/src/tools/depth2kin/src/module.cpp
@@ -26,7 +26,7 @@
 #include <utility>
 
 #include <yarp/cv/Cv.h>
-#include <opencv2/imgproc/imgproc_c.h>
+#include <opencv2/imgproc.hpp>
 #include <yarp/math/Math.h>
 #include <yarp/math/Rand.h>
 #include <yarp/math/NormRand.h>
@@ -180,7 +180,7 @@ cv::Rect CalibModule::extractFingerTip(ImageOf<PixelMono> &imgIn, ImageOf<PixelB
     if ((c[0]<10.0) || (c[0]>imgIn.width()-10) ||
         (c[1]<10.0) || (c[1]>imgIn.height()-10))
     {
-        cv::cvtColor(imgInMat,imgOutMat,CV_GRAY2BGR);
+        cv::cvtColor(imgInMat,imgOutMat,cv::COLOR_GRAY2BGR);
         return cv::Rect();
     }
 
@@ -198,7 +198,7 @@ cv::Rect CalibModule::extractFingerTip(ImageOf<PixelMono> &imgIn, ImageOf<PixelB
     // run Otsu algorithm to segment out the finger    
     cv::Mat imgInMatRoi(imgInMat,rect);
     cv::threshold(imgInMatRoi,imgInMatRoi,0,255,cv::THRESH_BINARY|cv::THRESH_OTSU);
-    cv::cvtColor(imgInMat,imgOutMat,CV_GRAY2BGR);
+    cv::cvtColor(imgInMat,imgOutMat,cv::COLOR_GRAY2BGR);
 
     px.resize(2,0.0);
     bool ok=false;
@@ -1120,7 +1120,7 @@ void CalibModule::onRead(ImageOf<PixelMono> &imgIn)
         }
 
         cv::Mat img=toCvMat(imgOut);
-        cv::putText(img,tag,cv::Point(rect.x+5,rect.y+15),CV_FONT_HERSHEY_SIMPLEX,0.5,color);
+        cv::putText(img,tag,cv::Point(rect.x+5,rect.y+15),cv::FONT_HERSHEY_SIMPLEX,0.5,color);
 
         motorExplorationState=motorExplorationStateTrigger;
         holdImg=true;
@@ -1825,5 +1825,4 @@ bool CalibModule::close()
     delete calibrator;
     return true;
 }
-
 

--- a/src/tools/stereoCalib/CMakeLists.txt
+++ b/src/tools/stereoCalib/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 project(stereoCalib)
 
-find_package(YARP COMPONENTS os sig dev math cv)
+find_package(YARP COMPONENTS os sig dev math)
 
 file(GLOB source src/*.cpp)
 file(GLOB header include/*.h)
@@ -14,6 +14,18 @@ add_executable(${PROJECT_NAME} ${source} ${header})
 if(OpenCV_VERSION_MAJOR GREATER 2)
   target_compile_definitions(${PROJECT_NAME} PRIVATE OPENCV_GREATER_2)
 endif()
-target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES} ${OpenCV_LIBS} iKin)
+target_link_libraries(${PROJECT_NAME}
+                      YARP::YARP_os
+                      YARP::YARP_sig
+                      YARP::YARP_dev
+                      YARP::YARP_math
+                      iKin
+                      opencv_core
+                      opencv_imgcodecs
+                      opencv_imgproc)
+if(OpenCV_VERSION_MAJOR GREATER_EQUAL 5)
+  target_link_libraries(${PROJECT_NAME} opencv_calib opencv_objdetect)
+else()
+  target_link_libraries(${PROJECT_NAME} opencv_calib3d)
+endif()
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
-

--- a/src/tools/stereoCalib/include/stereoCalibThread.h
+++ b/src/tools/stereoCalib/include/stereoCalibThread.h
@@ -3,11 +3,11 @@
 #include <string>
 #include <mutex>
 
-#include <opencv2/calib3d/calib3d_c.h>
 #include <opencv2/calib3d.hpp>
-#include <opencv2/core/core_c.h>
-#include <opencv2/core/types_c.h>
+#include <opencv2/core.hpp>
 #include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/objdetect.hpp>
 
 
 
@@ -116,5 +116,3 @@ public:
     void onStop();
 
 };
-
-

--- a/src/tools/stereoCalib/src/stereoCalibThread.cpp
+++ b/src/tools/stereoCalib/src/stereoCalibThread.cpp
@@ -187,13 +187,13 @@ void stereoCalibThread::stereoCalibRun()
                     foundL = findCirclesGrid(Left, boardSize, pointbufL, CALIB_CB_ASYMMETRIC_GRID | CALIB_CB_CLUSTERING);
                     foundR = findCirclesGrid(Right, boardSize, pointbufR, CALIB_CB_ASYMMETRIC_GRID | CALIB_CB_CLUSTERING);
                 } else {
-                    foundL = findChessboardCorners(Left, boardSize, pointbufL, CV_CALIB_CB_ADAPTIVE_THRESH | CV_CALIB_CB_FAST_CHECK | CV_CALIB_CB_NORMALIZE_IMAGE);
-                    foundR = findChessboardCorners(Right, boardSize, pointbufR, CV_CALIB_CB_ADAPTIVE_THRESH | CV_CALIB_CB_FAST_CHECK | CV_CALIB_CB_NORMALIZE_IMAGE);
+                    foundL = findChessboardCorners(Left, boardSize, pointbufL, CALIB_CB_ADAPTIVE_THRESH | CALIB_CB_FAST_CHECK | CALIB_CB_NORMALIZE_IMAGE);
+                    foundR = findChessboardCorners(Right, boardSize, pointbufR, CALIB_CB_ADAPTIVE_THRESH | CALIB_CB_FAST_CHECK | CALIB_CB_NORMALIZE_IMAGE);
                 }
 
                 if(foundL && foundR) {
-                        cvtColor(Left,Left,CV_RGB2BGR);
-                        cvtColor(Right,Right,CV_RGB2BGR);
+                        cvtColor(Left,Left,COLOR_RGB2BGR);
+                        cvtColor(Right,Right,COLOR_RGB2BGR);
                         saveStereoImage(pathImg.c_str(),Left,Right,count);
 
                         imageListR.push_back(imr);
@@ -309,11 +309,11 @@ void stereoCalibThread::monoCalibRun()
                 } else if(boardType == "ASYMMETRIC_CIRCLES_GRID") {
                     foundL = findCirclesGrid(Left, boardSize, pointbufL, CALIB_CB_ASYMMETRIC_GRID | CALIB_CB_CLUSTERING);
                 } else {
-                    foundL = findChessboardCorners(Left, boardSize, pointbufL, CV_CALIB_CB_ADAPTIVE_THRESH | CV_CALIB_CB_FAST_CHECK | CV_CALIB_CB_NORMALIZE_IMAGE);
+                    foundL = findChessboardCorners(Left, boardSize, pointbufL, CALIB_CB_ADAPTIVE_THRESH | CALIB_CB_FAST_CHECK | CALIB_CB_NORMALIZE_IMAGE);
                 }
 
                 if(foundL) {
-                        cvtColor(Left,Left,CV_RGB2BGR);
+                        cvtColor(Left,Left,COLOR_RGB2BGR);
                         saveImage(pathImg.c_str(),Left,count);
                         imageListL.push_back(iml);
                         Mat cL(pointbufL);
@@ -616,7 +616,7 @@ void stereoCalibThread::monoCalibration(const vector<string>& imageList, int boa
          view = cv::imread(imageList[i], 1);
          imageSize = view.size();
          vector<Point2f> pointbuf;
-         cvtColor(view, viewGray, CV_BGR2GRAY);
+         cvtColor(view, viewGray, COLOR_BGR2GRAY);
 
          bool found = false;
          if(boardType == "CIRCLES_GRID") {
@@ -625,7 +625,7 @@ void stereoCalibThread::monoCalibration(const vector<string>& imageList, int boa
              found = findCirclesGrid(view, boardSize, pointbuf, CALIB_CB_ASYMMETRIC_GRID | CALIB_CB_CLUSTERING);
          } else {
              found = findChessboardCorners( view, boardSize, pointbuf,
-                                            CV_CALIB_CB_ADAPTIVE_THRESH | CV_CALIB_CB_FAST_CHECK | CV_CALIB_CB_NORMALIZE_IMAGE);
+                                            CALIB_CB_ADAPTIVE_THRESH | CALIB_CB_FAST_CHECK | CALIB_CB_NORMALIZE_IMAGE);
          }
 
          if(found)
@@ -640,7 +640,7 @@ void stereoCalibThread::monoCalibration(const vector<string>& imageList, int boa
     double totalAvgErr = 0;
 
     K = Mat::eye(3, 3, CV_64F);
-    if( flags & CV_CALIB_FIX_ASPECT_RATIO )
+    if( flags & CALIB_FIX_ASPECT_RATIO )
         K.at<double>(0,0) = aspectRatio;
 
     Dist = Mat::zeros(4, 1, CV_64F);
@@ -650,7 +650,7 @@ void stereoCalibThread::monoCalibration(const vector<string>& imageList, int boa
     objectPoints.resize(imagePoints.size(),objectPoints[0]);
 
     double rms = calibrateCamera(objectPoints, imagePoints, imageSize, K,
-                    Dist, rvecs, tvecs,CV_CALIB_FIX_K3);
+                    Dist, rvecs, tvecs, CALIB_FIX_K3);
     yInfo("RMS error reported by calibrateCamera: %g\n", rms);
     cout.flush();
 }
@@ -711,7 +711,7 @@ void stereoCalibThread::stereoCalibration(const vector<string>& imagelist, int b
                     found = findCirclesGrid(timg, boardSize, corners, CALIB_CB_ASYMMETRIC_GRID | CALIB_CB_CLUSTERING);
                 } else {
                     found = findChessboardCorners(timg, boardSize, corners,
-                                                  CV_CALIB_CB_ADAPTIVE_THRESH | CV_CALIB_CB_NORMALIZE_IMAGE);
+                                                  CALIB_CB_ADAPTIVE_THRESH | CALIB_CB_NORMALIZE_IMAGE);
                 }
 
                 if( found )
@@ -764,11 +764,11 @@ void stereoCalibThread::stereoCalibration(const vector<string>& imagelist, int b
                         this->Kright, this->DistR,
                         imageSize, this->R, this->T, E, F,
                     #ifdef OPENCV_GREATER_2
-                        CV_CALIB_FIX_ASPECT_RATIO + CV_CALIB_ZERO_TANGENT_DIST + CV_CALIB_SAME_FOCAL_LENGTH + CV_CALIB_FIX_K3,
+                        CALIB_FIX_ASPECT_RATIO + CALIB_ZERO_TANGENT_DIST + CALIB_SAME_FOCAL_LENGTH + CALIB_FIX_K3,
                         TermCriteria(TermCriteria::MAX_ITER+TermCriteria::EPS, 100, 1e-5));
                     #else
                         TermCriteria(TermCriteria::MAX_ITER+TermCriteria::EPS, 100, 1e-5),
-                        CV_CALIB_FIX_ASPECT_RATIO + CV_CALIB_ZERO_TANGENT_DIST + CV_CALIB_SAME_FOCAL_LENGTH + CV_CALIB_FIX_K3);
+                        CALIB_FIX_ASPECT_RATIO + CALIB_ZERO_TANGENT_DIST + CALIB_SAME_FOCAL_LENGTH + CALIB_FIX_K3);
                     #endif
         yInfo("done with RMS error= %f\n",rms);
     } else
@@ -779,11 +779,11 @@ void stereoCalibThread::stereoCalibration(const vector<string>& imagelist, int b
                 this->Kright, this->DistR,
                 imageSize, this->R, this->T, E, F,
             #ifdef OPENCV_GREATER_2
-                 CV_CALIB_FIX_ASPECT_RATIO + CV_CALIB_FIX_INTRINSIC + CV_CALIB_FIX_K3);
-                 TermCriteria(TermCriteria::MAX_ITER+TermCriteria::EPS, 100, 1e-5),
+                 CALIB_FIX_ASPECT_RATIO + CALIB_FIX_INTRINSIC + CALIB_FIX_K3,
+                 TermCriteria(TermCriteria::MAX_ITER+TermCriteria::EPS, 100, 1e-5));
             #else
                  TermCriteria(TermCriteria::MAX_ITER+TermCriteria::EPS, 100, 1e-5),
-                 CV_CALIB_FIX_ASPECT_RATIO + CV_CALIB_FIX_INTRINSIC + CV_CALIB_FIX_K3);
+                 CALIB_FIX_ASPECT_RATIO + CALIB_FIX_INTRINSIC + CALIB_FIX_K3);
             #endif
         yInfo("done with RMS error= %f\n",rms);
     }


### PR DESCRIPTION
This completely untested and probably contains some CMake workaround to cleanup, but I just realized that last week one of my agents (GPT5.6 Sol) did a whole work of migration of icub-main to compile with both OpenCV 4 and 5. 

I did not test this and I can't test this, but I thought it was more useful for the earth that the energy spent on solving this would end up in a draft PR rather then just on my PC.

If you are not interested in this, feel free to close, but at least now this code is public and indexed by search engines. 

Everything was tested against OpenCV 4.* and 5.* with this pixi.toml file:

~~~toml
[workspace]
name = "icub-main"
channels = ["conda-forge"]
platforms = ["linux-64"]

[dependencies]
cmake = ">=3.12"
cxx-compiler = "*"
gsl = "*"
libgl-devel = "*"
ninja = "*"
yarp = ">=3.12"
ycm-cmake-modules = ">=0.12"

[feature.opencv4.dependencies]
opencv = "4.*"

[feature.opencv4.tasks]
configure-opencv4 = "cmake -S . -B build-opencv4 -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-I$CONDA_PREFIX/include -DCMAKE_CXX_FLAGS=-I$CONDA_PREFIX/include -DCMAKE_INCLUDE_PATH=$CONDA_PREFIX/include -DOPENGL_INCLUDE_DIR=$CONDA_PREFIX/include -DALLOW_DEVICE_PARAM_PARSER_GENERATION=OFF -DICUB_USE_GSL=ON"
build-opencv4 = { cmd = "cmake --build build-opencv4", depends-on = ["configure-opencv4"] }
test-opencv4 = { cmd = "ctest --test-dir build-opencv4 --output-on-failure", depends-on = ["build-opencv4"] }

[feature.opencv5.dependencies]
opencv = "5.0.*"

[feature.opencv5.tasks]
configure = "cmake -S . -B build-opencv5 -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-I$CONDA_PREFIX/include -DCMAKE_CXX_FLAGS=-I$CONDA_PREFIX/include -DCMAKE_INCLUDE_PATH=$CONDA_PREFIX/include -DOPENGL_INCLUDE_DIR=$CONDA_PREFIX/include -DALLOW_DEVICE_PARAM_PARSER_GENERATION=OFF -DICUB_USE_GSL=ON"
build = { cmd = "cmake --build build-opencv5", depends-on = ["configure"] }
test = { cmd = "ctest --test-dir build-opencv5 --output-on-failure", depends-on = ["build"] }

[environments]
default = ["opencv5"]
opencv4 = ["opencv4"]
~~~