### PR TITLE
Yarp master compatibility fixes

### DIFF
--- a/src/libraries/icubmod/embObjFTsensor/embObjFTsensor.cpp
+++ b/src/libraries/icubmod/embObjFTsensor/embObjFTsensor.cpp
@@ -330,9 +330,10 @@ eth::iethresType_t embObjFTsensor::type()
 }
 
 // ---------------------- ITemperatureSensors --------------------------------------------------------
-size_t embObjFTsensor::getNrOfTemperatureSensors() const
+yarp::dev::ReturnValue embObjFTsensor::getNrOfTemperatureSensors(size_t &n) const
 {
-    return GET_privData(mPriv).useTemperature ? 1 : 0;
+    n = GET_privData(mPriv).useTemperature ? 1 : 0;
+    return yarp::dev::ReturnValue_ok;
 }
 
 yarp::dev::MAS_status embObjFTsensor::getTemperatureSensorStatus(size_t sens_index) const
@@ -340,40 +341,41 @@ yarp::dev::MAS_status embObjFTsensor::getTemperatureSensorStatus(size_t sens_ind
     return yarp::dev::MAS_OK;
 }
 
-bool embObjFTsensor::getTemperatureSensorName(size_t sens_index, std::string &name) const
+yarp::dev::ReturnValue embObjFTsensor::getTemperatureSensorName(size_t sens_index, std::string &name) const
 {
     name = GET_privData(mPriv).devicename;
-    return true;
+    return yarp::dev::ReturnValue_ok;
 }
 
-bool embObjFTsensor::getTemperatureSensorFrameName(size_t sens_index, std::string &frameName) const
+yarp::dev::ReturnValue embObjFTsensor::getTemperatureSensorFrameName(size_t sens_index, std::string &frameName) const
 {
     frameName = GET_privData(mPriv).frameName;
-    return true;
+    return yarp::dev::ReturnValue_ok;
 }
 
-bool embObjFTsensor::getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const
+yarp::dev::ReturnValue embObjFTsensor::getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const
 {
     std::lock_guard<std::mutex> lck(GET_privData(mPriv).mtx);
     out = GET_privData(mPriv).lastTemperature/10.0; //I need to convert from tenths of degree centigrade to degree centigrade
     timestamp =  GET_privData(mPriv).timestampTemperature;
-    return true;
+    return yarp::dev::ReturnValue_ok;
 }
 
-bool embObjFTsensor::getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+yarp::dev::ReturnValue embObjFTsensor::getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     std::lock_guard<std::mutex> lck(GET_privData(mPriv).mtx);
     out.resize(1);
     out[0] = GET_privData(mPriv).lastTemperature/10.0; //I need to convert from tenths of degree centigrade to degree centigrade
     timestamp =  GET_privData(mPriv).timestampTemperature;
-    return true;
+    return yarp::dev::ReturnValue_ok;
 }
 
 //------------------------- ISixAxisForceTorqueSensors -------------------------
 
-size_t embObjFTsensor::getNrOfSixAxisForceTorqueSensors() const
+yarp::dev::ReturnValue embObjFTsensor::getNrOfSixAxisForceTorqueSensors(size_t &n) const
 {
-    return 1;
+    n = 1;
+    return yarp::dev::ReturnValue_ok;
 }
 
 yarp::dev::MAS_status embObjFTsensor::getSixAxisForceTorqueSensorStatus(size_t sens_index) const
@@ -381,23 +383,23 @@ yarp::dev::MAS_status embObjFTsensor::getSixAxisForceTorqueSensorStatus(size_t s
     return yarp::dev::MAS_OK;
 }
 
-bool embObjFTsensor::getSixAxisForceTorqueSensorName(size_t sens_index, std::string &name) const
+yarp::dev::ReturnValue embObjFTsensor::getSixAxisForceTorqueSensorName(size_t sens_index, std::string &name) const
 {
     name = GET_privData(mPriv).devicename;
-    return true;
+    return yarp::dev::ReturnValue_ok;
 }
 
-bool embObjFTsensor::getSixAxisForceTorqueSensorFrameName(size_t sens_index, std::string &frameName) const
+yarp::dev::ReturnValue embObjFTsensor::getSixAxisForceTorqueSensorFrameName(size_t sens_index, std::string &frameName) const
 {
     frameName = GET_privData(mPriv).frameName;
-    return true;
+    return yarp::dev::ReturnValue_ok;
 }
 
-bool embObjFTsensor::getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+yarp::dev::ReturnValue embObjFTsensor::getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     if(false == GET_privData(mPriv).isOpen())
     {
-        return false;
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
     }
 
     std::lock_guard<std::mutex> lck(GET_privData(mPriv).mtx);
@@ -410,7 +412,7 @@ bool embObjFTsensor::getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp:
 
     timestamp =  GET_privData(mPriv).timestampAnalogdata;
 
-    return true;
+    return yarp::dev::ReturnValue_ok;
 }
 
 // eof

--- a/src/libraries/icubmod/embObjFTsensor/embObjFTsensor.h
+++ b/src/libraries/icubmod/embObjFTsensor/embObjFTsensor.h
@@ -24,6 +24,7 @@
 #define __embObjFTsensor_h__
 
 #include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/ReturnValue.h>
 #include "IethResource.h"
 
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
@@ -60,19 +61,19 @@ public:
     virtual bool update(eOprotID32_t id32, double timestamp, void* rxdata);
 
     // ITemperatureSensors
