### PR TITLE
Add fisheye rectification in camCalib module

### DIFF
--- a/src/modules/camCalib/CMakeLists.txt
+++ b/src/modules/camCalib/CMakeLists.txt
@@ -11,14 +11,16 @@ set(folder_source src/main.cpp
                   src/CamCalibModule.cpp
                   src/CalibToolFactory.cpp
                   src/PinholeCalibTool.cpp
-                  src/SphericalCalibTool.cpp)
+                  src/SphericalCalibTool.cpp
+                  src/FisheyeCalibTool.cpp)
                              
 set(folder_header include/iCub/spherical_projection.h
                   include/iCub/CamCalibModule.h
                   include/iCub/CalibToolFactory.h
                   include/iCub/ICalibTool.h
                   include/iCub/PinholeCalibTool.h
-                  include/iCub/SphericalCalibTool.h)
+                  include/iCub/SphericalCalibTool.h
+                  include/iCub/FisheyeCalibTool.h)
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 add_executable(${PROJECT_NAME} ${folder_source} ${folder_header})

--- a/src/modules/camCalib/include/iCub/FisheyeCalibTool.h
+++ b/src/modules/camCalib/include/iCub/FisheyeCalibTool.h
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 Istituto Italiano di Tecnologia (IIT)
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms of the
+// BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+#ifndef __FISHEYECALIBTOOL__
+#define __FISHEYECALIBTOOL__
+ 
+#include <string>
+ 
+#include <opencv2/core.hpp>
+ 
+#include <yarp/os/Searchable.h>
+#include <yarp/sig/Image.h>
+ 
+#include <iCub/ICalibTool.h>
+ 
+class FisheyeCalibTool : public ICalibTool
+{
+private:
+    struct CameraCalibration
+    {
+        cv::Mat K;
+        cv::Mat D;
+        cv::Size calibrationSize;
+    };
+ 
+    CameraCalibration leftCamera;
+    CameraCalibration rightCamera;
+    cv::Mat rotation;
+    cv::Mat translation;
+    cv::Mat leftMap1;
+    cv::Mat leftMap2;
+    cv::Mat rightMap1;
+    cv::Mat rightMap2;
+    cv::Size previousImageSize;
+    std::string groupName;
+    bool needInitialization;
+    double balance;
+    double fovScale;
+    bool drawEpipolars;
+    int epipolarLineStep;
+ 
+    bool loadCameraCalibration(const yarp::os::Searchable& group,
+                               CameraCalibration& camera,
+                               const std::string& groupName);
+    bool loadStereoCalibration(const yarp::os::Searchable& config);
+    bool initializeMaps(const cv::Size& imageSize);
+    cv::Mat scaledCameraMatrix(const CameraCalibration& camera,
+                               const cv::Size& imageSize) const;
+    void drawEpipolarLines(cv::Mat& image) const;
+ 
+public:
+    FisheyeCalibTool();
+    ~FisheyeCalibTool() = default;
+ 
+    bool open(yarp::os::Searchable& config) override;
+    bool close() override;
+    bool configure(yarp::os::Searchable& config) override;
+ 
+    void apply(const yarp::sig::ImageOf<yarp::sig::PixelRgb>& in,
+               yarp::sig::ImageOf<yarp::sig::PixelRgb>& out) override;
+};
+ 
+#endif