-    virtual size_t getNrOfTemperatureSensors() const override;
+    virtual yarp::dev::ReturnValue getNrOfTemperatureSensors(size_t &n) const override;
     virtual yarp::dev::MAS_status getTemperatureSensorStatus(size_t sens_index) const override;
-    virtual bool getTemperatureSensorName(size_t sens_index, std::string &name) const override;
-    virtual bool getTemperatureSensorFrameName(size_t sens_index, std::string &frameName) const override;
-    virtual bool getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const override;
-    virtual bool getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    virtual yarp::dev::ReturnValue getTemperatureSensorName(size_t sens_index, std::string &name) const override;
+    virtual yarp::dev::ReturnValue getTemperatureSensorFrameName(size_t sens_index, std::string &frameName) const override;
+    virtual yarp::dev::ReturnValue getTemperatureSensorMeasure(size_t sens_index, double& out, double& timestamp) const override;
+    virtual yarp::dev::ReturnValue getTemperatureSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     // ISixAxisForceTorqueSensors
-    virtual size_t getNrOfSixAxisForceTorqueSensors() const override;
+    virtual yarp::dev::ReturnValue getNrOfSixAxisForceTorqueSensors(size_t &n) const override;
     virtual yarp::dev::MAS_status getSixAxisForceTorqueSensorStatus(size_t sens_index) const override;
-    virtual bool getSixAxisForceTorqueSensorName(size_t sens_index, std::string &name) const override;
-    virtual bool getSixAxisForceTorqueSensorFrameName(size_t sens_index, std::string &frameName) const override;
-    virtual bool getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    virtual yarp::dev::ReturnValue getSixAxisForceTorqueSensorName(size_t sens_index, std::string &name) const override;
+    virtual yarp::dev::ReturnValue getSixAxisForceTorqueSensorFrameName(size_t sens_index, std::string &frameName) const override;
+    virtual yarp::dev::ReturnValue getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
 
 private:

--- a/src/libraries/icubmod/embObjIMU/embObjIMU.cpp
+++ b/src/libraries/icubmod/embObjIMU/embObjIMU.cpp
@@ -204,13 +204,12 @@ bool embObjIMU::close()
 
 
 
-
-
-size_t embObjIMU::getNrOfThreeAxisGyroscopes() const
+yarp::dev::ReturnValue embObjIMU::getNrOfThreeAxisGyroscopes(size_t &n) const
 {
-    return GET_privData(mPriv).sens.getNumOfSensors(eoas_imu_gyr) +
-           GET_privData(mPriv).sens.getNumOfSensors(eoas_gyros_st_l3g4200d) + 
-           GET_privData(mPriv).sens.getNumOfSensors(eoas_gyros_mtb_ext);
+    n = GET_privData(mPriv).sens.getNumOfSensors(eoas_imu_gyr) +
+        GET_privData(mPriv).sens.getNumOfSensors(eoas_gyros_st_l3g4200d) +
+        GET_privData(mPriv).sens.getNumOfSensors(eoas_gyros_mtb_ext);
+    return yarp::dev::ReturnValue_ok;
 }
 
 yarp::dev::MAS_status embObjIMU::getThreeAxisGyroscopeStatus(size_t sens_index) const
@@ -219,34 +218,62 @@ yarp::dev::MAS_status embObjIMU::getThreeAxisGyroscopeStatus(size_t sens_index) 
     return GET_privData(mPriv).sensorState_eo2yarp(gyroSubIndex.second, GET_privData(mPriv).sens.getSensorStatus(gyroSubIndex.first, gyroSubIndex.second));
 }
 
-bool embObjIMU::getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const
+yarp::dev::ReturnValue embObjIMU::getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const
 {
     auto gyroSubIndex = getGyroSubIndex(sens_index);
-    return GET_privData(mPriv).sens.getSensorName(gyroSubIndex.first, gyroSubIndex.second, name);
+    if(GET_privData(mPriv).sens.getSensorName(gyroSubIndex.first, gyroSubIndex.second, name))
+    {
+        return yarp::dev::ReturnValue_ok;
+    }
+    else
+    {
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
 }
 
-bool embObjIMU::getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const
+yarp::dev::ReturnValue embObjIMU::getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const
 {
     auto gyroSubIndex = getGyroSubIndex(sens_index);
-    return GET_privData(mPriv).sens.getSensorFrameName(gyroSubIndex.first, gyroSubIndex.second, frameName);
+    if(GET_privData(mPriv).sens.getSensorFrameName(gyroSubIndex.first, gyroSubIndex.second, frameName))
+    {
+        return yarp::dev::ReturnValue_ok;
+    }
+    else
+    {
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
 }
 
-bool embObjIMU::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+yarp::dev::ReturnValue embObjIMU::getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     auto gyroSubIndex = getGyroSubIndex(sens_index);
-    return GET_privData(mPriv).sens.getSensorMeasure(gyroSubIndex.first, gyroSubIndex.second, out, timestamp);
+    if(GET_privData(mPriv).sens.getSensorMeasure(gyroSubIndex.first, gyroSubIndex.second, out, timestamp))
+    {
+        return yarp::dev::ReturnValue_ok;
+    }
+    else
+    {
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
 }
 
-size_t embObjIMU::getNrOfThreeAxisLinearAccelerometers() const
+yarp::dev::ReturnValue embObjIMU::getNrOfThreeAxisLinearAccelerometers(size_t &n) const
 {
-    return GET_privData(mPriv).sens.getNumOfSensors(eoas_imu_acc) + 
-           GET_privData(mPriv).sens.getNumOfSensors(eoas_accel_mtb_int) +
-           GET_privData(mPriv).sens.getNumOfSensors(eoas_accel_mtb_ext);
+    n = GET_privData(mPriv).sens.getNumOfSensors(eoas_imu_acc) +
+        GET_privData(mPriv).sens.getNumOfSensors(eoas_accel_mtb_int) +
+        GET_privData(mPriv).sens.getNumOfSensors(eoas_accel_mtb_ext);
+    return yarp::dev::ReturnValue_ok;
 }
 
 yarp::dev::MAS_status embObjIMU::getThreeAxisLinearAccelerometerStatus(size_t sens_index) const
 {
-    if (sens_index >= getNrOfThreeAxisLinearAccelerometers()) {
+    size_t nAcc = 0;
+    if(!getNrOfThreeAxisLinearAccelerometers(nAcc))
+    {
+        yError() << getBoardInfo() << "getThreeAxisLinearAccelerometerStatus: unable to retrieve the number of accelerometers";
+        return MAS_status::MAS_ERROR;
+    }
+    if (sens_index >= nAcc) {
         yError() << getBoardInfo() << "getThreeAxisLinearAccelerometerStatus: index out of range";
         return MAS_status::MAS_ERROR;
 	}
@@ -254,47 +281,93 @@ yarp::dev::MAS_status embObjIMU::getThreeAxisLinearAccelerometerStatus(size_t se
     return GET_privData(mPriv).sensorState_eo2yarp(accSubIndex.second, GET_privData(mPriv).sens.getSensorStatus(accSubIndex.first, accSubIndex.second));
 }
 
-bool embObjIMU::getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const
+yarp::dev::ReturnValue embObjIMU::getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const
 {
-    if (sens_index >= getNrOfThreeAxisLinearAccelerometers())
+    size_t nAcc = 0;
+    if(!getNrOfThreeAxisLinearAccelerometers(nAcc))
+    {
+        yError() << getBoardInfo() << "getThreeAxisLinearAccelerometerName: unable to retrieve the number of accelerometers";
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
+    if (sens_index >= nAcc)
     {
         yError() << getBoardInfo() << "getThreeAxisLinearAccelerometerName: index out of range";
-        return false;
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
     }
     auto accSubIndex = getAccSubIndex(sens_index);
-    return GET_privData(mPriv).sens.getSensorName(accSubIndex.first, accSubIndex.second, name);
+    if(GET_privData(mPriv).sens.getSensorName(accSubIndex.first, accSubIndex.second, name))
+    {
+        return yarp::dev::ReturnValue_ok;
+    }
+    else
+    {
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
 }
 
-bool embObjIMU::getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const
+yarp::dev::ReturnValue embObjIMU::getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const
 {
-    if (sens_index >= getNrOfThreeAxisLinearAccelerometers())
+    size_t nAcc = 0;
+    if(!getNrOfThreeAxisLinearAccelerometers(nAcc))
+    {
+        yError() << getBoardInfo() << "getThreeAxisLinearAccelerometerFrameName: unable to retrieve the number of accelerometers";
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
+    if (sens_index >= nAcc)
     {
         yError() << getBoardInfo() << "getThreeAxisLinearAccelerometerFrameName: index out of range";
-        return false;
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
     }
     auto accSubIndex = getAccSubIndex(sens_index);
-    return GET_privData(mPriv).sens.getSensorFrameName(accSubIndex.first, accSubIndex.second, frameName);
+    if(GET_privData(mPriv).sens.getSensorFrameName(accSubIndex.first, accSubIndex.second, frameName))
+    {
+        return yarp::dev::ReturnValue_ok;
+    }
+    else
+    {
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
 }
 
-bool embObjIMU::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+yarp::dev::ReturnValue embObjIMU::getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
-    if (sens_index >= getNrOfThreeAxisLinearAccelerometers())
+    size_t nAcc = 0;
+    if(!getNrOfThreeAxisLinearAccelerometers(nAcc))
+    {
+        yError() << getBoardInfo() << "getThreeAxisLinearAccelerometerMeasure: unable to retrieve the number of accelerometers";
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
+    if (sens_index >= nAcc)
     {
         yError() << getBoardInfo() << "getThreeAxisLinearAccelerometerMeasure: index out of range";
-        return false;
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
     }
     auto accSubIndex = getAccSubIndex(sens_index);
-    return GET_privData(mPriv).sens.getSensorMeasure(accSubIndex.first, accSubIndex.second, out, timestamp);
+    if(GET_privData(mPriv).sens.getSensorMeasure(accSubIndex.first, accSubIndex.second, out, timestamp))
+    {
+        return yarp::dev::ReturnValue_ok;
+    }
+    else
+    {
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
 }
 
-size_t embObjIMU::getNrOfThreeAxisMagnetometers() const
+yarp::dev::ReturnValue embObjIMU::getNrOfThreeAxisMagnetometers(size_t &n) const
 {
-    return GET_privData(mPriv).sens.getNumOfSensors(eoas_imu_mag);
+    n = GET_privData(mPriv).sens.getNumOfSensors(eoas_imu_mag);
+    return yarp::dev::ReturnValue_ok;
 }
 
 yarp::dev::MAS_status embObjIMU::getThreeAxisMagnetometerStatus(size_t sens_index) const
 {
-    if (sens_index >= getNrOfThreeAxisMagnetometers())
+    size_t nMag = 0;
+    if(!getNrOfThreeAxisMagnetometers(nMag))
+    {
+        yError() << getBoardInfo() << "getThreeAxisMagnetometerStatus: unable to retrieve the number of magnetometers";
+        return yarp::dev::MAS_status::MAS_ERROR;
+    }
+    if (sens_index >= nMag)
 	{
         yError() << getBoardInfo() << "getThreeAxisMagnetometerStatus: index out of range";
 		return MAS_status::MAS_ERROR;
@@ -302,44 +375,90 @@ yarp::dev::MAS_status embObjIMU::getThreeAxisMagnetometerStatus(size_t sens_inde
     return  GET_privData(mPriv).sensorState_eo2yarp(eoas_imu_mag, GET_privData(mPriv).sens.getSensorStatus(sens_index, eoas_imu_mag));
 }
 
-bool embObjIMU::getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const
+yarp::dev::ReturnValue embObjIMU::getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const
 {
-    if (sens_index >= getNrOfThreeAxisMagnetometers())
+    size_t nMag = 0;
+    if(!getNrOfThreeAxisMagnetometers(nMag))
+    {
+        yError() << getBoardInfo() << "getThreeAxisMagnetometerName: unable to retrieve the number of magnetometers";
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
+    if (sens_index >= nMag)
 	{
         yError() << getBoardInfo() << "getThreeAxisMagnetometerName: index out of range";
-		return false;
+		return yarp::dev::ReturnValue::return_code::return_value_error_generic;
 	}
-    return GET_privData(mPriv).sens.getSensorName(sens_index, eoas_imu_mag, name);
+    if(GET_privData(mPriv).sens.getSensorName(sens_index, eoas_imu_mag, name))
+    {
+        return yarp::dev::ReturnValue_ok;
+    }
+    else
+    {
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
 }
 
-bool embObjIMU::getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const
+yarp::dev::ReturnValue embObjIMU::getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const
 {
-    if (sens_index >= getNrOfThreeAxisMagnetometers())
+    size_t nMag = 0;
+    if(!getNrOfThreeAxisMagnetometers(nMag))
+    {
+        yError() << getBoardInfo() << "getThreeAxisMagnetometerFrameName: unable to retrieve the number of magnetometers";
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
+    if (sens_index >= nMag)
     {
         yError() << getBoardInfo() << "getThreeAxisMagnetometerFrameName: index out of range";
-		return false;
+		return yarp::dev::ReturnValue::return_code::return_value_error_generic;
 	}
-    return GET_privData(mPriv).sens.getSensorFrameName(sens_index, eoas_imu_mag, frameName);
+    if(GET_privData(mPriv).sens.getSensorFrameName(sens_index, eoas_imu_mag, frameName))
+    {
+        return yarp::dev::ReturnValue_ok;
+    }
+    else
+    {
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
 }
 
-bool embObjIMU::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+yarp::dev::ReturnValue embObjIMU::getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
-    if (sens_index >= getNrOfThreeAxisMagnetometers())
+    size_t nMag = 0;
+    if(!getNrOfThreeAxisMagnetometers(nMag))
+    {
+        yError() << getBoardInfo() << "getThreeAxisMagnetometerMeasure: unable to retrieve the number of magnetometers";
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
+    if (sens_index >= nMag)
 	{
         yError() << getBoardInfo() << "getThreeAxisMagnetometerMeasure: index out of range";
-		return false;
+		return yarp::dev::ReturnValue::return_code::return_value_error_generic;
 	}
-    return GET_privData(mPriv).sens.getSensorMeasure(sens_index, eoas_imu_mag, out, timestamp);
+    if(GET_privData(mPriv).sens.getSensorMeasure(sens_index, eoas_imu_mag, out, timestamp))
+    {
+        return yarp::dev::ReturnValue_ok;
+    }
+    else
+    {
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
 }
 
-size_t embObjIMU::getNrOfOrientationSensors() const
+yarp::dev::ReturnValue embObjIMU::getNrOfOrientationSensors(size_t& n) const
 {
-    return GET_privData(mPriv).sens.getNumOfSensors(eoas_imu_eul);
+    n = GET_privData(mPriv).sens.getNumOfSensors(eoas_imu_eul);
+    return yarp::dev::ReturnValue_ok;
 }
 
 yarp::dev::MAS_status embObjIMU::getOrientationSensorStatus(size_t sens_index) const
 {
-    if (sens_index >= getNrOfOrientationSensors())
+    size_t nOri = 0;
+    if(!getNrOfOrientationSensors(nOri))
+    {
+        yError() << getBoardInfo() << "getOrientationSensorStatus: unable to retrieve the number of orientation sensors";
+        return MAS_status::MAS_ERROR;
+    }
+    if (sens_index >= nOri)
     {
         yError() << getBoardInfo() <<  "getOrientationSensorStatus: index out of range";
         return MAS_status::MAS_ERROR;
@@ -347,35 +466,73 @@ yarp::dev::MAS_status embObjIMU::getOrientationSensorStatus(size_t sens_index) c
     return  GET_privData(mPriv).sensorState_eo2yarp(eoas_imu_eul, GET_privData(mPriv).sens.getSensorStatus(sens_index, eoas_imu_eul));
 }
 
-bool embObjIMU::getOrientationSensorName(size_t sens_index, std::string &name) const
+yarp::dev::ReturnValue embObjIMU::getOrientationSensorName(size_t sens_index, std::string &name) const
 {
-    if (sens_index >= getNrOfOrientationSensors())
+    size_t nOri = 0;
+    if(!getNrOfOrientationSensors(nOri))
+    {
+        yError() << getBoardInfo() << "getOrientationSensorName: unable to retrieve the number of orientation sensors";
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
+    if (sens_index >= nOri)
     {
 		yError() << getBoardInfo() << "getOrientationSensorName: index out of range";
-		return false;
+		return yarp::dev::ReturnValue::return_code::return_value_error_generic;
 	}
-    return GET_privData(mPriv).sens.getSensorName(sens_index, eoas_imu_eul, name);
+    if(GET_privData(mPriv).sens.getSensorName(sens_index, eoas_imu_eul, name))
+    {
+        return yarp::dev::ReturnValue_ok;
+    }
+    else
+    {
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
 }
 
-bool embObjIMU::getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const
+yarp::dev::ReturnValue embObjIMU::getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const
 {
-    if (sens_index >= getNrOfOrientationSensors())
+    size_t nOri = 0;
+    if(!getNrOfOrientationSensors(nOri))
+    {
+        yError() << getBoardInfo() << "getOrientationSensorFrameName: unable to retrieve the number of orientation sensors";
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
+    if (sens_index >= nOri)
 	{
         yError() << getBoardInfo() << "getOrientationSensorFrameName: index out of range";
-        return false;
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
     }
-    return GET_privData(mPriv).sens.getSensorFrameName(sens_index, eoas_imu_eul, frameName);
+    if(GET_privData(mPriv).sens.getSensorFrameName(sens_index, eoas_imu_eul, frameName))
+    {
+        return yarp::dev::ReturnValue_ok;
+    }
+    else
+    {
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
 }
 
-bool embObjIMU::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy_out, double& timestamp) const
+yarp::dev::ReturnValue embObjIMU::getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy_out, double& timestamp) const
 {
-    if (sens_index >= getNrOfOrientationSensors())
+    size_t nOri = 0;
+    if(!getNrOfOrientationSensors(nOri))
+    {
+        yError() << getBoardInfo() << "getOrientationSensorMeasureAsRollPitchYaw: unable to retrieve the number of orientation sensors";
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
+    if (sens_index >= nOri)
         {
 		yError() << getBoardInfo() << "getOrientationSensorMeasureAsRollPitchYaw: index out of range";
-		return false;
+		return yarp::dev::ReturnValue::return_code::return_value_error_generic;
 	}
-    return GET_privData(mPriv).sens.getSensorMeasure(sens_index, eoas_imu_eul, rpy_out, timestamp);
-
+    if(GET_privData(mPriv).sens.getSensorMeasure(sens_index, eoas_imu_eul, rpy_out, timestamp))
+    {
+        return yarp::dev::ReturnValue_ok;
+    }
+    else
+    {
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
+    }
 }
 
 

--- a/src/libraries/icubmod/embObjIMU/embObjIMU.h
+++ b/src/libraries/icubmod/embObjIMU/embObjIMU.h
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/ReturnValue.h>
 
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 
@@ -58,32 +59,32 @@ public:
     virtual bool close() override;
 
     /* IThreeAxisGyroscopes methods */
-    virtual size_t getNrOfThreeAxisGyroscopes() const override;
+    virtual yarp::dev::ReturnValue getNrOfThreeAxisGyroscopes(size_t &n) const override;
     virtual yarp::dev::MAS_status getThreeAxisGyroscopeStatus(size_t sens_index) const override;
-    virtual bool getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const override;
-    virtual bool getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const override;
-    virtual bool getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    virtual yarp::dev::ReturnValue getThreeAxisGyroscopeName(size_t sens_index, std::string &name) const override;
+    virtual yarp::dev::ReturnValue getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const override;
+    virtual yarp::dev::ReturnValue getThreeAxisGyroscopeMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IThreeAxisLinearAccelerometers methods */
-    virtual size_t getNrOfThreeAxisLinearAccelerometers() const override;
+    virtual yarp::dev::ReturnValue getNrOfThreeAxisLinearAccelerometers(size_t &n) const override;
     virtual yarp::dev::MAS_status getThreeAxisLinearAccelerometerStatus(size_t sens_index) const override;
-    virtual bool getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const override;
-    virtual bool getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
-    virtual bool getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    virtual yarp::dev::ReturnValue getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const override;
+    virtual yarp::dev::ReturnValue getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
+    virtual yarp::dev::ReturnValue getThreeAxisLinearAccelerometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IThreeAxisMagnetometers methods */
-    virtual size_t getNrOfThreeAxisMagnetometers() const override;
+    virtual yarp::dev::ReturnValue getNrOfThreeAxisMagnetometers(size_t &n) const override;
     virtual yarp::dev::MAS_status getThreeAxisMagnetometerStatus(size_t sens_index) const override;
-    virtual bool getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const override;
-    virtual bool getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const override;
-    virtual bool getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    virtual yarp::dev::ReturnValue getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const override;
+    virtual yarp::dev::ReturnValue getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const override;
+    virtual yarp::dev::ReturnValue getThreeAxisMagnetometerMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
 
     /* IOrientationSensors methods */
-    virtual size_t getNrOfOrientationSensors() const override;
+    virtual yarp::dev::ReturnValue getNrOfOrientationSensors(size_t &n) const override;
     virtual yarp::dev::MAS_status getOrientationSensorStatus(size_t sens_index) const override;
-    virtual bool getOrientationSensorName(size_t sens_index, std::string &name) const override;
-    virtual bool getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const override;
-    virtual bool getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
+    virtual yarp::dev::ReturnValue getOrientationSensorName(size_t sens_index, std::string &name) const override;
+    virtual yarp::dev::ReturnValue getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const override;
+    virtual yarp::dev::ReturnValue getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
 
 
     /* Iethresource methods */

--- a/src/libraries/icubmod/embObjMais/embObjMais.cpp
+++ b/src/libraries/icubmod/embObjMais/embObjMais.cpp
@@ -440,8 +440,9 @@ void embObjMais::getCounters(unsigned int &sat, unsigned int &err, unsigned int 
     to=counterTimeout;
 }
 
-size_t embObjMais::getNrOfEncoderArrays() const {
-    return 1;
+yarp::dev::ReturnValue embObjMais::getNrOfEncoderArrays(size_t &n) const {
+    n = 1;
+    return yarp::dev::ReturnValue_ok;
 }
 
 yarp::dev::MAS_status embObjMais::getEncoderArrayStatus(size_t sens_index) const {
@@ -449,18 +450,18 @@ if (sens_index >= 1) return yarp::dev::MAS_UNKNOWN;
     return yarp::dev::MAS_OK;
 }
 
-bool embObjMais::getEncoderArrayName(size_t sens_index, std::string &name) const {
-    if (sens_index >= 1) return false;
+yarp::dev::ReturnValue embObjMais::getEncoderArrayName(size_t sens_index, std::string &name) const {
+    if (sens_index >= 1) return yarp::dev::ReturnValue::return_code::return_value_error_generic;
     name = serviceConfig.nameOfMais;
-    return true;
+    return yarp::dev::ReturnValue_ok;
 }
 
-bool embObjMais::getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const {
-    if (sens_index >= 1) return false;
+yarp::dev::ReturnValue embObjMais::getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const {
+    if (sens_index >= 1) return yarp::dev::ReturnValue::return_code::return_value_error_generic;
     timestamp = this->timeStamp;
     out.resize(analogdata.size());
     out = analogdata;
-    return true;
+    return yarp::dev::ReturnValue_ok;
 }
 
 size_t embObjMais::getEncoderArraySize(size_t sens_index) const {

--- a/src/libraries/icubmod/embObjMais/embObjMais.h
+++ b/src/libraries/icubmod/embObjMais/embObjMais.h
@@ -7,6 +7,7 @@
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
+#include <yarp/dev/ReturnValue.h>
 #include <string>
 #include <list>
 #include <mutex>
@@ -55,10 +56,10 @@ public:
     bool close();
 
     // IEncoderArrays interface
-    virtual size_t getNrOfEncoderArrays() const override;
+    virtual yarp::dev::ReturnValue getNrOfEncoderArrays(size_t &n) const override;
     virtual yarp::dev::MAS_status getEncoderArrayStatus(size_t sens_index) const override;
-    virtual bool getEncoderArrayName(size_t sens_index, std::string &name) const override;
-    virtual bool getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    virtual yarp::dev::ReturnValue getEncoderArrayName(size_t sens_index, std::string &name) const override;
+    virtual yarp::dev::ReturnValue getEncoderArrayMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
     virtual size_t getEncoderArraySize(size_t sens_index) const override;
 
     // IethResource interface

--- a/src/libraries/icubmod/embObjSkin/embObjSkin.cpp
+++ b/src/libraries/icubmod/embObjSkin/embObjSkin.cpp
@@ -579,10 +579,11 @@ bool EmbObjSkin::close()
     return true;
 }
 
-size_t EmbObjSkin::getNrOfSkinPatches() const
+yarp::dev::ReturnValue EmbObjSkin::getNrOfSkinPatches(size_t &n) const
 {
     yCDebug(EMBOBJSKIN) << __YFUNCTION__ << ":" << boardInfo() << ": n. of enabled skin patches" << _skCfg.numOfPatches;
-    return _skCfg.numOfPatches; //should return the number of patches defined as the parameter `skinCanAddrsPatch1` in the hw configuration file (thus for our boards 1 or 2)
+    n = _skCfg.numOfPatches; //should return the number of patches defined as the parameter `skinCanAddrsPatch1` in the hw configuration file (thus for our boards 1 or 2)
+    return yarp::dev::ReturnValue_ok;
 }
 
 MAS_status EmbObjSkin::getSkinPatchStatus(size_t sens_index) const
@@ -595,25 +596,25 @@ MAS_status EmbObjSkin::getSkinPatchStatus(size_t sens_index) const
     return MAS_OK;
 }
 
-bool EmbObjSkin::getSkinPatchName(size_t sens_index, std::string &name) const
+yarp::dev::ReturnValue EmbObjSkin::getSkinPatchName(size_t sens_index, std::string &name) const
 {
     if(sens_index >= _skCfg.numOfPatches)
     {
         yCError(EMBOBJSKIN) << __YFUNCTION__ << ":" << boardInfo() << ": index out of range. Requested:" << sens_index << "max:" << _skCfg.numOfPatches;
-        return false;
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
     }
 
     name = "skin_patch_" + std::to_string(_skCfg.patchInfoList[sens_index].idPatch);
     yCDebug(EMBOBJSKIN) << __YFUNCTION__ << ":" << boardInfo() << name;
-    return true;
+    return yarp::dev::ReturnValue_ok;
 }
 
-bool EmbObjSkin::getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
+yarp::dev::ReturnValue EmbObjSkin::getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const
 {
     if(sens_index >= _skCfg.numOfPatches)
     {
         yCError(EMBOBJSKIN) << __YFUNCTION__ << ":" << boardInfo() << ": index out of range. Requested:" << sens_index << "max:" << _skCfg.numOfPatches;
-        return false;
+        return yarp::dev::ReturnValue::return_code::return_value_error_generic;
     }
 
     const auto& patch = _skCfg.patchInfoList[sens_index];
@@ -625,7 +626,7 @@ bool EmbObjSkin::getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, 
     }
     timestamp = yarp::os::Time::now();
 
-    return true;
+    return yarp::dev::ReturnValue_ok;
 }
 
 size_t EmbObjSkin::getSkinPatchSize(size_t sens_index) const

--- a/src/libraries/icubmod/embObjSkin/embObjSkin.h
+++ b/src/libraries/icubmod/embObjSkin/embObjSkin.h
@@ -29,6 +29,7 @@
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/ReturnValue.h>
 
 
 #include "IethResource.h"
@@ -138,13 +139,13 @@ public:
 
     // ISkinPatches interface    
     /** Get the number of skin patches exposed by THIS device */
-    virtual size_t  getNrOfSkinPatches() const override;
+    virtual yarp::dev::ReturnValue  getNrOfSkinPatches(size_t &n) const override;
     /** Get the status of the specified patch */
     virtual MAS_status getSkinPatchStatus(size_t sens_index) const override;
     /** Get the name of the specified patch */
-    virtual bool    getSkinPatchName(size_t sens_index, std::string &name) const override;
+    virtual yarp::dev::ReturnValue    getSkinPatchName(size_t sens_index, std::string &name) const override;
     /** Get the last readings of the sensors related to the specified patch */
-    virtual bool    getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
+    virtual yarp::dev::ReturnValue    getSkinPatchMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const override;
     /** Get the size of the specified skin patch, i.e., the number of taxels (sensors) it contains */
     virtual size_t  getSkinPatchSize(size_t sens_index) const override;
 

--- a/src/libraries/perceptiveModels/src/sensors.cpp
+++ b/src/libraries/perceptiveModels/src/sensors.cpp
@@ -93,8 +93,12 @@ bool SensorEncoderArrays::getOutput(Value &in) const
     auto* iencarray=static_cast<IEncoderArrays*>(source);
     if (!configured)
         return false;
-    
-    if ((index_array<0) || (index_array>=iencarray->getNrOfEncoderArrays()))
+
+    size_t encArrays;
+    if (!iencarray->getNrOfEncoderArrays(encArrays))
+        return false;
+
+    if ((index_array<0) || (index_array>=encArrays))
         return false;
 
     if ((index_element<0) || (index_element>=iencarray->getEncoderArraySize(index_array)))

--- a/src/libraries/perceptiveModels/src/springyFingers.cpp
+++ b/src/libraries/perceptiveModels/src/springyFingers.cpp
@@ -329,7 +329,14 @@ bool SpringyFingersModel::fromProperty(const Property &options)
     IEncoderArrays *iencarray; drvMAIS.view(iencarray);
 
     propGen.clear();
-    propGen.put("num_arrays",(int)iencarray->getNrOfEncoderArrays());
+    size_t nrOfArrays;
+    if (!iencarray->getNrOfEncoderArrays(nrOfArrays))
+    {
+        printMessage(log::error,1,"unable to get number of encoder arrays");
+        close();
+        return false;
+    }
+    propGen.put("num_arrays",(int)nrOfArrays);
     propGen.put("index_array",0);
 
     Property thumb_mp=propGen;   thumb_mp.put(  "name","Out_0");   thumb_mp.put("index_element","1");

--- a/src/modules/skinManager/include/iCub/skinManager/compensator.h
+++ b/src/modules/skinManager/include/iCub/skinManager/compensator.h
@@ -61,9 +61,9 @@ private:
     static const int MIN_TOUCH_THR = 1;         // min value assigned to the touch thresholds (i.e. the 95% percentile)
     static const double BIN_TOUCH;              // output value of the binarization filter when touch is detected
     static const double BIN_NO_TOUCH;           // output value of the binarization filter when no touch is detected
-    
+
     // INIT
-    unsigned int skinDim;                       // number of taxels (for the hand it is 192)
+    size_t skinDim;                       // number of taxels (for the hand it is 192)
     string robotName;
     string name;                                // name of the compensator
     SkinPart skinPart;                          // id of the part of the skin (e.g. left_hand, right_forearm, left_upper_arm)

--- a/src/modules/skinManager/src/compensator.cpp
+++ b/src/modules/skinManager/src/compensator.cpp
@@ -107,7 +107,9 @@ bool Compensator::init(string name, string robotName, string outputPortName, str
     }
     
     int getChannelsCounter = 0;
-    skinDim = tactileSensor->getNrOfSkinPatches(); // this should return the total number of sensors per skin patch, i.e. 16*12*number of CARDS
+    if(!tactileSensor->getNrOfSkinPatches(skinDim)){ // this should return the total number of sensors per skin patch, i.e. 16*12*number of CARDS
+        sendInfoMsg("Error reading the number of channels of the port.");
+    }
     while(skinDim<=0){
         // getNrOfSkinPatches() returns 0 if it hasn't performed the first reading yet
         // so wait for 1/50 sec, then try again        
@@ -118,7 +120,9 @@ bool Compensator::init(string name, string robotName, string outputPortName, str
             break;
         }
         Time::delay(0.02);
-        skinDim = tactileSensor->getNrOfSkinPatches();
+        if(!tactileSensor->getNrOfSkinPatches(skinDim)){
+            sendInfoMsg("Error reading the number of channels of the port.");
+        }
     }
     readErrorCounter = 0;
     rawData.resize(skinDim);
@@ -741,7 +745,7 @@ bool Compensator::setTaxelPosesFromFileOld(const char *filePath){
     posFile.seekg(0, std::ios::beg);//rewind iterator
     if(totalLines!=skinDim){
         char* temp = new char[200];
-        sprintf(temp, "Error while reading taxel position file %s: num of lines %d is not equal to num of taxels %d.\n", 
+        sprintf(temp, "Error while reading taxel position file %s: num of lines %d is not equal to num of taxels %ld.\n",
             filePath, totalLines, skinDim);
         sendInfoMsg(temp);
     }

--- a/src/tools/iCubSkinGui/plugin/SkinMeshClient.cpp
+++ b/src/tools/iCubSkinGui/plugin/SkinMeshClient.cpp
@@ -336,7 +336,12 @@ bool SkinMeshClient::configureSkinClient(yarp::os::Searchable& config, const std
     }
 
     yarp::os::Bottle skinPatchNames;
-    const size_t skinPatchCount = clientSkinPatches->getNrOfSkinPatches();
+    size_t skinPatchCount;
+    if (!clientSkinPatches->getNrOfSkinPatches(skinPatchCount))
+    {
+        yCError(SKINMESHCLIENT) << "SkinMeshClient: unable to retrieve the number of skin patches from the multipleanalogsensorsclient.";
+        return false;
+    }
     yCDebug(SKINMESHCLIENT) << "Number of skin patches available from the multipleanalogsensorsclient:" << skinPatchCount;
 
     if (skinPatchCount == 0)
@@ -409,7 +414,12 @@ bool SkinMeshClient::configureSkinClient(yarp::os::Searchable& config, const std
         return false;
     }
 
-    const size_t remappedSkinPatchCount = remappedMASInterfaces.iskinPatchesSensors->getNrOfSkinPatches();
+    size_t remappedSkinPatchCount;
+    if (!remappedMASInterfaces.iskinPatchesSensors->getNrOfSkinPatches(remappedSkinPatchCount))
+    {
+        yCError(SKINMESHCLIENT) << "SkinMeshClient: unable to retrieve the number of skin patches from the multipleanalogsensorsremapper.";
+        return false;
+    }
     if (remappedSkinPatchCount != skinPatchCount)
     {
         yCError(SKINMESHCLIENT) << "SkinMeshClient: MultipleAnalogSensorsRemapper exposes"
@@ -430,7 +440,12 @@ bool SkinMeshClient::readSkinPatches(yarp::sig::Vector& skinValue) const
         return false;
     }
 
-    const size_t skinPatchCount = remappedMASInterfaces.iskinPatchesSensors->getNrOfSkinPatches();
+    size_t skinPatchCount;
+    if (!remappedMASInterfaces.iskinPatchesSensors->getNrOfSkinPatches(skinPatchCount))
+    {
+        yCError(SKINMESHCLIENT) << "SkinMeshClient: unable to retrieve the number of skin patches from the multipleanalogsensorsclient.";
+        return false;
+    }
     if (skinPatchCount == 0)
     {
         const double now = yarp::os::Time::now();


### PR DESCRIPTION
This quite large PR fixes a set of issues that some classes have with Yarp master branch. These are the classes:

- `embObjFTsensor`
- `embObjIMU`
- `embObjMais`
- `embObjSkin`
- `perceptiveModels/sensors`
- `perceptiveModels/springyFingers`
- `SkinManager/compensator`
- `SkinMeshClient`

This PR is flagged as **DRAFT** because is pretty big. If there are any issue with it, It can be easily split in smaller ones