--- a/src/modules/camCalib/src/CamCalibModule.cpp
+++ b/src/modules/camCalib/src/CamCalibModule.cpp
@@ -109,8 +109,8 @@ bool CamCalibModule::configure(yarp::os::ResourceFinder &rf){
     setName(str.c_str()); // modulePortName
 
     // pass configuration over to bottle
-    Bottle botConfig(rf.toString());
-    // Load from configuration group ([<group_name>]), if group option present
+    Bottle fullConfig(rf.toString());
+    Bottle botConfig(fullConfig);    // Load from configuration group ([<group_name>]), if group option present
     Value *valGroup; // check assigns pointer to reference
     if(botConfig.check("group", valGroup, "Configuration group to load module options from (string)."))
     {
@@ -137,7 +137,7 @@ bool CamCalibModule::configure(yarp::os::ResourceFinder &rf){
 
     _calibTool = CalibToolFactories::getPool().get(calibToolName.c_str());
     if (_calibTool!=NULL) {
-        bool ok = _calibTool->open(botConfig);
+        bool ok = _calibTool->open(calibToolName == "fisheye" ? fullConfig : botConfig);
         if (!ok) {
             delete _calibTool;
             _calibTool = NULL;

--- a/src/modules/camCalib/src/CamCalibModule.cpp
+++ b/src/modules/camCalib/src/CamCalibModule.cpp
@@ -133,7 +133,7 @@ bool CamCalibModule::configure(yarp::os::ResourceFinder &rf){
 
     string calibToolName = botConfig.check("projection",
                                          Value("pinhole"),
-                                         "Projection/mapping applied to calibrated image [pinhole|spherical] (string).").asString();
+                                         "Projection/mapping applied to calibrated image [pinhole|spherical|fisheye] (string).").asString();
 
     _calibTool = CalibToolFactories::getPool().get(calibToolName.c_str());
     if (_calibTool!=NULL) {
@@ -220,5 +220,4 @@ bool CamCalibModule::respond(const Bottle& command, Bottle& reply)
     }
     return true;
 }
-
 

--- a/src/modules/camCalib/src/FisheyeCalibTool.cpp
+++ b/src/modules/camCalib/src/FisheyeCalibTool.cpp
@@ -1,0 +1,267 @@
+// Copyright (C) 2026 Istituto Italiano di Tecnologia (IIT)
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms of the
+// BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+#include <opencv2/calib3d.hpp>
+#include <opencv2/imgproc.hpp>
+ 
+#include <algorithm>
+#include <cmath>
+ 
+#include <yarp/os/Bottle.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/os/Value.h>
+ 
+#include <iCub/FisheyeCalibTool.h>
+ 
+using yarp::os::Bottle;
+using yarp::os::Searchable;
+using yarp::sig::ImageOf;
+using yarp::sig::PixelRgb;
+ 
+FisheyeCalibTool::FisheyeCalibTool()
+    : previousImageSize(-1, -1)
+    , groupName()
+    , needInitialization(true)
+    , balance(0.0)
+    , fovScale(1.0)
+    , drawEpipolars(false)
+    , epipolarLineStep(48)
+{
+}
+ 
+bool FisheyeCalibTool::open(Searchable& config)
+{
+    return configure(config);
+}
+ 
+bool FisheyeCalibTool::close()
+{
+    leftMap1.release();
+    leftMap2.release();
+    rightMap1.release();
+    rightMap2.release();
+    return true;
+}
+ 
+bool FisheyeCalibTool::loadCameraCalibration(const Searchable& group,
+                                               CameraCalibration& camera,
+                                               const std::string& groupName)
+{
+    const char* required[] = {"w", "h", "fx", "fy", "cx", "cy", "k1", "k2", "k3", "k4"};
+    for (const char* key : required)
+    {
+        if (!group.check(key))
+        {
+            yError() << "Stereo rectification: missing" << key << "in" << groupName;
+            return false;
+        }
+    }
+ 
+    camera.calibrationSize = cv::Size(group.find("w").asInt32(), group.find("h").asInt32());
+    if (camera.calibrationSize.width <= 0 || camera.calibrationSize.height <= 0)
+    {
+        yError() << "Stereo rectification: invalid calibration size in" << groupName;
+        return false;
+    }
+ 
+    camera.K = cv::Mat::eye(3, 3, CV_64F);
+    camera.K.at<double>(0, 0) = group.find("fx").asFloat64();
+    camera.K.at<double>(1, 1) = group.find("fy").asFloat64();
+    camera.K.at<double>(0, 2) = group.find("cx").asFloat64();
+    camera.K.at<double>(1, 2) = group.find("cy").asFloat64();
+ 
+    camera.D = cv::Mat::zeros(4, 1, CV_64F);
+    camera.D.at<double>(0, 0) = group.find("k1").asFloat64();
+    camera.D.at<double>(1, 0) = group.find("k2").asFloat64();
+    camera.D.at<double>(2, 0) = group.find("k3").asFloat64();
+    camera.D.at<double>(3, 0) = group.find("k4").asFloat64();
+    return true;
+}
+ 
+bool FisheyeCalibTool::loadStereoCalibration(const Searchable& config)
+{
+    if (!config.check("STEREO_DISPARITY"))
+    {
+        yError() << "Stereo rectification: [STEREO_DISPARITY] group not found";
+        return false;
+    }
+ 
+    const Bottle& stereo = config.findGroup("STEREO_DISPARITY");
+    if (!stereo.check("HN"))
+    {
+        yError() << "Stereo rectification: HN is missing from [STEREO_DISPARITY]";
+        return false;
+    }
+ 
+    const Bottle* homogeneous = stereo.find("HN").asList();
+    if (homogeneous == nullptr || homogeneous->size() != 16)
+    {
+        yError() << "Stereo rectification: HN must contain a 4x4 homogeneous transform";
+        return false;
+    }
+ 
+    rotation = cv::Mat::eye(3, 3, CV_64F);
+    translation = cv::Mat::zeros(3, 1, CV_64F);
+    for (int row = 0; row < 3; ++row)
+    {
+        for (int col = 0; col < 3; ++col)
+        {
+            rotation.at<double>(row, col) = homogeneous->get(row * 4 + col).asFloat64();
+        }
+        translation.at<double>(row, 0) = homogeneous->get(row * 4 + 3).asFloat64();
+    }
+ 
+    if (cv::norm(translation) <= 1e-12)
+    {
+        yError() << "Stereo rectification: translation from HN is zero";
+        return false;
+    }
+    return true;
+}
+ 
+bool FisheyeCalibTool::configure(Searchable& config)
+{
+    groupName = config.check("group", yarp::os::Value("")).asString();
+    if (groupName != "CAMERA_CALIBRATION_LEFT" && groupName != "CAMERA_CALIBRATION_RIGHT")
+    {
+        yError() << "Stereo rectification requires --group CAMERA_CALIBRATION_LEFT or CAMERA_CALIBRATION_RIGHT";
+        return false;
+    }
+    if (!config.check("CAMERA_CALIBRATION_LEFT") || !config.check("CAMERA_CALIBRATION_RIGHT"))
+    {
+        yError() << "Stereo rectification requires both camera calibration groups";
+        return false;
+    }
+ 
+    const Bottle& leftGroup = config.findGroup("CAMERA_CALIBRATION_LEFT");
+    const Bottle& rightGroup = config.findGroup("CAMERA_CALIBRATION_RIGHT");
+    if (!loadCameraCalibration(leftGroup, leftCamera, "CAMERA_CALIBRATION_LEFT")
+        || !loadCameraCalibration(rightGroup, rightCamera, "CAMERA_CALIBRATION_RIGHT")
+        || !loadStereoCalibration(config))
+    {
+        return false;
+    }
+
+    const Bottle& selectedGroup = (groupName == "CAMERA_CALIBRATION_LEFT") ? leftGroup : rightGroup;
+    const yarp::os::Value defaultBalance = config.check("rectifyAlpha", yarp::os::Value(0.0));
+    balance = config.check("balance", selectedGroup.check("balance", defaultBalance)).asFloat64();
+    balance = std::max(0.0, std::min(1.0, balance));
+    fovScale = config.check("fovScale", selectedGroup.check("fovScale", yarp::os::Value(1.0))).asFloat64();
+    if (fovScale <= 0.0)
+    {
+        yError() << "Fisheye rectification: fovScale must be greater than zero";
+        return false;
+    }
+    drawEpipolars = config.check("drawEpipolars", yarp::os::Value(false)).asBool();
+    epipolarLineStep = config.check("epipolarLineStep", yarp::os::Value(48)).asInt32();
+    epipolarLineStep = epipolarLineStep > 0 ? epipolarLineStep : 1;
+    previousImageSize = cv::Size(-1, -1);
+    needInitialization = true;
+    yDebug() << "FisheyeCalibTool configured with balance:" << balance << "fovScale:" << fovScale
+             << "drawEpipolars:" << drawEpipolars << "epipolarLineStep:" << epipolarLineStep;
+    return true;
+}
+ 
+cv::Mat FisheyeCalibTool::scaledCameraMatrix(const CameraCalibration& camera,
+                                               const cv::Size& imageSize) const
+{
+    const double scaleX = static_cast<double>(imageSize.width) / camera.calibrationSize.width;
+    const double scaleY = static_cast<double>(imageSize.height) / camera.calibrationSize.height;
+    cv::Mat scaled = camera.K.clone();
+    scaled.at<double>(0, 0) *= scaleX;
+    scaled.at<double>(0, 2) *= scaleX;
+    scaled.at<double>(1, 1) *= scaleY;
+    scaled.at<double>(1, 2) *= scaleY;
+    return scaled;
+}
+ 
+bool FisheyeCalibTool::initializeMaps(const cv::Size& imageSize)
+{
+    const cv::Mat leftK = scaledCameraMatrix(leftCamera, imageSize);
+    const cv::Mat rightK = scaledCameraMatrix(rightCamera, imageSize);
+    cv::Mat leftR;
+    cv::Mat rightR;
+    cv::Mat leftP;
+    cv::Mat rightP;
+    cv::Mat disparityToDepth;
+    cv::fisheye::stereoRectify(leftK, leftCamera.D, rightK, rightCamera.D, imageSize,
+                               rotation, translation, leftR, rightR, leftP, rightP,
+                               disparityToDepth, cv::fisheye::CALIB_ZERO_DISPARITY,
+                               imageSize, balance, fovScale);
+ 
+    if (leftR.empty() || rightR.empty() || leftP.empty() || rightP.empty())
+    {
+        yError() << "Fisheye rectification: stereoRectify returned empty matrices";
+        return false;
+    }
+ 
+    const double leftFocal = leftP.at<double>(0, 0);
+    const double rightFocal = rightP.at<double>(0, 0);
+    if (!std::isfinite(leftFocal) || !std::isfinite(rightFocal)
+        || leftFocal < 1.0 || rightFocal < 1.0)
+    {
+        yWarning() << "Fisheye rectification: stereoRectify returned an invalid focal length"
+                   << leftFocal << rightFocal
+                   << "- using a projection matrix derived from the original intrinsics";
+        cv::Mat commonProjection = cv::Mat::eye(3, 3, CV_64F);
+        commonProjection.at<double>(0, 0) = 0.5 * (leftK.at<double>(0, 0) + rightK.at<double>(0, 0));
+        commonProjection.at<double>(1, 1) = 0.5 * (leftK.at<double>(1, 1) + rightK.at<double>(1, 1));
+        commonProjection.at<double>(0, 2) = 0.5 * (leftK.at<double>(0, 2) + rightK.at<double>(0, 2));
+        commonProjection.at<double>(1, 2) = 0.5 * (leftK.at<double>(1, 2) + rightK.at<double>(1, 2));
+        leftP = commonProjection;
+        rightP = commonProjection;
+    }
+
+    if(groupName == "CAMERA_CALIBRATION_LEFT")
+    {
+        cv::fisheye::initUndistortRectifyMap(leftK, leftCamera.D, leftR, leftP,
+                                        imageSize, CV_16SC2, leftMap1, leftMap2);
+    }
+    else if(groupName == "CAMERA_CALIBRATION_RIGHT")
+    {
+        cv::fisheye::initUndistortRectifyMap(rightK, rightCamera.D, rightR, rightP,
+                                            imageSize, CV_16SC2, rightMap1, rightMap2);    
+    }
+
+    previousImageSize = imageSize;
+    needInitialization = false;
+    return (!leftMap1.empty() && !leftMap2.empty()) || (!rightMap1.empty() && !rightMap2.empty());
+}
+ 
+void FisheyeCalibTool::drawEpipolarLines(cv::Mat& image) const
+{
+    const cv::Scalar lineColor(0, 255, 0);
+    for (int y = 0; y < image.rows; y += epipolarLineStep)
+    {
+        cv::line(image, cv::Point(0, y), cv::Point(image.cols - 1, y), lineColor, 1, cv::LINE_AA);
+    }
+}
+ 
+void FisheyeCalibTool::apply(const ImageOf<PixelRgb>& in, ImageOf<PixelRgb>& out)
+{
+    const cv::Size imageSize(in.width(), in.height());
+    if (needInitialization || imageSize != previousImageSize)
+    {
+        if (!initializeMaps(imageSize))
+        {
+            yError() << "Fisheye calibration: unable to initialize maps";
+            out = in;
+            return;
+        }
+    }
+
+    out.resize(in.width(), in.height());
+    cv::Mat input(in.height(), in.width(), CV_8UC3, in.getRawImage(), in.getRowSize());
+    cv::Mat output(out.height(), out.width(), CV_8UC3, out.getRawImage(), out.getRowSize());
+    const cv::Mat& activeMap1 = (groupName == "CAMERA_CALIBRATION_LEFT") ? leftMap1 : rightMap1;
+    const cv::Mat& activeMap2 = (groupName == "CAMERA_CALIBRATION_LEFT") ? leftMap2 : rightMap2;
+    cv::remap(input, output, activeMap1, activeMap2, cv::INTER_LINEAR, cv::BORDER_CONSTANT);
+    if (drawEpipolars)
+    {
+        drawEpipolarLines(output);
+    }
+}
+ 

--- a/src/modules/camCalib/src/main.cpp
+++ b/src/modules/camCalib/src/main.cpp
@@ -58,14 +58,28 @@
  *   specifies the sub-path from \c $ICUB_ROOT/icub/app to the configuration file
  *
  * - \c --name \c camcalib \n 
- *   specifies the name of the module (used to form the stem of module port names)  
- * For calibration configuration options see: PinholeCalibTool::configure
- * 
+ *   specifies the name of the module (used to form the stem of module port names)
  *
- * Configuration File Parameters
+ * - \c --group \c CAMERA_CALIBRATION_LEFT \n
+ *   selects the configuration group to load and, for fisheye rectification, the camera stream
+ *   to rectify (\c CAMERA_CALIBRATION_LEFT or \c CAMERA_CALIBRATION_RIGHT)
  *
- * The following key-value pairs can be specified as parameters in the configuration file 
- * The value part can be changed to suit your needs; the default values are shown below. 
+ * \section pinhole_sec Pinhole Lens Calibration
+ *
+ * Set \c projection \c pinhole in the selected camera calibration group to undistort a
+ * standard pinhole camera image. The following parameters are required in that group:
+ *
+ * - \c drawCenterCross: \c 0 to disable or \c 1 to draw a cross at the principal point
+ * - \c w, \c h: image size used when deriving the calibration
+ * - \c fx, \c fy: focal lengths
+ * - \c cx, \c cy: principal point
+ * - \c k1, \c k2: radial distortion coefficients
+ * - \c p1, \c p2: tangential distortion coefficients
+ *
+ * The intrinsic matrix is automatically rescaled when the runtime image size differs from
+ * \c w and \c h. The distortion coefficients remain unchanged.
+ *
+ * Example pinhole configuration:
  *
  * <pre>
  * projection pinhole
@@ -82,6 +96,80 @@
  * p2 0.000456613
  *
  * </pre>
+ *
+ * \section fisheye_sec Fisheye Lens Stereo Rectification
+ *
+ * The module also supports \c projection \c fisheye for stereo fisheye lenses. In this mode,
+ * \c camCalib rectifies one camera stream at a time using the calibration of both cameras plus
+ * the stereo extrinsic transform stored in the same configuration file.
+ *
+ * Fisheye requirements:
+ *
+ * - \c projection \c fisheye in the selected camera group
+ * - \c --group set to either \c CAMERA_CALIBRATION_LEFT or \c CAMERA_CALIBRATION_RIGHT
+ * - both \c [CAMERA_CALIBRATION_LEFT] and \c [CAMERA_CALIBRATION_RIGHT] groups available
+ * - a \c [STEREO_DISPARITY] group containing \c HN as a 4x4 homogeneous transform
+ *
+ * Each fisheye camera group must contain:
+ *
+ * - \c w, \c h
+ * - \c fx, \c fy, \c cx, \c cy
+ * - \c k1, \c k2, \c k3, \c k4
+ *
+ * Fisheye rectification settings:
+ *
+ * - \c balance: value in [0,1] controlling the crop level after rectification. It can be
+ *   specified globally or in the selected camera group; the global value takes precedence.
+ * - \c fovScale: value greater than 0 that scales the output field of view. It can be
+ *   specified globally or in the selected camera group; the global value takes precedence.
+ * - \c rectifyAlpha: global fallback value for \c balance when \c balance is not set.
+ * - \c drawEpipolars: global boolean that overlays horizontal epipolar lines on the
+ *   rectified image.
+ * - \c epipolarLineStep: global pixel spacing between epipolar lines; values less than
+ *   one are treated as one.
+ *
+ * Fisheye rectification automatically rescales the intrinsic matrices if the runtime image size
+ * differs from the calibration size.
+ *
+ * Example fisheye configuration:
+ *
+ * <pre>
+ * [CAMERA_CALIBRATION_LEFT]
+ * projection fisheye
+ * w 640
+ * h 480
+ * fx 320.0
+ * fy 320.0
+ * cx 320.0
+ * cy 240.0
+ * k1 -0.01
+ * k2 0.001
+ * k3 0.0
+ * k4 0.0
+ * balance 0.0
+ * fovScale 1.0
+ *
+ * [CAMERA_CALIBRATION_RIGHT]
+ * projection fisheye
+ * w 640
+ * h 480
+ * fx 320.0
+ * fy 320.0
+ * cx 320.0
+ * cy 240.0
+ * k1 -0.01
+ * k2 0.001
+ * k3 0.0
+ * k4 0.0
+ *
+ * [STEREO_DISPARITY]
+ * HN (-1 0 0 0 0 -1 0 0 0 0 1 0 0.05 0 0 1)
+ * </pre>
+ *
+ * Example invocation:
+ *
+ * <tt>camCalib --name /icub/camcalib/left --context cameraCalibration --from icubEyes.ini --group CAMERA_CALIBRATION_LEFT</tt>
+ *
  * \section portsc_sec Ports Created
  *
  * Input port 

--- a/src/modules/camCalib/src/main.cpp
+++ b/src/modules/camCalib/src/main.cpp
@@ -130,6 +130,7 @@
 #include <iCub/CalibToolFactory.h>
 #include <iCub/PinholeCalibTool.h>
 #include <iCub/SphericalCalibTool.h>
+#include <iCub/FisheyeCalibTool.h>
 #include <iCub/CamCalibModule.h>
 
 // OpenCV
@@ -145,6 +146,7 @@ int main(int argc, char *argv[]) {
     CalibToolFactories& pool = CalibToolFactories::getPool();
     pool.add(new CalibToolFactoryOf<PinholeCalibTool>("pinhole"));
     pool.add(new CalibToolFactoryOf<SphericalCalibTool>("spherical"));
+    pool.add(new CalibToolFactoryOf<FisheyeCalibTool>("fisheye"));
 
     Network yarp;
     ResourceFinder rf;


### PR DESCRIPTION
This PR adds support for fisheye camera calibration and rectification to the `camCalib` module. The main changes include introducing a new `FisheyeCalibTool` class, updating the build system and factory registration to include it, and modifying configuration handling to support the new tool. These changes enable the module to process fisheye camera images using appropriate calibration and rectification algorithms.

> [!IMPORTANT]
> Let's keep it in draft until a final test on a setup/robot is done.

cc @MSECode  